### PR TITLE
Correct energy unit conversion for epsilon

### DIFF
--- a/topology/formats/lammpsdata.py
+++ b/topology/formats/lammpsdata.py
@@ -165,7 +165,7 @@ def write_lammpsdata(topology, filename, atom_style='full'):
             for idx,epsilon in epsilon_dict.items():
                 data.write('{}\t{:.5f}\t{:.5f}\n'.format(
                     idx,
-                    epsilon.in_units(u.Unit('kcal')).value,
+                    epsilon.in_units(u.Unit('kcal/mol')).value,
                     sigma_dict[idx].in_units(u.angstrom).value))
 
         # TODO: Write out bond coefficients


### PR DESCRIPTION
Currently, when trying to write out to a unit system in lammps, the
quantity is converted from `kcal/mol` to `kcal` which essentially sets
the epsilon value to 0.0.

This change converts the `epsilon` unit to `kcal/mol`, although it is
noted that this might have to change in the future. Since the unit
systems of lammps are varied and have different units based on the
system the engine is operating in.