### PR TITLE
Add very basic mixing rule support

### DIFF
--- a/topology/core/topology.py
+++ b/topology/core/topology.py
@@ -34,6 +34,8 @@ class Topology(object):
         self._bond_types = list()
         self._angle_types = list()
 
+        self._combining_rule = 'lorentz'
+
     @property
     def name(self):
         return self._name
@@ -49,6 +51,16 @@ class Topology(object):
     @box.setter
     def box(self, box):
         self._box = box
+
+    @property
+    def combining_rule(self):
+        return self._combining_rule
+
+    @combining_rule.setter
+    def combining_rule(self, rule):
+        if rule not in ['lorentz', 'geometric']:
+            raise TopologyError('Combining rule must be `lorentz` or `geometric`')
+        self._combining_rule = rule
 
     def positions(self):
         xyz = np.empty(shape=(self.n_sites, 3)) * u.nm
@@ -259,6 +271,9 @@ class Topology(object):
             return False
 
         if self.n_sites != other.n_sites:
+            return False
+
+        if self.combining_rule != other.combining_rule:
             return False
 
         for (con1, con2) in zip(self.connections, other.connections):

--- a/topology/tests/test_topology.py
+++ b/topology/tests/test_topology.py
@@ -15,6 +15,7 @@ from topology.core.angle_type import AngleType
 from topology.external.convert_parmed import from_parmed
 
 from topology.tests.base_test import BaseTest
+from topology.exceptions import TopologyError
 from topology.utils.testing import allclose
 from topology.tests.base_test import BaseTest
 from topology.utils.io import get_fn, import_, has_parmed
@@ -27,6 +28,14 @@ class TestTopology(BaseTest):
     def test_new_topology(self):
         top = Topology(name='mytop')
         assert top.name == 'mytop'
+
+    def test_change_comb_rule(self):
+        top = Topology()
+        assert top.combining_rule == 'lorentz'
+        top.combining_rule = 'geometric'
+        assert top.combining_rule == 'geometric'
+        with pytest.raises(TopologyError):
+            top.combining_rule = 'kong'
 
     def test_add_site(self):
         top = Topology()


### PR DESCRIPTION
This is basically copied from `ParmEd`; it just tracks a _name_ of a mixing rule but makes no effort to actually apply them. But this is enough to write a `.top` file so it's progress.

https://github.com/ParmEd/ParmEd/blob/67b9b024626a1310c4b7e69b713d5c0ba2aa2e44/parmed/structure.py#L1564-L1575