### PR TITLE
TOP writer: "moleculename" tag doesn't correspond to the "molecule" tag 

### DIFF
--- a/gmso/formats/top.py
+++ b/gmso/formats/top.py
@@ -100,7 +100,7 @@ def write_top(top, filename):
             out_file.write(
                 '{0}\t\t\t'
                 '{1}\n\n'.format(
-                    top.subtops[0].name,
+                    top.name,
                     3
                 )
             )


### PR DESCRIPTION
This is a hotfix to get GROMACS sims working with the current format (one big molecule). When/if we unique subtops/molecules set up this can be reverted. 

This change ensures that the name in "[moleculename]" is the same as the name in "[molecules]".