### PR TITLE
Change trigger for azure pipelines to 'master'

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,6 @@
 trigger:
-  - 175-core-equality-checks
+  - master 
+
 pr:
   - master
 
@@ -9,7 +10,7 @@ jobs:
       vmImage: 'ubuntu-latest'
     steps:
       - bash: echo "##vso[task.prependpath]$CONDA/bin"
-        displayName: Add conta to path
+        displayName: Add conda to path
 
       - bash: |
           conda config --set always_yes yes --set changeps1 no


### PR DESCRIPTION
I think this should make AZP CI work. Should now be triggered by any PR change to master. 