### PR TITLE
More tests for GROMACS topology writer

### DIFF
--- a/gmso/formats/top.py
+++ b/gmso/formats/top.py
@@ -100,7 +100,7 @@ def write_top(top, filename):
             out_file.write(
                 '{0}\t\t\t'
                 '{1}\n\n'.format(
-                    top.subtops[0].name,
+                    top.name,
                     3
                 )
             )

--- a/gmso/tests/base_test.py
+++ b/gmso/tests/base_test.py
@@ -116,7 +116,7 @@ class BaseTest:
             atom.atom_type = ff.atom_types[atom.name]
 
         for bond in top.bonds:
-            bond.bond_type = ff.bond_types["opls_111~opls_112"]
+            bond.connection_type = ff.bond_types["opls_111~opls_112"]
 
         for subtop in top.subtops:
             angle = Angle(

--- a/gmso/tests/test_top.py
+++ b/gmso/tests/test_top.py
@@ -15,10 +15,10 @@ class TestTop(BaseTest):
         write_top(top, 'ar.top')
 
 
-    def test_pmd_loop(self, typed_ar_system):
-        top = typed_ar_system
-        write_top(top, 'ar.top')
-        pmd.load_file('ar.top')
+    def test_pmd_loop(self, typed_ar_system, typed_water_system):
+        for top in [typed_ar_system, typed_water_system]:
+            write_top(top, 'system.top')
+            pmd.load_file('system.top')
 
 
     def test_modified_potentials(self, ar_system):

--- a/gmso/tests/test_top.py
+++ b/gmso/tests/test_top.py
@@ -15,10 +15,11 @@ class TestTop(BaseTest):
         write_top(top, 'ar.top')
 
 
-    def test_pmd_loop(self, typed_ar_system, typed_water_system):
-        for top in [typed_ar_system, typed_water_system]:
-            write_top(top, 'system.top')
-            pmd.load_file('system.top')
+    @pytest.mark.parametrize('top', ['typed_ar_system',
+        'typed_water_system'])
+    def test_pmd_loop(self, top, request):
+        write_top(request.getfixturevalue(top), 'system.top')
+        pmd.load_file('system.top')
 
 
     def test_modified_potentials(self, ar_system):


### PR DESCRIPTION
This is built off of #306, I tried to include the typed water box as a fixture so that we can run a round-trip with `ParmEd`, which handles the case that @uppittu11's PR fixed.

I could use some help turning `test_pmd_loop` into something that more elegantly loops over pytest fixtures, ideally with `pytest.mark.parametrize`.

I like the idea of using `ParmEd` as a dummy check for our writers as we build them up, and maybe remove this in the future if we are more confident in our glue.