### PR TITLE
Unit vector and scaled vector support for Box

### DIFF
--- a/topology/core/box.py
+++ b/topology/core/box.py
@@ -129,10 +129,12 @@ class Box(object):
 
         return u.unyt_array(box_vec, u.nm, dtype=np.float)
 
-    def get_scaled_vectors(self):
+    def get_vectors(self):
+        """ Return the vectors of the box."""
         return (self._lengths.v * self.get_unit_vectors().T).T
     
     def get_unit_vectors(self):
+        """ Return the normalized vectors of the box."""
         return self._unit_vectors_from_angles()
 
     def __repr__(self):

--- a/topology/tests/test_box.py
+++ b/topology/tests/test_box.py
@@ -68,7 +68,7 @@ class TestBox(BaseTest):
 
     def test_scaled_vectors(self):
         box = Box(lengths=u.unyt_array((2, 2, 2), u.nm), angles=u.degree*[40.0, 50.0, 60.0])
-        vectors = box.get_scaled_vectors()
+        vectors = box.get_vectors()
         test_vectors = np.array([[1, 0, 0],
                                 [0.5, 0.86603, 0],
                                 [0.64278, 0.51344, 0.56852]])


### PR DESCRIPTION
Added support for getting scaled and unit vector's from the Box class. Also correctly passing units to these arrays as well. 

Maybe these shouldnt have units since they are vectors, which specify directions. Maybe that should only happen when they are scaled? ie. Multiplying by `lengths` which have units?