### PR TITLE
Support for list and arrays of unyt quantities

### DIFF
--- a/topology/core/box.py
+++ b/topology/core/box.py
@@ -8,7 +8,7 @@ from topology.utils.testing import allclose
 def _validate_lengths(lengths):
     if not isinstance(lengths, u.unyt_array):
         if all(isinstance(length, u.unyt_quantity) for length in lengths):
-            print("Converting list or np.array of unyt quantities to a unyt array")
+            print("Converting list of unyt quantities to a unyt array")
             lengths = u.unyt_array([l for l in lengths], str(lengths[0].units))
         else:
             warnings.warn('Lengths are assumed to be in nm')

--- a/topology/tests/test_box.py
+++ b/topology/tests/test_box.py
@@ -96,3 +96,9 @@ class TestBox(BaseTest):
         diff_angles = deepcopy(box)
         diff_angles.angles = u.degree * [90, 90, 120]
         assert box != diff_angles
+
+    def test_list_to_unyt_array(self):
+        length = 5 * u.nm
+        box = Box([length, length, length])
+
+        assert isinstance(box.lengths, u.unyt_array)


### PR DESCRIPTION
Referenced in #147, `_validate_lengths` will assume nanometer units if the lengths aren't an instance of  a `unyt_array`.

The change I'm proposing is that if a `np.array` or list of unyt quantities is passed into this function as lengths, these data structures will be converted to a `unyt_array` with the specified units.