### PR TITLE
Fix some xyz_tests

### DIFF
--- a/topology/tests/test_xyz.py
+++ b/topology/tests/test_xyz.py
@@ -1,3 +1,5 @@
+import pytest
+
 from topology.formats.xyz import read_xyz
 from topology.utils.io import get_fn
 
@@ -9,8 +11,8 @@ def test_read_xyz():
     top = read_xyz(get_fn('cu_block.xyz'))
     assert top.n_sites == 108
 
-def test_wrong_n_atoms(self):
+def test_wrong_n_atoms():
     with pytest.raises(ValueError):
-        mb.load(get_fn('too_few_atoms.xyz'))
+        read_xyz(get_fn('too_few_atoms.xyz'))
     with pytest.raises(ValueError):
-        mb.load(get_fn('too_many_atoms.xyz'))
+        read_xyz(get_fn('too_many_atoms.xyz'))


### PR DESCRIPTION
#25 woops looks like we didn't catch some of the errors in the actual test function
* We were loading using mbuild, not topology
* needed a pytest import
* passed `self` to a test function which was unnecessary