### PR TITLE
Add some more documentation pages

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,0 +1,3 @@
+Contributing
+------------
+plz help

--- a/docs/design_principles.rst
+++ b/docs/design_principles.rst
@@ -1,0 +1,61 @@
+=================
+Design Principles
+=================
+
+Scope and Features of ``Topology``
+----------------------------------
+
+``Topology`` is designed to enable the flexible, general representation of
+chemical topologies for molecular simulation. Efforts are made to enable
+lossless, bias-free storage of data, without assuming particular chemistries,
+models, or using any particular engine's ecosystem as a starting point. The
+scope is generally restrained to the preparation, manipulation, and conversion
+of and of input files for molecular simulation, i.e. before engines are called
+to execute the simulations themselves. ``Topology`` currently does not support
+conversions between trajectory file formats for analysis codes. In the scope of
+molecular simulation, we loosely define a chemical topology as everything
+needed to reproducibly prepare a chemical system for simulation. This includes
+particle coordinates and connectivity, box information, force field data
+(functional forms, parameters tagged with units, partial charges, etc.) and
+some optional information that may not apply to all systems (i.e. specification
+of elements with each particle).
+
+``Topology`` enables the following features:
+
+* Supporting a variety of models in the molecular simulation/computational
+  chemistry community: No assumptions are made about an interaciton site
+  represetning an atom or bead, instead supported atomistic,
+  united-atom/coarse-grained, polarizable, and other models!
+
+* Greater flexibility for exotic potentials: The ``AtomType`` (and analoug
+  classes for intramolecular interactions) uses ``sympy`` toclass can store any
+  potential that can be represented by a mathematical expression. If you can
+  write it down, it can be stored!
+
+* Easier development for glue to new engines: by not initially for
+  compatibility with any particular molecular simulation engine or ecosystem,
+  it becomes more tractable for developers in the community add glue for
+  engines that are not currently supported (and even ones that do not exist at
+  present)!
+
+
+* Compatibility with existing community tools: No single molecular simulation
+  tool will be a silver bullet, so ``Topology`` includes functions to convert
+  objects. These can be used in their own right to convert between objects in
+  memory and also to support conversion to file formats not natively support at
+  any given time. Currently supported conversions include ``ParmEd``,
+  ``OpenMM``, ``mBuild``, ``MDTraj``, with others coming in the future!
+
+
+* Native support for reading and writing many common file formats (``XYZ``,
+  ``GRO``, ``TOP``, ``LAMMPSDATA``) and indirect support, through other
+  libraries, for many more!
+
+
+Structure of ``Topology``
+-------------------------
+There are three main modules within the Python package:
+
+* ``topology.core`` stores the classes that constitute the core data structures.
+* ``topology.formats`` stores readers and writers for (on-disk) file formats.
+* ``topology.extermal`` includes functions that convert core data structures between external libraries and their internal representation.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,9 +9,8 @@ Topology: Flexible storage of chemical topology for molecular simulation
 .. toctree::
    :hidden:
 
+   design_principles
    data_structures
    forcefield
-
-
-
-
+   installation
+   contributing

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,72 @@
+============
+Installation
+============
+
+Installing dependencies with `conda <http://continuum.io/downloads>`_
+---------------------------------------------------------------------
+
+Dependencies of ``Topology`` are listed in the file ``requirements.txt``. They
+can be installed in one line:
+::
+
+    $ conda install -c omnia -c mosdef -c conda-forge --file requirements.txt
+
+Alternatively you can add all the required channels to your ``.condarc`` file
+and then install dependenices.
+
+    $ conda config --add channels omnia
+    $ conda config --add channels mosdef
+    $ conda config --add channels conda-forge
+    $ conda install --file requirements.txt
+
+.. note::
+    These commands will likely change a configuration file on your computer and
+    may affect installation of other packages in other projects you are working
+    on. However, the channel priority recommended is fairly common
+    (in particle, having ``conda-forge`` having the highest priority) and should
+    work well for most installations.
+
+Installing dependencies with `pip <https://pypi.org/project/pip/>`_
+-------------------------------------------------------------------
+::
+
+    $ pip install --file requirements.txt
+
+.. note::
+    Compared to ``conda`` installation, this is less tested. Some upstream
+    dependencies may not be available on ``PyPI`` but can be installed via
+    source or ``conda``.
+
+Install an editable version from source
+---------------------------------------
+
+Once all dependencies are installed, the ``Topology`` itself can be installed.
+It is currently only available through its source code. It will be available
+through ``pip`` and ``conda`` in the future.
+::
+
+    $ git clone https://github.com/mattwthompson/topology
+    $ cd topology
+    $ pip install -e .
+
+
+Supported Python Versions
+-------------------------
+
+Python 3.7 is the recommend version for users. It is the only version on which
+development and testing consistently takes place.  Older (3.6) and newer (3.8+)
+versions of Python 3 are likely to work but no guarantee is made and, in
+addition, some dependencies may not be available for other versions.  No effort
+is made to support Python 2 because it is considered obsolete as of early 2020. 
+
+Testing your installation
+-------------------------
+
+``Topology`` uses ``py.test`` to execute its unit tests. To run them, first install some extra depdencies:
+::
+    $ conda install --file requirements-test.txt
+
+
+And then run the tests with the ``py.test`` executable:
+::
+    $ py.test -v


### PR DESCRIPTION
* Needs some color and/or flashy images

* I noticed the `ForceField` class got added into its own `topology.forcefield` module. I had personally envisioned it as another class in `topology.core`. What do you all think?

* Will need to update lots of things for a different name

* Installation instructions are barebones but should be sufficient for next week
* Lots of autodoc lines look bad, but we will improve docstrings soon.