### PR TITLE
Add additional potential templates

### DIFF
--- a/topology/lib/potential_templates.py
+++ b/topology/lib/potential_templates.py
@@ -29,6 +29,21 @@ class LennardJonesPotential(PotentialTemplate):
             template=True,
         )
 
+class MiePotential(PotentialTemplate):
+    def __init__(self,
+                 name='MiePotential',
+                 expression='(n/(n-m)) * (n/m)**(m/(n-m)) * ' +
+                            'epsilon * ((sigma/r)**n - (sigma/r)**m)',
+                 independent_variables=None):
+        if independent_variables is None:
+            independent_variables = {'r'}
+        super(PotentialTemplate, self).__init__(
+            name=name,
+            expression=expression,
+            independent_variables=independent_variables,
+            template=True,
+        )
+
 class BuckinghamPotential(PotentialTemplate):
     def __init__(self,
                  name='BuckinghamPotential',
@@ -70,10 +85,40 @@ class HarmonicAnglePotential(PotentialTemplate):
             template=True,
         )
 
+class HarmonicTorsionPotential(PotentialTemplate):
+    def __init__(self,
+                 name='HarmonicTorsionPotential',
+                 expression='0.5 * k * (phi - phi_eq)**2',
+                 independent_variables={'phi'}):
+
+        super(PotentialTemplate, self).__init__(
+                name=name,
+                expression=expression,
+                independent_variables=independent_variables,
+                template=True
+        )
+
 class PeriodicTorsionPotential(PotentialTemplate):
     def __init__(self,
                  name='PeriodicTorsionPotential',
                  expression='k * (1 + cos(n * phi - phi_eq))**2',
+                 independent_variables={'phi'}):
+
+        super(PotentialTemplate, self).__init__(
+                name=name,
+                expression=expression,
+                independent_variables=independent_variables,
+                template=True
+        )
+
+class OPLSTorsionPotential(PotentialTemplate):
+    def __init__(self,
+                 name='OPLSTorsionPotential',
+                 expression='k0 + ' +
+                            '0.5 * k1 * (1 + cos(phi)) + ' +
+                            '0.5 * k2 * (1 - cos(2*phi)) + ' +
+                            '0.5 * k3 * (1 + cos(3*phi)) + ' +
+                            '0.5 * k4 * (1 - cos(4*phi))',
                  independent_variables={'phi'}):
 
         super(PotentialTemplate, self).__init__(
@@ -89,6 +134,19 @@ class RyckaertBellemansTorsionPotential(PotentialTemplate):
                  expression='c0 * cos(phi)**0 + c1 * cos(phi)**1 + ' +
                     'c2 * cos(phi)**2 + c3 * cos(phi)**3 + c4 * cos(phi)**4 + ' +
                     'c5 * cos(phi)**5',
+                 independent_variables={'phi'}):
+
+        super(PotentialTemplate, self).__init__(
+                name=name,
+                expression=expression,
+                independent_variables=independent_variables,
+                template=True
+        )
+
+class HarmonicImproperPotential(PotentialTemplate):
+    def __init__(self,
+                 name='HarmonicImproperPotetial',
+                 expression='0.5 * k * (phi - phi_eq)**2',
                  independent_variables={'phi'}):
 
         super(PotentialTemplate, self).__init__(


### PR DESCRIPTION
Adding four more potential templates for potentials that are supported in Cassandra.

1. Mie non-bonded potential
2. Harmonic torsion
3. OPLS-style fourier series torsion
4. Harmonic improper

I didn't see any unit tests for the other potentials defined in `lib`, but please let me know what tests I should add if we would like some.

One possible issue I see is the HarmonicImproperPotential has the same functional form and parameters as the HarmonicDihedralPotential. I _think_ those will evaluate to equivalent in `_check_single_potential`, #121 . 