### PR TITLE
Add virtual templates

### DIFF
--- a/topology/core/virtualsite.py
+++ b/topology/core/virtualsite.py
@@ -1,5 +1,6 @@
 import warnings
 from topology.core.site import Site
+from topology.core.potential import Potential
 
 
 class VirtualSite(object):
@@ -7,25 +8,32 @@ class VirtualSite(object):
 
     Partners
     --------
-    vs_type: topology.Potential
-        An instance of topology.Potential that describes
-        the virtual site function and parameters of this interaction
+    virtual_site: topology.site
+        An instance of topology.site that is the virtual site
     virtual_site_members: list of topology.Site
         Should be length 2 or 3
+    virtual_site_type: topology.Potential
+        An instance of topology.Potential that describes
+        the virtual site function and parameters of this interaction
     name: name of the virtual site
     """
 
-    def __init__(self, virtual_site_members=[], virtual_site_type=None, name="VirtualSite"):
+    def __init__(self, virtual_site, virtual_site_members=[], virtual_site_type=None, name="VirtualSite"):
         if virtual_site_members is None:
             virtual_site_members = tuple()
         
         # TODO: validate virtual site members
         #self._virtual_site_members = _validate_virtual_site_members(virtual_site_members)
+        self._virtual_site = virtual_site
         self._virtual_site_members = virtual_site_members
         self._virtual_site_type = _validate_vs_type(virtual_site_type)
         self._name = _validate_name(name)
         # TODO: update members
         #self._update_members()
+
+    @property
+    def virtual_site(self):
+        return self._virtual_site
 
     @property
     def virtual_site_members(self):

--- a/topology/core/virtualsite.py
+++ b/topology/core/virtualsite.py
@@ -1,49 +1,65 @@
 import warnings
-
-from topology.core.connection import Connection
-from topology.core.dihedral_type import DihedralType
-from topology.exceptions import TopologyError
+from topology.core.site import Site
 
 
-class VirtualSite(Connection):
+class VirtualSite(object):
     """A virtual site construction
 
     Partners
     --------
-    connection_members: list of topology.Site
-        Should be length 4
-    connection_type : topology.DihedralType
-    name : name of the virtual site
-        inherits the name attribute from Connection
-
-    Notes
-    -----
-    Inherits some methods from Connection:
-        __eq__, __repr__, _validate methods
-    Addiitonal _validate methods are presented
+    vs_type: topology.Potential
+        An instance of topology.Potential that describes
+        the virtual site function and parameters of this interaction
+    virtual_site_members: list of topology.Site
+        Should be length 2 or 3
+    name: name of the virtual site
     """
 
-    def __init__(self, connection_members=[], connection_type=None, name="Dihedral"):
-        connection_members = _validate_four_partners(connection_members)
-        connection_type = _validate_dihedraltype(connection_type)
+    def __init__(self, virtual_site_members=[], virtual_site_type=None, name="VirtualSite"):
+        if virtual_site_members is None:
+            virtual_site_members = tuple()
+        
+        # TODO: validate virtual site members
+        #self._virtual_site_members = _validate_virtual_site_members(virtual_site_members)
+        self._virtual_site_members = virtual_site_members
+        self._virtual_site_type = _validate_vs_type(virtual_site_type)
+        self._name = _validate_name(name)
+        # TODO: update members
+        #self._update_members()
 
-        super(Dihedral, self).__init__(connection_members=connection_members,
-                connection_type=connection_type, name=name)
+    @property
+    def virtual_site_members(self):
+        return self._virtual_site_members
 
+    @property
+    def virtual_site_type(self):
+        return self._virtual_site_type
 
-def _validate_four_partners(connection_members):
-    """Ensure 4 partners are involved in Dihedral"""
-    if len(connection_members) != 4:
-        raise TopologyError("Trying to create an Dihedral "
-                "with {} connection members". format(len(connection_members)))
+    @property
+    def name(self):
+        return self._name
 
-    return connection_members
+    @name.setter
+    def name(self, vsname):
+        self._name = _validate_name(vsname)
 
+    def __repr__(self):
+        descr = '<{} Virtual Site, id {}'.format(
+                self.virtual_site_type, id(self))
+        if self.name:
+            descr += ', name {}'.format(self.name)
+        descr += '>'
 
-def _validate_dihedraltype(contype):
-    """Ensure connection_type is a DihedralType """
-    if contype is None:
-        warnings.warn("Non-parametrized Dihedral detected")
-    elif not isinstance(contype, DihedralType):
-        raise TopologyError("Supplied non-DihedralType {}".format(contype))
-    return contype
+        return descr
+
+def _validate_vs_type(c_type):
+    if c_type is None:
+        warnings.warn("Non-parametrized virtual site detected")
+    elif not isinstance(c_type, Potential):
+        raise TopologyError("Supplied non-Potential {}".format(c_type))
+    return c_type
+
+def _validate_name(conname):
+    if not isinstance(conname, str):
+        raise TopologyError("Supplied name {} is not a string".format(conname))
+    return conname

--- a/topology/core/virtualsite.py
+++ b/topology/core/virtualsite.py
@@ -1,0 +1,49 @@
+import warnings
+
+from topology.core.connection import Connection
+from topology.core.dihedral_type import DihedralType
+from topology.exceptions import TopologyError
+
+
+class VirtualSite(Connection):
+    """A virtual site construction
+
+    Partners
+    --------
+    connection_members: list of topology.Site
+        Should be length 4
+    connection_type : topology.DihedralType
+    name : name of the virtual site
+        inherits the name attribute from Connection
+
+    Notes
+    -----
+    Inherits some methods from Connection:
+        __eq__, __repr__, _validate methods
+    Addiitonal _validate methods are presented
+    """
+
+    def __init__(self, connection_members=[], connection_type=None, name="Dihedral"):
+        connection_members = _validate_four_partners(connection_members)
+        connection_type = _validate_dihedraltype(connection_type)
+
+        super(Dihedral, self).__init__(connection_members=connection_members,
+                connection_type=connection_type, name=name)
+
+
+def _validate_four_partners(connection_members):
+    """Ensure 4 partners are involved in Dihedral"""
+    if len(connection_members) != 4:
+        raise TopologyError("Trying to create an Dihedral "
+                "with {} connection members". format(len(connection_members)))
+
+    return connection_members
+
+
+def _validate_dihedraltype(contype):
+    """Ensure connection_type is a DihedralType """
+    if contype is None:
+        warnings.warn("Non-parametrized Dihedral detected")
+    elif not isinstance(contype, DihedralType):
+        raise TopologyError("Supplied non-DihedralType {}".format(contype))
+    return contype

--- a/topology/core/virtualsite_type.py
+++ b/topology/core/virtualsite_type.py
@@ -1,0 +1,70 @@
+import warnings
+import unyt as u
+
+from topology.core.potential import Potential
+from topology.exceptions import TopologyError
+from topology.utils._constants import DIHEDRAL_TYPE_DICT
+
+class VirtualSiteType(Potential):
+    """A virtual site construction.
+
+    Parameters
+    ----------
+    name : str
+    expression : str or sympy.Expression
+        See `Potential` documentation for more information
+    parameters : dict {str, unyt.unyt_quantity}
+        See `Potential` documentation for more information
+    independent vars : set of str
+        See `Potential` documentation for more information
+    member_types : list of topology.AtomType.name (str)
+    topology: topology.core.Topology, the topology of which this dihedral type is a part of, default=None
+    set_ref: (str), the string name of the bookkeeping set in topology class.
+
+    Notes
+    ----
+    Inherits many functions from topology.Potential:
+        __eq__, _validate functions
+    """
+
+    def __init__(self,
+                 name='VirtualSiteType',
+                 expression='k * (1 + cos(n * phi - phi_eq))**2',
+                 parameters=None,
+                 independent_variables=None,
+                 member_types=None,
+                 topology=None,
+                 set_ref='dihedral_type_set'):
+        if parameters is None:
+            parameters = {
+                'a': 0.35 * u.dimensionless
+            }
+        if independent_variables is None:
+            independent_variables = {'phi'}
+
+        if member_types is None:
+            member_types = list()
+
+        super(VirtualSiteType, self).__init__(name=name, expression=expression,
+                                           parameters=parameters, independent_variables=independent_variables,
+                                           topology=topology)
+        self._set_ref = VIRTUALSITE_TYPE_DICT
+        self._member_types = _validate_four_member_type_names(member_types)
+
+    @property
+    def set_ref(self):
+        return self._set_ref
+
+    @property
+    def member_types(self):
+        return self._member_types
+
+    @member_types.setter
+    def member_types(self, val):
+        if self.member_types != val:
+            warnings.warn("Changing an VirtualSiteType's constituent "
+                          "member types: {} to {}".format(self.member_types, val))
+        self._member_types = _validate_four_member_type_names(val)
+
+    def __repr__(self):
+        return "<VirtualSiteType {}, id {}>".format(self.name, id(self))

--- a/topology/core/virtualsite_type.py
+++ b/topology/core/virtualsite_type.py
@@ -18,7 +18,7 @@ class VirtualSiteType(Potential):
     independent vars : set of str
         See `Potential` documentation for more information
     member_types : list of topology.AtomType.name (str)
-    topology: topology.core.Topology, the topology of which this dihedral type is a part of, default=None
+    topology: topology.core.Topology, the topology of which this virtual site type is a part of, default=None
     set_ref: (str), the string name of the bookkeeping set in topology class.
 
     Notes
@@ -29,18 +29,16 @@ class VirtualSiteType(Potential):
 
     def __init__(self,
                  name='VirtualSiteType',
-                 expression='k * (1 + cos(n * phi - phi_eq))**2',
+                 expression='1 - a',
                  parameters=None,
                  independent_variables=None,
                  member_types=None,
                  topology=None,
-                 set_ref='dihedral_type_set'):
+                 set_ref='virtualsite_type_set'):
         if parameters is None:
             parameters = {
                 'a': 0.35 * u.dimensionless
             }
-        if independent_variables is None:
-            independent_variables = {'phi'}
 
         if member_types is None:
             member_types = list()
@@ -48,8 +46,8 @@ class VirtualSiteType(Potential):
         super(VirtualSiteType, self).__init__(name=name, expression=expression,
                                            parameters=parameters, independent_variables=independent_variables,
                                            topology=topology)
-        self._set_ref = VIRTUALSITE_TYPE_DICT
-        self._member_types = _validate_four_member_type_names(member_types)
+        #self._set_ref = VIRTUALSITE_TYPE_DICT
+        self._member_types = member_types
 
     @property
     def set_ref(self):

--- a/topology/lib/virtual_templates.py
+++ b/topology/lib/virtual_templates.py
@@ -15,61 +15,21 @@ class VirtualSiteTemplate(Potential):
             template=template,
         )
 
+class TwoSiteConstruction(VirtualSiteTemplate):
+    def __init__(self,
+                 name='TwoSiteConstruction',
+                 expression='1 - a)',
+                 independent_variables=None):
+        super(PotentialTemplate, self).__init__(
+            name=name,
+            expression=expression,
+            independent_variables=independent_variables,
+            template=True,
+        )
+
 class ThreeSiteConstruction(VirtualSiteTemplate):
     def __init__(self,
                  name='ThreeSiteConstruction',
-                 expression='1 - a - b)',
-                 independent_variables=None):
-        super(PotentialTemplate, self).__init__(
-            name=name,
-            expression=expression,
-            independent_variables=independent_variables,
-            template=True,
-        )
-
-class ThreeSiteFDConstruction(VirtualSiteTemplate):
-    def __init__(self,
-                 name='ThreeSiteFDConstruction',
-                 # This is not right
-                 expression='1 - a - b)',
-                 independent_variables=None):
-        super(PotentialTemplate, self).__init__(
-            name=name,
-            expression=expression,
-            independent_variables=independent_variables,
-            template=True,
-        )
-
-class ThreeSiteFADConstruction(VirtualSiteTemplate):
-    def __init__(self,
-                 name='ThreeSiteFDConstruction',
-                 # This is not right
-                 expression='1 - a - b)',
-                 independent_variables=None):
-        super(PotentialTemplate, self).__init__(
-            name=name,
-            expression=expression,
-            independent_variables=independent_variables,
-            template=True,
-        )
-
-class ThreeSiteOutConstruction(VirtualSiteTemplate):
-    def __init__(self,
-                 name='ThreeSiteOutConstruction',
-                 # This is not right
-                 expression='1 - a - b)',
-                 independent_variables=None):
-        super(PotentialTemplate, self).__init__(
-            name=name,
-            expression=expression,
-            independent_variables=independent_variables,
-            template=True,
-        )
-
-class FourSiteConstruction(VirtualSiteTemplate):
-    def __init__(self,
-                 name='FourSiteConstruction',
-                 # This is not right
                  expression='1 - a - b)',
                  independent_variables=None):
         super(PotentialTemplate, self).__init__(

--- a/topology/lib/virtual_templates.py
+++ b/topology/lib/virtual_templates.py
@@ -1,0 +1,80 @@
+from topology.core.potential import Potential
+
+
+class VirtualSiteTemplate(Potential):
+    def __init__(self,
+                 name='VirtualSiteTemplate',
+                 expression='1 - a',
+                 independent_variables=None,
+                 template=True):
+
+        super(VirtualSiteTemplate, self).__init__(
+            name=name,
+            expression=expression,
+            independent_variables=independent_variables,
+            template=template,
+        )
+
+class ThreeSiteConstruction(VirtualSiteTemplate):
+    def __init__(self,
+                 name='ThreeSiteConstruction',
+                 expression='1 - a - b)',
+                 independent_variables=None):
+        super(PotentialTemplate, self).__init__(
+            name=name,
+            expression=expression,
+            independent_variables=independent_variables,
+            template=True,
+        )
+
+class ThreeSiteFDConstruction(VirtualSiteTemplate):
+    def __init__(self,
+                 name='ThreeSiteFDConstruction',
+                 # This is not right
+                 expression='1 - a - b)',
+                 independent_variables=None):
+        super(PotentialTemplate, self).__init__(
+            name=name,
+            expression=expression,
+            independent_variables=independent_variables,
+            template=True,
+        )
+
+class ThreeSiteFADConstruction(VirtualSiteTemplate):
+    def __init__(self,
+                 name='ThreeSiteFDConstruction',
+                 # This is not right
+                 expression='1 - a - b)',
+                 independent_variables=None):
+        super(PotentialTemplate, self).__init__(
+            name=name,
+            expression=expression,
+            independent_variables=independent_variables,
+            template=True,
+        )
+
+class ThreeSiteOutConstruction(VirtualSiteTemplate):
+    def __init__(self,
+                 name='ThreeSiteOutConstruction',
+                 # This is not right
+                 expression='1 - a - b)',
+                 independent_variables=None):
+        super(PotentialTemplate, self).__init__(
+            name=name,
+            expression=expression,
+            independent_variables=independent_variables,
+            template=True,
+        )
+
+class FourSiteConstruction(VirtualSiteTemplate):
+    def __init__(self,
+                 name='FourSiteConstruction',
+                 # This is not right
+                 expression='1 - a - b)',
+                 independent_variables=None):
+        super(PotentialTemplate, self).__init__(
+            name=name,
+            expression=expression,
+            independent_variables=independent_variables,
+            template=True,
+        )


### PR DESCRIPTION
Really primitive `VirtualSite` class.  My plan was originally to inherit from the `Connection` class.  However virtual sites are not technically connected to the other members, so I decided to create a new class.  I could be doing this wrong though so feel free to provide any criticism/ feedback.

In this class, I've separated out the attributes so that `virtual_site` and `virtual_site_members` are separate attributes.  The underlying `virtual_site_type` needs work but hoping we can discuss this sometime.