### PR TITLE
Prohibit boxes with any zero lengths

### DIFF
--- a/topology/core/box.py
+++ b/topology/core/box.py
@@ -18,9 +18,17 @@ def _validate_lengths(lengths):
     lengths.convert_to_units(u.nm)
 
     if np.any(np.less(lengths, [0, 0, 0], )):
-        raise ValueError('Negative or 0 value lengths passed.'
-                         'Lengths must be a value greater than 0.0'
-                         'You passed {}'.format(lengths))
+        raise ValueError('Negative length(s) passed. Lengths must be a value '
+                         'greater than 0.0. You passed {}'.format(lengths))
+
+    if np.any(np.equal(lengths, [0, 0, 0], )):
+        if lengths[0] > 0 and lengths[1] > 0:
+            warnings.warn('A c value of 0 was passed. This will be '
+                          'interpreted as a 2-D box.')
+        else:
+            raise ValueError('Length(s) of value 0 were passed. Lengths must '
+                             'be a value greater than 0.0. You passed '
+                             '{}'.format(lengths))
     return lengths
 
 

--- a/topology/tests/test_box.py
+++ b/topology/tests/test_box.py
@@ -15,10 +15,14 @@ class TestBox():
         box = Box(lengths=np.ones(3), angles=[40.0, 50.0, 60.0])
         assert np.array_equal(box.angles, [40.0, 50.0, 60.0])
 
-    @pytest.mark.parametrize('lengths', [[4.0, 4.0, 0.0], [4.0, 5.0, -1.0]])
+    @pytest.mark.parametrize('lengths', [[0.0, 4.0, 4.0], [4.0, 5.0, -1.0]])
     def test_bad_lengths(self, lengths):
         with pytest.raises(ValueError):
             box = Box(lengths=lengths, angles=90*np.ones(3))
+
+    def test_build_2D_Box(self):
+        with pytest.warns(UserWarning):
+            box = Box(lengths=u.nm * [4, 4, 0])
 
     def test_dtype(self):
         box = Box(lengths=np.ones(3))


### PR DESCRIPTION
This depends somewhat on how we feel #22 at the moment. But whether we want to do it now, later, or not at all, this adds a single test checking for bad box lengths.