### PR TITLE
Formats docstrings for gro  and gsd io

### DIFF
--- a/gmso/formats/gro.py
+++ b/gmso/formats/gro.py
@@ -13,14 +13,18 @@ from gmso.utils.testing import allclose
 def read_gro(filename):
     """Provided a filepath to a gro file, generate a topology.
 
-    The Gromos87 (gro) format is a common plain text structure file used commonly with the GROMACS simulation engine.
-    This file contains the simulation box parameters, number of atoms, the residue and atom number for each atom, as well as their positions and velocities (velocity is optional).
-    This method will receive a filepath representation either as a string, or a file object and return a `topology`.
+    The Gromos87 (gro) format is a common plain text structure file used
+    commonly with the GROMACS simulation engine.  This file contains the
+    simulation box parameters, number of atoms, the residue and atom number for
+    each atom, as well as their positions and velocities (velocity is
+    optional).  This method will receive a filepath representation either as a
+    string, or a file object and return a `topology`.
 
     Parameters
     ----------
     filename : str or file object
-        The path to the gro file either as a string, or a file object that points to the gro file.
+        The path to the gro file either as a string, or a file object that
+        points to the gro file.
 
     Returns
     -------
@@ -30,11 +34,14 @@ def read_gro(filename):
 
     Notes
     -----
-    Gro files do not specify connections between atoms, the returned topology will not have connections between sites either.
+    Gro files do not specify connections between atoms, the returned topology
+    will not have connections between sites either.
 
-    Currently this implementation does not support a gro file with more than 1 frame.
+    Currently this implementation does not support a gro file with more than 1
+    frame.
 
-    All residues and resid information from the gro file are currently lost when converting to `topology`.
+    All residues and resid information from the gro file are currently lost
+    when converting to `topology`.
 
     """
 
@@ -85,9 +92,12 @@ def read_gro(filename):
 def write_gro(top, filename):
     """Write a topology to a gro file.
 
-    The Gromos87 (gro) format is a common plain text structure file used commonly with the GROMACS simulation engine.
-    This file contains the simulation box parameters, number of atoms, the residue and atom number for each atom, as well as their positions and velocities (velocity is optional).
-    This method takes a topology object and a filepath string or file object and saves a Gromos87 (gro) to disk.
+    The Gromos87 (gro) format is a common plain text structure file used
+    commonly with the GROMACS simulation engine.  This file contains the
+    simulation box parameters, number of atoms, the residue and atom number for
+    each atom, as well as their positions and velocities (velocity is
+    optional).  This method takes a topology object and a filepath string or
+    file object and saves a Gromos87 (gro) to disk.
 
     Parameters
     ----------
@@ -99,7 +109,8 @@ def write_gro(top, filename):
 
     Notes
     -----
-    Multiple residue assignment has not been added, each `site` will belong to the same resid of 1 currently.
+    Multiple residue assignment has not been added, each `site` will belong to
+    the same resid of 1 currently.
 
     """
 

--- a/gmso/formats/gsd.py
+++ b/gmso/formats/gsd.py
@@ -27,8 +27,9 @@ def write_gsd(top,
               write_special_pairs=True):
     """Output a GSD file (HOOMD v2 default data format).
 
-    The `GSD` binary file format is the native format of HOOMD-Blue.
-    This file can be used as a starting point for a HOOMD-Blue simulation, for analysis, and for visualization in various tools.
+    The `GSD` binary file format is the native format of HOOMD-Blue. This file
+    can be used as a starting point for a HOOMD-Blue simulation, for analysis,
+    and for visualization in various tools.
 
     Parameters
     ----------
@@ -43,15 +44,15 @@ def write_gsd(top,
     ref_energy : float, optional, default=1.0
         Reference energy for conversion to reduced units
     rigid_bodies : list of int, optional, default=None
-        List of rigid body information. An integer value is required for
-        each atom corresponding to the index of the rigid body the particle
-        is to be associated with. A value of None indicates the atom is not
-        part of a rigid body.
+        List of rigid body information. An integer value is required for each
+        atom corresponding to the index of the rigid body the particle is to be
+        associated with. A value of None indicates the atom is not part of a
+        rigid body.
     shift_coords : bool, optional, default=True
         Shift coordinates from (0, L) to (-L/2, L/2) if necessary.
     write_special_pairs : bool, optional, default=True
-        Writes out special pair information necessary to correctly use the OPLS fudged 1,4 interactions
-        in HOOMD.
+        Writes out special pair information necessary to correctly use the OPLS
+        fudged 1,4 interactions in HOOMD.
 
     Notes
     -----
@@ -106,9 +107,7 @@ def write_gsd(top,
 
 def _write_particle_information(gsd_snapshot, top, xyz, ref_distance, ref_mass,
                                 ref_energy, rigid_bodies):
-    """Write out the particle information.
-
-    """
+    """Write out the particle information."""
 
     gsd_snapshot.particles.N = top.n_sites
     warnings.warn("{} particles detected".format(top.n_sites))


### PR DESCRIPTION
Previously, the documentation for both the gro file reader and writer
were lacking.

Both the reader and writer are now documented and additional notes have
been included to document the current limitations of each reader and
writer. These can be removed as the updates are implemented.

Also, the docstrings for `write_gsd` were quite detailed already,
but additional information and warnings have also been added to the
necessary functions.