### PR TITLE
Improve the element class

### DIFF
--- a/topology/core/element.py
+++ b/topology/core/element.py
@@ -10,6 +10,13 @@ class Element(object):
             if elem.name == name:
                 return elem
 
+    def __repr__(self):
+        descr = list('<Element ')
+        descr.append(self.name + ', ')
+        descr.append(self.symbol + ', ')
+        descr.append(str(self.mass) + ' amu>')
+        return ''.join(descr)
+
 Hydrogen = Element(name='hydrogen', symbol='H', mass=1.007947)
 Carbon = Element(name='carbon', symbol='C', mass=12.011)
 Oxygen = Element(name='oxygen', symbol='O', mass=15.999)


### PR DESCRIPTION
This could probably be more elegant but it gets us started on some necessary lookup functionality

```
>>> from topology.core.element import Element
>>> element = Element()
>>> element.lookup_from_name(name='carbon')
<Element carbon, C, 12.011 amu>
```

There's also a `__repr__` now, which is more pleasant to look at than a bunch of `<topology.core.element.Element object at 0x11dc901d0>`

Adding other elements is tedious but I will do it once we agree on the behavior we actually want out of this class. We definitely want to be able to lookup elements by name, symbol, and possibly mass. What else comes to mind?