### PR TITLE
Get site indices by indexed set

### DIFF
--- a/gmso/formats/top.py
+++ b/gmso/formats/top.py
@@ -13,7 +13,6 @@ def write_top(top, filename):
 
     _validate_compatibility(top)
     top_vars = _get_top_vars()
-    _assign_indices(top)
 
     with open(filename, 'w') as out_file:
         out_file.write(
@@ -131,15 +130,15 @@ def write_top(top, filename):
             '\n[ bonds ]\n'
             ';   ai     aj  funct   c0      c1\n'
         )
-        for bond_idx, bond in enumerate(top.bonds):
+        for bond in top.bonds:
             out_file.write(
                 '\t{0}'
                 '\t{1}'
                 '\t{2}'
                 '\t{3}'
                 '\t{4}\n'.format(
-                    bond.connection_members[0].idx,
-                    bond.connection_members[1].idx,
+                    top.sites.index(bond.connection_members[0]),
+                    top.sites.index(bond.connection_members[1]),
                     '1',
                     bond.connection_type.parameters['r_eq'].in_units(u.nm).value,
                     bond.connection_type.parameters['k'].in_units(
@@ -151,7 +150,7 @@ def write_top(top, filename):
             '\n[ angles ]\n'
             ';   ai     aj      ak      funct   c0      c1\n'
         )
-        for angle_idx, angle in enumerate(top.angles):
+        for angle in top.angles:
             out_file.write(
                 '\t{0}'
                 '\t{1}'
@@ -159,9 +158,9 @@ def write_top(top, filename):
                 '\t{3}'
                 '\t{4}'
                 '\t{5}\n'.format(
-                    angle.connection_members[0].idx,
-                    angle.connection_members[1].idx,
-                    angle.connection_members[2].idx,
+                    top.sites.index(angle.connection_members[0]),
+                    top.sites.index(angle.connection_members[1]),
+                    top.sites.index(angle.connection_members[2]),
                     '1',
                     angle.connection_type.parameters['theta_eq'].in_units(u.degree).value,
                     angle.connection_type.parameters['k'].in_units(
@@ -173,7 +172,7 @@ def write_top(top, filename):
             '\n[ dihedrals ]\n'
             ';   ai     aj      ak      al  funct   c0      c1      c2\n'
         )
-        for dihedral_idx, dihedral in enumerate(top.dihedrals):
+        for dihedral in top.dihedrals:
             out_file.write(
                 '\t{0}'
                 '\t{1}'
@@ -186,10 +185,10 @@ def write_top(top, filename):
                 '\t{8}'
                 '\t{9}'
                 '\t{10}\n'.format(
-                    dihedral.connection_members[0].idx,
-                    dihderal.connection_members[1].idx,
-                    dihedral.connection_members[2].idx,
-                    dihedral.connection_members[3].idx,
+                    top.sites.index(dihedral.connection_members[0]),
+                    top.sites.index(dihedral.connection_members[1]),
+                    top.sites.index(dihedral.connection_members[2]),
+                    top.sites.index(dihedral.connection_members[3]),
                     '3',
                     dihedral.connection_type.parameters['c0'],
                     dihedral.connection_type.parameters['c1'],
@@ -244,11 +243,6 @@ def _get_top_vars():
     top_vars['fudgeQQ'] = 1
 
     return top_vars
-
-
-def _assign_indices(top):
-    for idx, site in enumerate(top.sites):
-        site.idx = idx + 1
 
 
 def _lookup_atomic_number(atom_type):


### PR DESCRIPTION
This PR addresses the way that site indices are set and written out in `top.py`.  Originally, `idx` was added as a site attribute.  Now, the `indexed_set` of `top.sites` is used to grab the indices.

I also removed `bond_idx`, `angle_idx`, and `dihedral_idx` since those don't seem to get used.