### PR TITLE
Hoomd metadata

### DIFF
--- a/topology/formats/gsd.py
+++ b/topology/formats/gsd.py
@@ -92,8 +92,8 @@ def write_gsd(top,
     #    _write_pair_information(gsd_file, top)
     if top.n_bonds > 0:
         _write_bond_information(gsd_file, top)
-    #if structure.angles:
-    #    _write_angle_information(gsd_file, top)
+    if top.n_angles > 0:
+        _write_angle_information(gsd_file, top)
     #if structure.rb_torsions:
     #    _write_dihedral_information(gsd_file, top)
 
@@ -191,15 +191,14 @@ def _write_bond_information(gsd_file, top):
     warnings.warn("{} bonds detected".format(top.n_bonds))
 
     unique_bond_types = set()
-    for bond in top.connections:
-        if isinstance(bond, Bond):
-            t1, t2 = bond.connection_members[0].atom_type, bond.connection_members[1].atom_type
-            if t1 is None or t2 is None:
-                t1, t2 = bond.connection_members[0].name, bond.connection_members[1].name
-            t1, t2 = sorted([t1, t2], key=lambda x: x.name)
-            bond_type = ('-'.join((t1.name, t2.name)))
+    for bond in top.bonds:
+        t1, t2 = bond.connection_members[0].atom_type, bond.connection_members[1].atom_type
+        if t1 is None or t2 is None:
+            t1, t2 = bond.connection_members[0], bond.connection_members[1]
+        t1, t2 = sorted([t1, t2], key=lambda x: x.name)
+        bond_type = ('-'.join((t1.name, t2.name)))
 
-            unique_bond_types.add(bond_type)
+        unique_bond_types.add(bond_type)
     unique_bond_types = sorted(list(unique_bond_types))
     gsd_file.bonds.types = unique_bond_types
     warnings.warn("{} unique bond types detected".format(
@@ -208,58 +207,65 @@ def _write_bond_information(gsd_file, top):
     bond_typeids = []
     bond_groups = []
     for bond in top.bonds:
-        if isinstance(bond, Bond):
-            t1, t2 = bond.connection_members[0].atom_type, bond.connection_members[1].atom_type
-            if t1 is None or t2 is None:
-                t1, t2 = bond.connection_members[0].name, bond.connection_members[1].name
-            t1, t2 = sorted([t1, t2], key=lambda x: x.name)
+        t1, t2 = bond.connection_members[0].atom_type, bond.connection_members[1].atom_type
+        if t1 is None or t2 is None:
+            t1, t2 = bond.connection_members[0].name, bond.connection_members[1].name
+        t1, t2 = sorted([t1, t2], key=lambda x: x.name)
 
-            bond_type = ('-'.join((t1.name, t2.name)))
-            bond_typeids.append(unique_bond_types.index(bond_type))
-            bond_groups.append((top.sites.index(bond.connection_members[0]),
-                                top.sites.index(bond.connection_members[1])))
+        bond_type = ('-'.join((t1.name, t2.name)))
+        bond_typeids.append(unique_bond_types.index(bond_type))
+        bond_groups.append((top.sites.index(bond.connection_members[0]),
+                            top.sites.index(bond.connection_members[1])))
 
     gsd_file.bonds.typeid = bond_typeids
     gsd_file.bonds.group = bond_groups
 
 
-def _write_angle_information(gsd_file, structure):
-    """[NOT IMPLEMENTED] Write the angles in the system.
+def _write_angle_information(gsd_file, top):
+    """ Write the angles in the system.
 
     Parameters
     ----------
     gsd_file :
         The file object of the GSD file being written
-    structure : parmed.Structure
-        Parmed structure object holding system information
+    top : topology.Topology
+        Topology object holding system information
+
 
     """
+    gsd_file.angles.N = top.n_angles
+    warnings.warn("{} angles detected".format(top.n_angles))
 
-    #gsd_file.angles.N = len(structure.angles)
+    unique_angle_types = set()
+    for angle in top.angles:
+        t1, t2, t3 = [a.atom_type for a in angle.connection_members]
+        if t1 is None or t2 is None or t3 is None:
+            t1, t2, t3 = [a.name for a in angle.connection_members]
+        t1, t2, t3 = sorted([t1, t2, t3], key=lambda x: x.name)
+        angle_type = ('-'.join((t1.name, t2.name, t3.name)))
 
-    #unique_angle_types = set()
-    #for angle in structure.angles:
-    #    t1, t2, t3 = angle.atom1.type, angle.atom2.type, angle.atom3.type
-    #    t1, t3 = sorted([t1, t3], key=natural_sort)
-    #    angle_type = ('-'.join((t1, t2, t3)))
-    #    unique_angle_types.add(angle_type)
-    #unique_angle_types = sorted(list(unique_angle_types), key=natural_sort)
-    #gsd_file.angles.types = unique_angle_types
+        unique_angle_types.add(angle_type)
+    unique_angle_types = sorted(list(unique_angle_types))
+    gsd_file.angles.types = unique_angle_types
+    warnings.warn("{} unique angle types detected".format(
+        len(unique_angle_types)))
 
-    #angle_typeids = []
-    #angle_groups = []
-    #for angle in structure.angles:
-    #    t1, t2, t3 = angle.atom1.type, angle.atom2.type, angle.atom3.type
-    #    t1, t3 = sorted([t1, t3], key=natural_sort)
-    #    angle_type = ('-'.join((t1, t2, t3)))
-    #    angle_typeids.append(unique_angle_types.index(angle_type))
-    #    angle_groups.append((angle.atom1.idx, angle.atom2.idx,
-    #                         angle.atom3.idx))
+    angle_typeids = []
+    angle_groups = []
+    for angle in top.angles:
+        t1, t2, t3 = [a.atom_type for a in angle.connection_members]
+        if t1 is None or t2 is None or t3 is None:
+            t1, t2, t3 = [a for a in angle.connection_members]
+        t1, t2, t3= sorted([t1, t2, t3], key=lambda x: x.name)
 
-    #gsd_file.angles.typeid = angle_typeids
-    #gsd_file.angles.group = angle_groups
-    pass
+        angle_type = ('-'.join((t1.name, t2.name, t3.name)))
+        angle_typeids.append(unique_angle_types.index(angle_type))
+        angle_groups.append((top.sites.index(angle.connection_members[0]),
+                            top.sites.index(angle.connection_members[1]),
+                            top.sites.index(angle.connection_members[2])))
 
+    gsd_file.angles.typeid = angle_typeids
+    gsd_file.angles.group = angle_groups
 
 def _write_dihedral_information(gsd_file, structure):
     """[NOT IMPLEMENTED] Write the dihedrals in the system.

--- a/topology/formats/hoomd_metadata.py
+++ b/topology/formats/hoomd_metadata.py
@@ -1,0 +1,110 @@
+import warnings 
+import unyt as u
+import json
+import itertools as it
+
+from topology.exceptions import NotYetImplementedWarning, TopologyError
+from topology.lib import potential_templates
+
+# Define the supported functions for HOOMD in a dictionary
+# Keys are topology.PotentialTemplate
+# Values are the hoomd-metadata keyword
+supported_nonbonded = {
+        potential_templates.LennardJonesPotential(): 'hoomd.md.pair.lj'}
+
+
+def write_metadata(top, filename, unitsystem={'distance': u.nm, 'energy': u.Unit('kJ/mol'),
+                                    'mass': u.amu}):
+    """ Routine to write hoomdmeta data given a topology
+
+    Parameters
+    ----------
+    top : topology.Topology
+    filename : output file, string
+    unitsystem : dictionary
+        Keys are fundamental physical dimension
+        Values are the associated unit quantity
+        Default is a somewhat common unit system for molecular modeling
+        For more information, see 
+        https://hoomd-blue.readthedocs.io/en/stable/units.html
+        """
+    # First update the topology in its entirety
+    top.update_top()
+
+    metadata = {}
+    # Check for supported functions and print to metadata
+    _check_supported_nonbonded(top)
+
+    _write_nonbonded(top, metadata, unitsystem)
+    with open(filename, 'w') as f:
+        json.dump(metadata, f, indent=4)
+
+
+def _check_supported_nonbonded(top):
+    """ Verify the topology's nonbonded functions are supported in HOOMD """
+    for nb_function in top.atom_type_expressions:
+        if any([nb_function == func.expression for func in supported_nonbonded]):
+            continue
+        else:
+            raise NotYetImplementedWarning("Nonbonded function <{}> not implemented "
+                "or not supported in HOOMD".format(nb_function))
+
+def _write_nonbonded(top, metadata, unitsystem):
+    nb_key = "{},{}"
+
+    for first, second in it.combinations_with_replacement(top.atom_types, 2):
+        possible_hoomd_nb_funcs = [hoomd_func for top_func, hoomd_func 
+                in supported_nonbonded.items() 
+                if (first.expression == top_func.expression and
+                    second.expression == top_func.expression)]
+
+        if len(possible_hoomd_nb_funcs) > 1:
+            warnings.warn("Multiple possible HOOMD functions found for " 
+                        + "atom types {0} and {1}: {2}".format(
+                            first, second, possible_hoomd_nb_funcs))
+
+        if len(possible_hoomd_nb_funcs) == 0:
+            raise NotYetImplementedWarning(
+                "Nonbonded function for atomtypes {0} and {1} ".format(first, second)
+                + " not implemented or not supported in HOOMD")
+        else:
+            hoomd_nb_func = possible_hoomd_nb_funcs[0] 
+            if hoomd_nb_func not in metadata:
+                metadata[hoomd_nb_func] = {}
+            if first != second :
+                sigma, epsilon = _apply_combining_rule(
+                        top.combining_rule, first, second)
+            else:
+                sigma, epsilon = (first.parameters['sigma'], 
+                        first.parameters['epsilon'])
+
+            metadata[hoomd_nb_func][nb_key.format(first.name, second.name)] = {
+                    'sigma': _reduce_units(sigma, unitsystem),
+                    'epsilon': _reduce_units(epsilon, unitsystem)
+                    }
+
+def _apply_combining_rule(rule, first, second):
+    """ Apply combining rule to atomtypes first and second """
+    if rule == 'lorentz':
+        sigma = (first.parameters['sigma'] + second.parameters['sigma']) / 2
+        epsilon = (first.parameters['epsilon'] * second.parameters['epsilon']) ** 0.5
+    else:
+        warnings.warn("Combining rule {} not supported".format(rule)
+                + " defaulting to lorentz")
+        sigma = (first.parameters['sigma'] + second.parameters['sigma']) / 2
+        epsilon = (first.parameters['epsilon'] * second.parameters['epsilon']) ** 0.5
+
+    return (sigma, epsilon)
+
+
+def _reduce_units(quantity, unitsystem):
+    """ Reduce the units of quantity according to unitsystem """
+
+    # Okay honestly I don't know the best way to handle this
+    # But i DO know we want to parse the quantity,
+    # figure out its dimensions (is it distance, distance**3/mass, energy/mass, etc)
+    # And then divide out by the associated unitsystem quantities
+    # There might be some unyt functionality (unyt.unit_registry)? 
+
+    # For now, just strip out the units, and convert to float
+    return float(quantity.value)

--- a/topology/formats/hoomd_metadata.py
+++ b/topology/formats/hoomd_metadata.py
@@ -19,8 +19,8 @@ supported_angletypes = {
         potential_templates.HarmonicAnglePotential(): 'hoomd.md.angle.harmonic'}
 
 
-def write_metadata(top, filename, unitsystem={'distance': u.nm, 'energy': u.Unit('kJ/mol'),
-                                    'mass': u.amu}):
+def write_metadata(top, filename, 
+        unitsystem={'distance': u.nm, 'energy': u.Unit('kJ/mol'), 'mass': u.amu}):
     """ Routine to write hoomdmeta data given a topology
 
     Parameters
@@ -34,10 +34,8 @@ def write_metadata(top, filename, unitsystem={'distance': u.nm, 'energy': u.Unit
         For more information, see 
         https://hoomd-blue.readthedocs.io/en/stable/units.html
         """
-    # First update the topology in its entirety
-    top.update_top()
-
     metadata = {'objects':[]}
+
     # Check for supported functions and print to metadata
     _check_supported_bondtypes(top)
     _check_supported_angletypes(top)

--- a/topology/formats/hoomd_metadata.py
+++ b/topology/formats/hoomd_metadata.py
@@ -98,8 +98,8 @@ def _write_bondtypes(top, metadata, unitsystem):
             if hoomd_func not in metadata:
                 metadata[hoomd_func] = {}
 
-            bond_key = nb_key.format(bondtype.member_types[0], 
-                bondtype.membertypes[1])
+            bond_key = key.format(bondtype.member_types[0], 
+                bondtype.member_types[1])
             metadata[hoomd_func][bond_key] = {
                         'k': _reduce_units(bondtype.parameters['k'], unitsystem),
                         'r0': _reduce_units(bondtype.parameters['r_eq'], unitsystem)}
@@ -125,11 +125,11 @@ def _write_angletypes(top, metadata, unitsystem):
             if hoomd_func not in metadata:
                 metadata[hoomd_func] = {}
 
-            angle_key = nb_key.format(angletype.member_types[0], 
-                angletype.membertypes[1], angletype.member_types[2])
+            angle_key = key.format(angletype.member_types[0], 
+                angletype.member_types[1], angletype.member_types[2])
             metadata[hoomd_func][angle_key] = {
                         'k': _reduce_units(angletype.parameters['k'], unitsystem),
-                        'r0': _reduce_units(angletype.parameters['r_eq'], unitsystem)}
+                        't0': _reduce_units(angletype.parameters['theta_eq'], unitsystem)}
 
 def _write_nonbonded(top, metadata, unitsystem):
     key = "{},{}"

--- a/topology/formats/hoomd_metadata.py
+++ b/topology/formats/hoomd_metadata.py
@@ -120,6 +120,9 @@ def _write_bondtypes(top, metadata, hoomd_unytsystem):
             bond_key = key.format(bondtype.member_types[0], 
                 bondtype.member_types[1])
 
+            # This is where the metadata dictionary is actually modified
+            # If more hoomd functions were to be supported/written, 
+            # the code could follow this logic
             if hoomd_func == 'hoomd.md.bond.harmonic':
                 metadata['objects'][hoomd_func_address[hoomd_func]][hoomd_func]['tracked_fields']['parameters'][bond_key] = {
                                 'k': _reduce_units(bondtype.parameters['k'] * 
@@ -167,7 +170,10 @@ def _write_angletypes(top, metadata, hoomd_unytsystem):
 
             angle_key = key.format(angletype.member_types[0], 
                 angletype.member_types[1], angletype.member_types[2])
-            
+
+            # This is where the metadata dictionary is actually modified
+            # If more hoomd functions were to be supported/written, 
+            # the code could follow this logic
             if hoomd_func == 'hoomd.md.angle.harmonic':
                 metadata['objects'][hoomd_func_address[hoomd_func]][hoomd_func]['tracked_fields']['parameters'][angle_key] = {
                                 'k': _reduce_units(
@@ -227,7 +233,10 @@ def _write_nonbonded(top, metadata, hoomd_unytsystem, r_cut_default=1.2):
                 sigma, epsilon = (first.parameters['sigma'], 
                         first.parameters['epsilon'])
             nb_key = key.format(first.name, second.name)
-
+            
+            # This is where the metadata dictionary is actually modified
+            # If more hoomd functions were to be supported/written, 
+            # the code could follow this logic
             if hoomd_nb_func == 'hoomd.md.pair.lj':
                 metadata['objects'][hoomd_func_address[hoomd_nb_func]][hoomd_nb_func]['tracked_fields']['parameters'][nb_key] = {
                                 'sigma': _reduce_units(sigma, hoomd_unytsystem),

--- a/topology/lib/potential_templates.py
+++ b/topology/lib/potential_templates.py
@@ -52,3 +52,17 @@ class BuckinghamPotential(PotentialTemplate):
             independent_variables=independent_variables,
             template=True,
         )
+
+class HarmonicBondPotential(PotentialTemplate):
+    def __init__(self,
+                 name='HarmonicBondPotential',
+                 expression='0.5 * k * (r-r_eq)**2',
+                 independent_variables={'r'}):
+
+        super(PotentialTemplate, self).__init__(
+            name=name,
+            expression=expression,
+            independent_variables=independent_variables,
+            template=True,
+        )
+

--- a/topology/lib/potential_templates.py
+++ b/topology/lib/potential_templates.py
@@ -66,3 +66,16 @@ class HarmonicBondPotential(PotentialTemplate):
             template=True,
         )
 
+class HarmonicAnglePotential(PotentialTemplate):
+    def __init__(self,
+                 name='HarmonicAnglePotential',
+                 expression='0.5 * k * (theta-theta_eq)**2',
+                 independent_variables={'theta'}):
+
+        super(PotentialTemplate, self).__init__(
+            name=name,
+            expression=expression,
+            independent_variables=independent_variables,
+            template=True,
+        )
+

--- a/topology/lib/potential_templates.py
+++ b/topology/lib/potential_templates.py
@@ -15,6 +15,18 @@ class PotentialTemplate(Potential):
             template=template,
         )
 
+    def __hash__(self):
+        return hash(
+            tuple(
+                (
+                    self.name,
+                    self.expression,
+                    tuple(self.independent_variables),
+                )
+            )
+        )
+
+
 class LennardJonesPotential(PotentialTemplate):
     def __init__(self,
                  name='LennardJonesPotential',

--- a/topology/tests/test_hoomdmetadata.py
+++ b/topology/tests/test_hoomdmetadata.py
@@ -1,0 +1,102 @@
+import json
+import numpy as np
+
+import unyt as u
+
+import topology as topo
+from topology.formats.hoomd_metadata import write_metadata
+from topology.tests.base_test import BaseTest
+from topology.utils.testing import allclose
+
+class TestHoomdMetaData(BaseTest):
+    def test_lj(self):
+        top = topo.Topology()
+        atype = topo.AtomType(name='A', 
+                parameters={'sigma':2 * u.nm, 'epsilon':2 * u.Unit('kJ')})
+        top.add_site(topo.Site(name='a',
+            atom_type=atype))
+        write_metadata(top, 'out.json')
+        meta = json.load(open('out.json', 'r'))
+        assert np.isclose(meta['objects'][1]['hoomd.md.pair.lj']['tracked_fields']['parameters']['A,A']['sigma'], 2.0)
+        assert np.isclose(meta['objects'][1]['hoomd.md.pair.lj']['tracked_fields']['parameters']['A,A']['epsilon'], 2.0)
+
+    def test_lj_mix(self):
+        top = topo.Topology()
+        top.combining_rule = 'lorentz'
+        atype = topo.AtomType(name='A', 
+                parameters={'sigma':2 * u.nm, 'epsilon':2 * u.Unit('kJ')})
+
+        btype = topo.AtomType(name='B', 
+                parameters={'sigma':4 * u.nm, 'epsilon':4 * u.Unit('kJ')})
+
+        top.add_site(topo.Site(name='a',
+            atom_type=atype))
+        top.add_site(topo.Site(name='b',
+            atom_type=btype))
+
+        write_metadata(top, 'out.json')
+        meta = json.load(open('out.json', 'r'))
+        assert np.isclose(meta['objects'][1]['hoomd.md.pair.lj']['tracked_fields']['parameters']['A,B']['sigma'], 3)
+        assert np.isclose(meta['objects'][1]['hoomd.md.pair.lj']['tracked_fields']['parameters']['A,B']['epsilon'], (2*4)**0.5)
+
+    def test_harmonic_bond(self):
+        top = topo.Topology()
+        top.combining_rule = 'lorentz'
+        atype = topo.AtomType(name='A', 
+                parameters={'sigma':2 * u.nm, 'epsilon':2 * u.Unit('kJ')})
+
+        btype = topo.AtomType(name='B', 
+                parameters={'sigma':4 * u.nm, 'epsilon':4 * u.Unit('kJ')})
+
+        asite = topo.Site(name='a',
+            atom_type=atype)
+        bsite = topo.Site(name='b',
+            atom_type=btype)
+
+
+        bondtype = topo.BondType(parameters={'r_eq': 0.14 * u.nm,
+                                            'k': 3.0 * u.Unit('kJ')},
+                                member_types=['A', 'B'])
+        bond = topo.Bond(connection_members=[asite, bsite], 
+                connection_type=bondtype)
+        top.add_connection(bond)
+
+        top.update_top()
+        write_metadata(top, 'out.json')
+        meta = json.load(open('out.json', 'r'))
+
+        assert np.isclose(meta['objects'][1]['hoomd.md.bond.harmonic']['tracked_fields']['parameters']['A-B']['r0'], 0.14)
+        assert np.isclose(meta['objects'][1]['hoomd.md.bond.harmonic']['tracked_fields']['parameters']['A-B']['k'], 3.0)
+
+    def test_harmonic_angle(self):
+        top = topo.Topology()
+        top.combining_rule = 'lorentz'
+        atype = topo.AtomType(name='A', 
+                parameters={'sigma':2 * u.nm, 'epsilon':2 * u.Unit('kJ')})
+        btype = topo.AtomType(name='B', 
+                parameters={'sigma':4 * u.nm, 'epsilon':4 * u.Unit('kJ')})
+        ctype = topo.AtomType(name='C', 
+                parameters={'sigma':4 * u.nm, 'epsilon':4 * u.Unit('kJ')})
+
+
+        asite = topo.Site(name='a',
+            atom_type=atype)
+        bsite = topo.Site(name='b',
+            atom_type=btype)
+        csite = topo.Site(name='c',
+            atom_type=ctype)
+
+
+        angletype = topo.AngleType(parameters={'theta_eq': 3.14 * u.rad,
+                                            'k': 3.0 * u.Unit('kJ')},
+                                member_types=['A', 'B', 'C'])
+        angle = topo.Angle(connection_members=[asite, bsite, csite], 
+                connection_type=angletype)
+        top.add_connection(angle)
+
+        top.update_top()
+        write_metadata(top, 'out.json')
+        meta = json.load(open('out.json', 'r'))
+
+        assert np.isclose(meta['objects'][1]['hoomd.md.angle.harmonic']['tracked_fields']['parameters']['A-B-C']['t0'], 3.14)
+        assert np.isclose(meta['objects'][1]['hoomd.md.angle.harmonic']['tracked_fields']['parameters']['A-B-C']['k'], 3.0)

--- a/topology/tests/test_hoomdmetadata.py
+++ b/topology/tests/test_hoomdmetadata.py
@@ -12,7 +12,7 @@ class TestHoomdMetaData(BaseTest):
     def test_lj(self):
         top = topo.Topology()
         atype = topo.AtomType(name='A', 
-                parameters={'sigma':2 * u.nm, 'epsilon':2 * u.Unit('kJ')})
+                parameters={'sigma':2 * u.nm, 'epsilon':2 * u.Unit('kJ/mol')})
         top.add_site(topo.Site(name='a',
             atom_type=atype))
         write_metadata(top, 'out.json')
@@ -24,10 +24,10 @@ class TestHoomdMetaData(BaseTest):
         top = topo.Topology()
         top.combining_rule = 'lorentz'
         atype = topo.AtomType(name='A', 
-                parameters={'sigma':2 * u.nm, 'epsilon':2 * u.Unit('kJ')})
+                parameters={'sigma':2 * u.nm, 'epsilon':2 * u.Unit('kJ/mol')})
 
         btype = topo.AtomType(name='B', 
-                parameters={'sigma':4 * u.nm, 'epsilon':4 * u.Unit('kJ')})
+                parameters={'sigma':4 * u.nm, 'epsilon':4 * u.Unit('kJ/mol')})
 
         top.add_site(topo.Site(name='a',
             atom_type=atype))
@@ -43,10 +43,10 @@ class TestHoomdMetaData(BaseTest):
         top = topo.Topology()
         top.combining_rule = 'lorentz'
         atype = topo.AtomType(name='A', 
-                parameters={'sigma':2 * u.nm, 'epsilon':2 * u.Unit('kJ')})
+                parameters={'sigma':2 * u.nm, 'epsilon':2 * u.Unit('kJ/mol')})
 
         btype = topo.AtomType(name='B', 
-                parameters={'sigma':4 * u.nm, 'epsilon':4 * u.Unit('kJ')})
+                parameters={'sigma':4 * u.nm, 'epsilon':4 * u.Unit('kJ/mol')})
 
         asite = topo.Site(name='a',
             atom_type=atype)
@@ -55,7 +55,7 @@ class TestHoomdMetaData(BaseTest):
 
 
         bondtype = topo.BondType(parameters={'r_eq': 0.14 * u.nm,
-                                            'k': 3.0 * u.Unit('kJ')},
+                                            'k': 3.0 * u.Unit('kJ/mol/nm**2')},
                                 member_types=['A', 'B'])
         bond = topo.Bond(connection_members=[asite, bsite], 
                 connection_type=bondtype)
@@ -72,11 +72,11 @@ class TestHoomdMetaData(BaseTest):
         top = topo.Topology()
         top.combining_rule = 'lorentz'
         atype = topo.AtomType(name='A', 
-                parameters={'sigma':2 * u.nm, 'epsilon':2 * u.Unit('kJ')})
+                parameters={'sigma':2 * u.nm, 'epsilon':2 * u.Unit('kJ/mol')})
         btype = topo.AtomType(name='B', 
-                parameters={'sigma':4 * u.nm, 'epsilon':4 * u.Unit('kJ')})
+                parameters={'sigma':4 * u.nm, 'epsilon':4 * u.Unit('kJ/mol')})
         ctype = topo.AtomType(name='C', 
-                parameters={'sigma':4 * u.nm, 'epsilon':4 * u.Unit('kJ')})
+                parameters={'sigma':4 * u.nm, 'epsilon':4 * u.Unit('kJ/mol')})
 
 
         asite = topo.Site(name='a',
@@ -88,7 +88,7 @@ class TestHoomdMetaData(BaseTest):
 
 
         angletype = topo.AngleType(parameters={'theta_eq': 3.14 * u.rad,
-                                            'k': 3.0 * u.Unit('kJ')},
+                                            'k': 3.0 * u.Unit('kJ/mol/rad**2')},
                                 member_types=['A', 'B', 'C'])
         angle = topo.Angle(connection_members=[asite, bsite, csite], 
                 connection_type=angletype)


### PR DESCRIPTION
First pass at printing to a hoomd metadata json (#151 ). Goal is to have this working for LJ systems

Some important features:
* The use of a dictionary of `top.PotentialTemplate : hoomd.class` that outlines the supported functions while also relating the top.Potential to a particular hoomd object in the metadata
* Checking for supported functions is written right inside the metadata-writer, but a very similar ideas might be needed for gmx (mapping top.Potential to gmx.functiontype) or lammps (mapping top.Potential to lmp keyword)
* To use the dictionary, I needed to override the `PotentialTemplate.__hash__` because it was inheriting from `Potential.__hash__` which will throw errors because PotentialTemplate lacks the information a Potential has
* Some crude warnings/exceptions are thrown for un-supported NB functions, or for NB functions that won't mix well (two atom types with different NB functions)
* Some basic combining rule (this just looks at `top.combining_rule` string to perform a function) - I'm wondering if, down the line, `top.combining_rule` shouldn't be a string, but rather a class that has functions like `top.combinig_rule.mix_sigma` or `top.combining_rule.mix_epsilon`
* Since HOOMD works in reduced units, printing sigma and epsilon is not so trivial - we need to take the `unyt.quantities`, identify their fundamental dimensions, and then reduce their units according to a unitsystem
