### PR TITLE
docs namechange topology to gmso

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,6 +1,6 @@
 Contributing
 ============
-Contributions are welcomed via `pull requests on GitHub <https://github.com/mattwthompson/topology/pulls>`_. Developers and/or
+Contributions are welcomed via `pull requests on GitHub <https://github.com/mosdef-hub/gmso/pulls>`_. Developers and/or
 users will review requested changes and make comments. The rest of this file will serve as a set of general guidelines
 for contributors.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -45,8 +45,8 @@ It is currently only available through its source code. It will be available
 through ``pip`` and ``conda`` in the future.
 ::
 
-    $ git clone https://github.com/mattwthompson/topology
-    $ cd topology
+    $ git clone https://github.com/modef-hub/gmso.git
+    $ cd gmso
     $ pip install -e .
 
 


### PR DESCRIPTION
Update url for pull requests, cloning url, and directory name for installation of gmso to reflect change from 'topology' to 'gmso'