### PR TITLE
Add TabulatedPotential class

### DIFF
--- a/topology/__init__.py
+++ b/topology/__init__.py
@@ -16,3 +16,4 @@ from .core.atom_type import AtomType
 from .core.bond_type import BondType
 from .core.angle_type import AngleType
 from .core.dihedral_type import DihedralType
+from .core.tabulated_potential import TabulatedPotential

--- a/topology/core/tabulated_potential.py
+++ b/topology/core/tabulated_potential.py
@@ -5,7 +5,7 @@ from topology.exceptions import TopologyError
 
 
 class TabulatedPotential(object):
-    """A class representing an potential represented by vabulated values."""
+    """A class representing an potential represented by tabulated values."""
 
     def __init__(self, name="Potential", r=None, v=None, topology=None):
         self._name = name

--- a/topology/core/tabulated_potential.py
+++ b/topology/core/tabulated_potential.py
@@ -1,0 +1,74 @@
+import numpy as np
+
+from topology.utils.decorators import confirm_dict_existence
+from topology.exceptions import TopologyError
+
+
+class TabulatedPotential(object):
+    """A class representing an potential represented by vabulated values."""
+
+    def __init__(self, name="Potential", r=None, v=None, topology=None):
+        self._name = name
+        self._r = r
+        self._v = v
+
+        if topology is not None:
+            self._topology = topology
+        else:
+            self._topology = None
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    @confirm_dict_existence
+    def name(self, val):
+        self._name = val
+
+    @property
+    def r(self):
+        return self._r
+
+    @r.setter
+    def r(self, val):
+        val = _preprocess_array(val)
+        _check_consistency(val, self._v)
+        self._r = val
+
+    @property
+    def v(self):
+        return self._v
+
+    @v.setter
+    def v(self, val):
+        val = _preprocess_array(val)
+        _check_consistency(self._r, val)
+        self._v = val
+
+    def set_r_and_v(self, r, v):
+        r_ = _preprocess_array(r)
+        v_ = _preprocess_array(v)
+        _check_consistency(r_, v_)
+        self._r = r_
+        self._v = v_
+
+
+def _preprocess_array(arr):
+    arr = np.asarray(arr)
+
+    if arr.ndim != 1:
+        raise TopologyError(
+            'Array found to have non-1 number of dimensions after conversion'
+            'to NumPy. Number of dimensions found: {arr.ndim}'
+        )
+
+    return arr
+
+
+def _check_consistency(a, b):
+    if a.shape != b.shape:
+        raise TopologyError(
+            'Trying to set an array of length unequal to other attribute. See '
+            'TabulatedPotential.set_r_and_v() to set both r and v in one step'
+        )

--- a/topology/tests/base_test.py
+++ b/topology/tests/base_test.py
@@ -7,6 +7,7 @@ from topology.core.topology import Topology
 from topology.core.element import Hydrogen
 from topology.core.site import Site
 from topology.core.atom_type import AtomType
+from topology.core.tabulated_potential import TabulatedPotential
 
 
 class BaseTest:
@@ -55,3 +56,12 @@ class BaseTest:
             return top
 
         return _topology
+
+    @pytest.fixture
+    def tab_pot(self):
+        pot = TabulatedPotential(
+            r = np.linspace(0, 1),
+            v = np.linspace(5, 0),
+        )
+
+        return pot

--- a/topology/tests/test_tabulated_potential.py
+++ b/topology/tests/test_tabulated_potential.py
@@ -1,0 +1,41 @@
+import numpy as np
+import unyt as u
+import pytest
+
+from topology.core.tabulated_potential import TabulatedPotential
+from topology.tests.base_test import BaseTest
+from topology.utils.testing import allclose
+from topology.exceptions import TopologyError
+
+
+class TestPotential(BaseTest):
+    def test_new_potential(self):
+        pot = TabulatedPotential(
+            r = np.linspace(0, 1),
+            v = np.linspace(5, 0),
+        )
+
+    def test_getters_setters(self, tab_pot):
+        assert np.allclose(tab_pot.r, np.linspace(0, 1))
+        assert np.allclose(tab_pot.v, np.linspace(5, 0))
+
+        tab_pot.r = np.linspace(0, 10)
+        tab_pot.v = np.linspace(2, 0)
+
+        assert np.allclose(tab_pot.r, np.linspace(0, 10))
+        assert np.allclose(tab_pot.v, np.linspace(2, 0))
+
+    def test_set_both(self, tab_pot):
+        tab_pot.set_r_and_v(
+            r=np.linspace(0, 1, 40),
+            v=np.linspace(5, 0, 40),
+        )
+
+        assert np.allclose(tab_pot.r, np.linspace(0, 1, 40))
+        assert np.allclose(tab_pot.v, np.linspace(5, 0, 40))
+
+    def test_bad_setters(self, tab_pot):
+        with pytest.raises(TopologyError):
+            tab_pot.r = np.linspace(0, 10, num=73)
+        with pytest.raises(TopologyError):
+            tab_pot.v = np.eye(4)


### PR DESCRIPTION
In keeping this with design philosophy of this package, I have kept the internals of this class fairly light. I would like to keep it that way. This class does little more than store `r` and `v` as NumPy arrays (`.force` is coming soon) and provide some basic sanity checks along the way. The unit tests should characterize the spirit of the usage I had in mind, but I'm also including a gist that shows some manipulation

TODO
* [ ] - Optionally store forces
* [ ] - Include some simple functions to generate forces by differentiating potential
* [ ] - Some sanity checks with units

Outside the scope of this PR:
* [ ] - Storing tabulated potentials on disk (in our or other XML formats)
* [ ] - Interactions with other simulation engines
* [ ] - Routines for generating tabulated potentials from other functional forms and other helper functions (@uppittu11 @ahy3nz IIRC  there are some things in Tim's version of the MSIBI code that are related)