### PR TITLE
Convert high-level lists to IndexedSets

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 mbuild
 unyt
+boltons

--- a/topology/core/topology.py
+++ b/topology/core/topology.py
@@ -2,7 +2,7 @@ import warnings
 
 import numpy as np
 import unyt as u
-from orderedset import OrderedSet
+from boltons.setutils import IndexedSet
 
 from topology.core.bond import Bond
 from topology.core.angle import Angle
@@ -24,7 +24,7 @@ class Topology(object):
         if name is not None:
             self._name = name
         self._box = box
-        self._sites = OrderedSet()
+        self._sites = IndexedSet()
         self._connections = list()
         self._bonds = list()
         self._angles = list()


### PR DESCRIPTION
I basically did what @ahy3nz said he did earlier, on `.sites` only, will do other things later. This makes that sluggish GRO test run in about a second.

Note that this uses `orderedset`, not `oset` as mBuild does (which raises the question of if it should change there, too ...)