### PR TITLE
Refactor PotentialTemplates as a lazy loading json module(Closes #333)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include gmso/lib/jsons/*.json

--- a/gmso/formats/mcf.py
+++ b/gmso/formats/mcf.py
@@ -6,19 +6,15 @@ import sympy
 import unyt as u
 
 from gmso.core.topology import Topology
-from gmso.lib.potential_templates import LennardJonesPotential
-from gmso.lib.potential_templates import MiePotential
-from gmso.lib.potential_templates import HarmonicAnglePotential
-from gmso.lib.potential_templates import HarmonicTorsionPotential
-from gmso.lib.potential_templates import PeriodicTorsionPotential
-from gmso.lib.potential_templates import OPLSTorsionPotential
-from gmso.lib.potential_templates import RyckaertBellemansTorsionPotential
+from gmso.lib.potential_templates import PotentialTemplateLibrary
 from gmso.utils.compatibility import check_compatibility
 from gmso.utils.conversions import convert_ryckaert_to_opls
 from gmso.exceptions import GMSOError
 
 
 __all__ = ["write_mcf"]
+
+potential_templates = PotentialTemplateLibrary()
 
 
 def write_mcf(top, filename):
@@ -663,14 +659,13 @@ def _check_compatibility(top):
         raise GMSOError(
             "MCF writing not supported without parameterized forcefield."
         )
-
     accepted_potentials = [
-        LennardJonesPotential(),
-        MiePotential(),
-        HarmonicAnglePotential(),
-        PeriodicTorsionPotential(),
-        OPLSTorsionPotential(),
-        RyckaertBellemansTorsionPotential(),
+        potential_templates['LennardJonesPotential'],
+        potential_templates['MiePotential'],
+        potential_templates['HarmonicAnglePotential'],
+        potential_templates['PeriodicTorsionPotential'],
+        potential_templates['OPLSTorsionPotential'],
+        potential_templates['RyckaertBellemansTorsionPotential'],
     ]
     check_compatibility(top, accepted_potentials)
 
@@ -678,7 +673,8 @@ def _check_compatibility(top):
 def _get_vdw_style(atom_type):
     """Return the vdw style"""
 
-    vdw_styles = {"LJ": LennardJonesPotential(), "Mie": MiePotential()}
+    vdw_styles = {"LJ": potential_templates['LennardJonesPotential'],
+                  "Mie": potential_templates['MiePotential']}
 
     return _get_potential_style(vdw_styles, atom_type)
 
@@ -687,10 +683,10 @@ def _get_dihedral_style(dihedral_type):
     """Return the dihedral style"""
 
     dihedral_styles = {
-        "charmm": PeriodicTorsionPotential(),
-        "harmonic": HarmonicTorsionPotential(),
-        "opls": OPLSTorsionPotential(),
-        "ryckaert": RyckaertBellemansTorsionPotential(),
+        "charmm": potential_templates['PeriodicTorsionPotential'],
+        "harmonic": potential_templates['HarmonicTorsionPotential'],
+        "opls": potential_templates['OPLSTorsionPotential'],
+        "ryckaert": potential_templates['RyckaertBellemansTorsionPotential'],
     }
 
     return _get_potential_style(dihedral_styles, dihedral_type)

--- a/gmso/formats/top.py
+++ b/gmso/formats/top.py
@@ -3,7 +3,7 @@ import datetime
 import unyt as u
 
 from gmso.core.element import element_by_atom_type
-from gmso.lib.potential_templates import LennardJonesPotential, HarmonicBondPotential, HarmonicAnglePotential
+from gmso.lib.potential_templates import PotentialTemplates
 from gmso.utils.compatibility import check_compatibility
 from gmso.exceptions import GMSOError
 
@@ -228,7 +228,11 @@ def write_top(top, filename):
 
 def _validate_compatibility(top):
     """Check compatability of topology object with GROMACS TOP format"""
-    accepted_potentials = [LennardJonesPotential(), HarmonicBondPotential(), HarmonicAnglePotential()]
+    templates = PotentialTemplates()
+    lennard_jones_potential = templates['LennardJonesPotential']
+    harmonic_bond_potential = templates['HarmonicBondPotential']
+    harmonic_angle_potential = templates['HarmonicAnglePotential']
+    accepted_potentials = [lennard_jones_potential, harmonic_bond_potential, harmonic_angle_potential]
     check_compatibility(top, accepted_potentials)
 
 

--- a/gmso/formats/top.py
+++ b/gmso/formats/top.py
@@ -3,7 +3,7 @@ import datetime
 import unyt as u
 
 from gmso.core.element import element_by_atom_type
-from gmso.lib.potential_templates import PotentialTemplates
+from gmso.lib.potential_templates import PotentialTemplateLibrary
 from gmso.utils.compatibility import check_compatibility
 from gmso.exceptions import GMSOError
 
@@ -228,7 +228,7 @@ def write_top(top, filename):
 
 def _validate_compatibility(top):
     """Check compatability of topology object with GROMACS TOP format"""
-    templates = PotentialTemplates()
+    templates = PotentialTemplateLibrary()
     lennard_jones_potential = templates['LennardJonesPotential']
     harmonic_bond_potential = templates['HarmonicBondPotential']
     harmonic_angle_potential = templates['HarmonicAnglePotential']

--- a/gmso/lib/jsons/.gitignore
+++ b/gmso/lib/jsons/.gitignore
@@ -1,1 +1,0 @@
-TestTemplate.json

--- a/gmso/lib/jsons/.gitignore
+++ b/gmso/lib/jsons/.gitignore
@@ -1,0 +1,1 @@
+TestTemplate.json

--- a/gmso/lib/jsons/BuckinghamPotential.json
+++ b/gmso/lib/jsons/BuckinghamPotential.json
@@ -1,0 +1,5 @@
+{
+  "name": "BuckinghamPotential",
+  "expression": "a*exp(-b*r) - c*r**-6",
+  "independent_variables": "r"
+}

--- a/gmso/lib/jsons/HarmonicAnglePotential.json
+++ b/gmso/lib/jsons/HarmonicAnglePotential.json
@@ -1,0 +1,5 @@
+{
+  "name": "HarmonicAnglePotential",
+  "expression": "0.5 * k * (theta-theta_eq)**2",
+  "independent_variables": "theta"
+}

--- a/gmso/lib/jsons/HarmonicBondPotential.json
+++ b/gmso/lib/jsons/HarmonicBondPotential.json
@@ -1,0 +1,5 @@
+{
+  "name": "HarmonicBondPotential",
+  "expression": "0.5 * k * (r-r_eq)**2",
+  "independent_variables": "r"
+}

--- a/gmso/lib/jsons/HarmonicImproperPotential.json
+++ b/gmso/lib/jsons/HarmonicImproperPotential.json
@@ -1,0 +1,5 @@
+{
+  "name": "HarmonicImproperPotential",
+  "expression": "0.5 * k * (phi - phi_eq)**2",
+  "independent_variables": "phi"
+}

--- a/gmso/lib/jsons/HarmonicTorsionPotential.json
+++ b/gmso/lib/jsons/HarmonicTorsionPotential.json
@@ -1,0 +1,5 @@
+{
+  "name": "HarmonicTorsionPotential",
+  "expression": "0.5 * k * (phi - phi_eq)**2",
+  "independent_variables": "phi"
+}

--- a/gmso/lib/jsons/LennardJonesPotential.json
+++ b/gmso/lib/jsons/LennardJonesPotential.json
@@ -1,0 +1,5 @@
+{
+  "name": "LennardJonesPotential",
+  "expression": "4*epsilon*((sigma/r)**12 - (sigma/r)**6)",
+  "independent_variables": "r"
+}

--- a/gmso/lib/jsons/MiePotential.json
+++ b/gmso/lib/jsons/MiePotential.json
@@ -1,0 +1,5 @@
+{
+  "name": "MiePotential",
+  "expression": "(n/(n-m)) * (n/m)**(m/(n-m)) * epsilon * ((sigma/r)**n - (sigma/r)**m)",
+  "independent_variables": "r"
+}

--- a/gmso/lib/jsons/OPLSTorsionPotential.json
+++ b/gmso/lib/jsons/OPLSTorsionPotential.json
@@ -1,0 +1,6 @@
+{
+  "name": "OPLSTorsionPotential",
+  "expression": "0.5 * k0 + 0.5 * k1 * (1 + cos(phi)) + 0.5 * k2 * (1 - cos(2*phi)) + 0.5 * k3 * (1 + cos(3*phi)) + 0.5 * k4 * (1 - cos(4*phi))",
+  "independent_variables": "phi"
+}
+

--- a/gmso/lib/jsons/PeriodicTorsionPotential.json
+++ b/gmso/lib/jsons/PeriodicTorsionPotential.json
@@ -1,0 +1,5 @@
+{
+  "name": "PeriodicTorsionPotential",
+  "expression": "k * (1 + cos(n * phi - phi_eq))**2",
+  "independent_variables": "phi"
+}

--- a/gmso/lib/jsons/README.md
+++ b/gmso/lib/jsons/README.md
@@ -45,3 +45,5 @@ abcTemplate_dict = {
         }       
 templates.save_potential_template('ABCTemplate', abcTemplate_dict, True)
 ```
+
+After you are satisfied with your template, add a test to verify that it is actually created [here](../../tests/test_potential_templates.py).

--- a/gmso/lib/jsons/README.md
+++ b/gmso/lib/jsons/README.md
@@ -11,7 +11,7 @@ A potential template object requires the following attributes:
 
 
 ## For Developers
-To add/contribute a new `PotentialTemplate` there are two ways:
+To add/contribute a new `PotentialTemplate` there are the following ways:
 
 1. **Add JSON File**: The example below shows the content of an example json file(OPLSTorsionPotential):
 ```json
@@ -25,25 +25,6 @@ If you want to add a template named `ABCTemplate`. Create a file called
 `ABCTemplate.json` in this directory. Using the json reference above, 
 name the template `ABCTemplate` and change the `expression` and `independent_variables`.
 
-If there are more than one  `independent_variables` in your template, simply separate them by a comma(,).
-
-2. **Use a python script**:
-Let's say you want to create a new PotentialTemplate. There's a static method 
-in `PotentialTemplates` that let's you add a new one.
-
-Use the following script to generate potential template(in your dev branch):
-
-**Warning: Do not use this script on conda/pip installed version or master branch**
-
-```python
-from gmso.lib.potential_templates import PotentialTemplates
-templates = PotentialTemplates()
-abcTemplate_dict = {
-            'name': 'ABCTemplate', 
-            'expression': 'expression', 
-            'independent_variables': 'variables'
-        }       
-templates.save_potential_template('ABCTemplate', abcTemplate_dict, True)
-```
+If there are more than one  `independent_variables` in your template, simply separate them with a comma(,).
 
 After you are satisfied with your template, add a test to verify that it is actually created [here](../../tests/test_potential_templates.py).

--- a/gmso/lib/jsons/README.md
+++ b/gmso/lib/jsons/README.md
@@ -1,0 +1,47 @@
+# GMSO Potential Templates JSON Files
+
+This directory contains json representations of GMSO potential 
+templates. 
+
+A potential template object requires the following attributes:
+
+1. `name`: Name of the potential template
+2. `expression`: expression for the potential template
+3. `independent_variables`: Independent variables for the template 
+
+
+## For Developers
+To add/contribute a new `PotentialTemplate` there are two ways:
+
+1. **Add JSON File**: The example below shows the content of an example json file(OPLSTorsionPotential):
+```json
+{
+  "name": "OPLSTorsionPotential",
+  "expression": "0.5 * k0 + 0.5 * k1 * (1 + cos(phi)) + 0.5 * k2 * (1 - cos(2*phi)) + 0.5 * k3 * (1 + cos(3*phi)) + 0.5 * k4 * (1 - cos(4*phi))",
+  "independent_variables": "phi"
+}
+```
+If you want to add a template named `ABCTemplate`. Create a file called
+`ABCTemplate.json` in this directory. Using the json reference above, 
+name the template `ABCTemplate` and change the `expression` and `independent_variables`.
+
+If there are more than one  `independent_variables` in your template, simply separate them by a comma(,).
+
+2. **Use a python script**:
+Let's say you want to create a new PotentialTemplate. There's a static method 
+in `PotentialTemplates` that let's you add a new one.
+
+Use the following script to generate potential template(in your dev branch):
+
+**Warning: Do not use this script on conda/pip installed version or master branch**
+
+```python
+from gmso.lib.potential_templates import PotentialTemplates
+templates = PotentialTemplates()
+abcTemplate_dict = {
+            'name': 'ABCTemplate', 
+            'expression': 'expression', 
+            'independent_variables': 'variables'
+        }       
+templates.save_potential_template('ABCTemplate', abcTemplate_dict, True)
+```

--- a/gmso/lib/jsons/RyckaertBellemansTorsionPotential.json
+++ b/gmso/lib/jsons/RyckaertBellemansTorsionPotential.json
@@ -1,0 +1,5 @@
+{
+  "name": "RyckaertBellemansTorsionPotential",
+  "expression": "c0 * cos(phi)**0 + c1 * cos(phi)**1 + c2 * cos(phi)**2 + c3 * cos(phi)**3 + c4 * cos(phi)**4 + c5 * cos(phi)**5",
+  "independent_variables": "phi"
+}

--- a/gmso/lib/potential_templates.py
+++ b/gmso/lib/potential_templates.py
@@ -41,7 +41,7 @@ class PotentialTemplate(Potential):
         )
 
 
-class PotentialTemplates(Singleton):
+class PotentialTemplateLibrary(Singleton):
     """A singleton collection of all the potential templates"""
 
     def __init__(self):

--- a/gmso/lib/potential_templates.py
+++ b/gmso/lib/potential_templates.py
@@ -1,29 +1,12 @@
-import glob
-import os
 import json
+from pathlib import Path
 
 from gmso.core.potential import Potential
 from gmso.utils.singleton import Singleton
 from gmso.exceptions import GMSOError
 
-POTENTIAL_JSONS = glob.glob(os.path.join(os.path.dirname(__file__), 'jsons', '*.json'))
-JSON_DIR = os.path.join(os.path.dirname(__file__), 'jsons')
-USER_TEMPLATE_PREFIX = 'potential_templates'
-
-
-def _create_hidden_dir(new_dir=None):
-    gmso_dir = os.path.join(os.path.expanduser('~'), '.gmso')
-    if new_dir is None:
-        if os.path.exists(gmso_dir) and os.path.isdir(gmso_dir):
-            return gmso_dir
-        else:
-            os.makedirs(gmso_dir)
-    else:
-        dir_loc = os.path.join(gmso_dir, new_dir)
-        if not os.path.exists(dir_loc) and not os.path.isdir(dir_loc):
-            os.makedirs(dir_loc)
-        return dir_loc
-    return gmso_dir
+POTENTIAL_JSONS = list(Path(__file__).parent.glob('jsons/*.json'))
+JSON_DIR = Path.joinpath(Path(__file__).parent, 'jsons')
 
 
 def _verify_potential_template_keys(_dict, name):
@@ -35,7 +18,7 @@ def _verify_potential_template_keys(_dict, name):
 
 
 def _load_template_json(item, json_dir=JSON_DIR):
-    with open(os.path.join(json_dir, f'{item}.json')) as json_file:
+    with json_dir.joinpath(f'{item}.json').open('r') as json_file:
         potential_dict = json.load(json_file)
         _verify_potential_template_keys(potential_dict, item)
         return potential_dict
@@ -66,65 +49,21 @@ class PotentialTemplates(Singleton):
             self.json_refs
         except AttributeError:
             self.json_refs = POTENTIAL_JSONS
-            self.user_jsons = []
-            potential_names = [(os.path.split(filename)[-1]).replace('.json', '') for filename in POTENTIAL_JSONS]
+            potential_names = [pot_json.name for pot_json in POTENTIAL_JSONS]
             self._ref_dict = {potential.replace('.json', ''): None for potential in potential_names}
             self._user_ref_dict = {}
 
     def get_available_template_names(self):
         return tuple(self._ref_dict.keys())
 
-    def load_user_templates(self):
-        gmso_dir = _create_hidden_dir(USER_TEMPLATE_PREFIX)
-        user_jsons = glob.glob(os.path.join(gmso_dir, '*.json'))
-        self.user_jsons.extend(user_jsons)
-        self.user_jsons = list(set(self.user_jsons))
-        user_potential_names = [(os.path.split(filename)[-1]).replace('.json', '') for filename in user_jsons]
-        self._user_ref_dict.update({potential.replace('.json', ''): self._user_ref_dict.get(potential, None)
-                                    for potential in user_potential_names})
-
     def __getitem__(self, item):
-        exists_user = True
-        exists_package = True
         if item not in self._ref_dict:
-            exists_package = False
-        if item not in self._user_ref_dict:
-            exists_user = False
+            raise KeyError(f'Potential Template {item} not found.')
 
-        if exists_user:
-            return self._load_from_json(item, ref='user')
-        if exists_package:
-            return self._load_from_json(item, ref='package')
+        return self._load_from_json(item)
 
-        raise KeyError(f'Potential Template {item} not found in user as well as package templates'
-                       f'Please make sure the user templates are loaded by using load_user_templates')
-
-    def _load_from_json(self, item, ref='package'):
-        if ref == 'package':
-            ref_dict = self._ref_dict
-            _dir = JSON_DIR
-        elif ref == 'user':
-            ref_dict = self._user_ref_dict
-            _dir = _create_hidden_dir(USER_TEMPLATE_PREFIX)
-        else:
-            raise GMSOError(f'Cannot load template from {ref}. Please use either package or user.')
-
-        if ref_dict[item] is None:
-            potential_dict = _load_template_json(item, _dir)
-            ref_dict[item] = PotentialTemplate(**potential_dict)
-        return ref_dict[item]
-
-    @staticmethod
-    def save_potential_template(name, template_dict, update=True, user_template=True):
-        """Add a new potential template to the PotentialTemplates Library"""
-        parent_dir = JSON_DIR
-        if user_template:
-            parent_dir = _create_hidden_dir(USER_TEMPLATE_PREFIX)
-
-        _verify_potential_template_keys(template_dict, name)
-        with open(os.path.join(parent_dir, f'{name}.json'), 'w') as json_file:
-            json.dump(template_dict, json_file)
-
-        if update:
-            delattr(PotentialTemplates(), 'json_refs')
-            PotentialTemplates()
+    def _load_from_json(self, item):
+        if self._ref_dict[item] is None:
+            potential_dict = _load_template_json(item, JSON_DIR)
+            self._ref_dict[item] = PotentialTemplate(**potential_dict)
+        return self._ref_dict[item]

--- a/gmso/lib/potential_templates.py
+++ b/gmso/lib/potential_templates.py
@@ -8,6 +8,7 @@ from gmso.exceptions import GMSOError
 
 POTENTIAL_JSONS = glob.glob(os.path.join(os.path.dirname(__file__), 'jsons', '*.json'))
 JSON_DIR = os.path.join(os.path.dirname(__file__), 'jsons')
+USER_TEMPLATE_PREFIX = 'potential_templates'
 
 
 def _create_hidden_dir(new_dir=None):
@@ -30,6 +31,13 @@ def _verify_potential_template_keys(_dict, name):
     assert 'independent_variables' in _dict, f"Key independent_variables not found in the potential template {name}.json"
     if str(name) != _dict['name']:
         raise GMSOError(f'Mismatch between Potential name {name} and {_dict["name"]}')
+
+
+def _load_template_json(item, json_dir=JSON_DIR):
+    with open(os.path.join(json_dir, f'{item}.json')) as json_file:
+        potential_dict = json.load(json_file)
+        _verify_potential_template_keys(potential_dict, item)
+        return potential_dict
 
 
 class PotentialTemplate(Potential):
@@ -57,33 +65,59 @@ class PotentialTemplates(Singleton):
             self.json_refs
         except AttributeError:
             self.json_refs = POTENTIAL_JSONS
+            self.user_jsons = []
             potential_names = [(os.path.split(filename)[-1]).replace('.json', '') for filename in POTENTIAL_JSONS]
             self._ref_dict = {potential.replace('.json', ''): None for potential in potential_names}
+            self._user_ref_dict = {}
 
     def get_available_template_names(self):
         return tuple(self._ref_dict.keys())
 
+    def load_user_templates(self):
+        gmso_dir = _create_hidden_dir(USER_TEMPLATE_PREFIX)
+        user_jsons = glob.glob(os.path.join(gmso_dir, '*.json'))
+        self.user_jsons = list(set(self.user_jsons.extend(user_jsons)))
+        user_potential_names = [(os.path.split(filename)[-1]).replace('.json', '') for filename in user_jsons]
+        self._user_ref_dict.update({potential.replace('.json', ''): self._user_ref_dict.get(potential, None)
+                                    for potential in user_potential_names})
+
     def __getitem__(self, item):
+        exists_user = True
+        exists_package = True
         if item not in self._ref_dict:
-            raise KeyError(f'No Potential named {item} found in the library')
-        if self._ref_dict[item] is None:
-            potential_dict = self._load_json(item)
-            self._ref_dict[item] = PotentialTemplate(**potential_dict)
+            exists_package = False
+        if item not in self._user_ref_dict:
+            exists_user = False
 
-        return self._ref_dict[item]
+        if exists_user:
+            return self._load_from_json(item, ref='user')
+        if exists_package:
+            return self._load_from_json(item, ref='package')
 
-    def _load_json(self, item):
-        with open(os.path.join(JSON_DIR, f'{item}.json')) as json_file:
-            potential_dict = json.load(json_file)
-            _verify_potential_template_keys(potential_dict, item)
-            return potential_dict
+        raise KeyError(f'Potential Template {item} not found in user as well as package templates'
+                       f'Please make sure the user templates are loaded by using load_user_templates')
+
+    def _load_from_json(self, item, ref='package'):
+        if ref == 'package':
+            ref_dict = self._ref_dict
+            _dir = JSON_DIR
+        elif ref == 'user':
+            ref_dict = self._user_ref_dict
+            _dir = _create_hidden_dir(USER_TEMPLATE_PREFIX)
+        else:
+            raise GMSOError(f'Cannot load template from {ref}. Please use either package or user.')
+
+        if ref_dict[item] is None:
+            potential_dict = _load_template_json(item, _dir)
+            ref_dict[item] = PotentialTemplate(**potential_dict)
+        return ref_dict[item]
 
     @staticmethod
     def save_potential_template(name, template_dict, update=True, user_template=True):
         """Add a new potential template to the PotentialTemplates Library"""
         parent_dir = JSON_DIR
         if user_template:
-            parent_dir = _create_hidden_dir('potential_templates')
+            parent_dir = _create_hidden_dir(USER_TEMPLATE_PREFIX)
 
         _verify_potential_template_keys(template_dict, name)
         with open(os.path.join(parent_dir, f'{name}.json'), 'w') as json_file:

--- a/gmso/lib/potential_templates.py
+++ b/gmso/lib/potential_templates.py
@@ -60,6 +60,9 @@ class PotentialTemplates(Singleton):
             potential_names = [(os.path.split(filename)[-1]).replace('.json', '') for filename in POTENTIAL_JSONS]
             self._ref_dict = {potential.replace('.json', ''): None for potential in potential_names}
 
+    def get_available_template_names(self):
+        return tuple(self._ref_dict.keys())
+
     def __getitem__(self, item):
         if item not in self._ref_dict:
             raise KeyError(f'No Potential named {item} found in the library')
@@ -83,7 +86,7 @@ class PotentialTemplates(Singleton):
             parent_dir = _create_hidden_dir('potential_templates')
 
         _verify_potential_template_keys(template_dict, name)
-        with open(os.path.join(parent_dir, f'{name}.json')) as json_file:
+        with open(os.path.join(parent_dir, f'{name}.json'), 'w') as json_file:
             json.dump(template_dict, json_file)
 
         if update:

--- a/gmso/lib/potential_templates.py
+++ b/gmso/lib/potential_templates.py
@@ -1,12 +1,45 @@
+import glob
+import os
+import json
+
 from gmso.core.potential import Potential
+from gmso.utils.singleton import Singleton
+from gmso.exceptions import GMSOError
+
+POTENTIAL_JSONS = glob.glob(os.path.join(os.path.dirname(__file__), 'jsons', '*.json'))
+JSON_DIR = os.path.join(os.path.dirname(__file__), 'jsons')
+
+
+def _create_hidden_dir(new_dir=None):
+    gmso_dir = os.path.join(os.path.expanduser('~'), '.gmso')
+    if os.path.exists(gmso_dir) and os.path.isdir(gmso_dir):
+        return
+    else:
+        os.makedirs(gmso_dir)
+    if new_dir is not None:
+        dir_loc = os.path.join(gmso_dir, new_dir)
+        if os.path.exists(dir_loc) and os.path.isdir(dir_loc):
+            os.makedirs(dir_loc)
+        return dir_loc
+    return gmso_dir
+
+
+def _verify_potential_template_keys(_dict, name):
+    assert 'name' in _dict, f"Key name not found in the potential template {name}.json"
+    assert 'expression' in _dict, f"Key expression not found in the potential template {name}.json"
+    assert 'independent_variables' in _dict, f"Key independent_variables not found in the potential template {name}.json"
+    if str(name) != _dict['name']:
+        raise GMSOError(f'Mismatch between Potential name {name} and {_dict["name"]}')
 
 
 class PotentialTemplate(Potential):
     def __init__(self,
                  name='PotentialTemplate',
                  expression='4*epsilon*((sigma/r)**12 - (sigma/r)**6)',
-                 independent_variables={'r'},
+                 independent_variables='r',
                  template=True):
+        if not isinstance(independent_variables, set):
+            independent_variables = set(independent_variables.split(','))
 
         super(PotentialTemplate, self).__init__(
             name=name,
@@ -15,144 +48,44 @@ class PotentialTemplate(Potential):
             template=template,
         )
 
-class LennardJonesPotential(PotentialTemplate):
-    def __init__(self,
-                 name='LennardJonesPotential',
-                 expression='4*epsilon*((sigma/r)**12 - (sigma/r)**6)',
-                 independent_variables=None):
-        if independent_variables is None:
-            independent_variables = {'r'}
-        super(PotentialTemplate, self).__init__(
-            name=name,
-            expression=expression,
-            independent_variables=independent_variables,
-            template=True,
-        )
 
-class MiePotential(PotentialTemplate):
-    def __init__(self,
-                 name='MiePotential',
-                 expression=('(n/(n-m)) * (n/m)**(m/(n-m)) * '
-                            'epsilon * ((sigma/r)**n - (sigma/r)**m)'),
-                 independent_variables=None):
-        if independent_variables is None:
-            independent_variables = {'r'}
-        super(PotentialTemplate, self).__init__(
-            name=name,
-            expression=expression,
-            independent_variables=independent_variables,
-            template=True,
-        )
+class PotentialTemplates(Singleton):
+    """A singleton collection of all the potential templates"""
 
-class BuckinghamPotential(PotentialTemplate):
-    def __init__(self,
-                 name='BuckinghamPotential',
-                 expression='a*exp(-b*r) - c*r**-6',
-                 independent_variables=None):
-        if independent_variables is None:
-            independent_variables = {'r'}
+    def __init__(self):
+        try:
+            self.json_refs
+        except AttributeError:
+            self.json_refs = POTENTIAL_JSONS
+            potential_names = [(os.path.split(filename)[-1]).replace('.json', '') for filename in POTENTIAL_JSONS]
+            self._ref_dict = {potential.replace('.json', ''): None for potential in potential_names}
 
-        super(PotentialTemplate, self).__init__(
-            name=name,
-            expression=expression,
-            independent_variables=independent_variables,
-            template=True,
-        )
+    def __getitem__(self, item):
+        if item not in self._ref_dict:
+            raise KeyError(f'No Potential named {item} found in the library')
+        if self._ref_dict[item] is None:
+            potential_dict = self._load_json(item)
+            self._ref_dict[item] = PotentialTemplate(**potential_dict)
 
-class HarmonicBondPotential(PotentialTemplate):
-    def __init__(self,
-                 name='HarmonicBondPotential',
-                 expression='0.5 * k * (r-r_eq)**2',
-                 independent_variables={'r'}):
+        return self._ref_dict[item]
 
-        super(PotentialTemplate, self).__init__(
-            name=name,
-            expression=expression,
-            independent_variables=independent_variables,
-            template=True,
-        )
+    def _load_json(self, item):
+        with open(os.path.join(JSON_DIR, f'{item}.json')) as json_file:
+            potential_dict = json.load(json_file)
+            _verify_potential_template_keys(potential_dict, item)
+            return potential_dict
 
-class HarmonicAnglePotential(PotentialTemplate):
-    def __init__(self,
-                 name='HarmonicAnglePotential',
-                 expression='0.5 * k * (theta-theta_eq)**2',
-                 independent_variables={'theta'}):
+    @staticmethod
+    def save_potential_template(name, template_dict, update=True, user_template=True):
+        """Add a new potential template to the PotentialTemplates Library"""
+        parent_dir = JSON_DIR
+        if user_template:
+            parent_dir = _create_hidden_dir('potential_templates')
 
-        super(PotentialTemplate, self).__init__(
-            name=name,
-            expression=expression,
-            independent_variables=independent_variables,
-            template=True,
-        )
+        _verify_potential_template_keys(template_dict, name)
+        with open(os.path.join(parent_dir, f'{name}.json')) as json_file:
+            json.dump(template_dict, json_file)
 
-class HarmonicTorsionPotential(PotentialTemplate):
-    def __init__(self,
-                 name='HarmonicTorsionPotential',
-                 expression='0.5 * k * (phi - phi_eq)**2',
-                 independent_variables={'phi'}):
-
-        super(PotentialTemplate, self).__init__(
-                name=name,
-                expression=expression,
-                independent_variables=independent_variables,
-                template=True
-        )
-
-class PeriodicTorsionPotential(PotentialTemplate):
-    def __init__(self,
-                 name='PeriodicTorsionPotential',
-                 expression='k * (1 + cos(n * phi - phi_eq))**2',
-                 independent_variables={'phi'}):
-
-        super(PotentialTemplate, self).__init__(
-                name=name,
-                expression=expression,
-                independent_variables=independent_variables,
-                template=True
-        )
-
-class OPLSTorsionPotential(PotentialTemplate):
-    def __init__(self,
-                 name='OPLSTorsionPotential',
-                 expression=('0.5 * k0 + '
-                             '0.5 * k1 * (1 + cos(phi)) + '
-                             '0.5 * k2 * (1 - cos(2*phi)) + '
-                             '0.5 * k3 * (1 + cos(3*phi)) + '
-                             '0.5 * k4 * (1 - cos(4*phi))'),
-                 independent_variables={'phi'}):
-
-        super(PotentialTemplate, self).__init__(
-                name=name,
-                expression=expression,
-                independent_variables=independent_variables,
-                template=True
-        )
-
-class RyckaertBellemansTorsionPotential(PotentialTemplate):
-    def __init__(self,
-                 name='RyckaertBellemansTorsionPotential',
-                 expression=('c0 * cos(phi)**0 + c1 * cos(phi)**1 + '
-                             'c2 * cos(phi)**2 + c3 * cos(phi)**3 + '
-                             'c4 * cos(phi)**4 + c5 * cos(phi)**5'),
-                 independent_variables={'phi'}):
-
-        super(PotentialTemplate, self).__init__(
-                name=name,
-                expression=expression,
-                independent_variables=independent_variables,
-                template=True
-        )
-
-class HarmonicImproperPotential(PotentialTemplate):
-    def __init__(self,
-                 name='HarmonicImproperPotetial',
-                 expression='0.5 * k * (phi - phi_eq)**2',
-                 independent_variables={'phi'}):
-
-        super(PotentialTemplate, self).__init__(
-                name=name,
-                expression=expression,
-                independent_variables=independent_variables,
-                template=True
-        )
-
+        if update:
+            delattr(PotentialTemplates(), 'json_refs')
+            PotentialTemplates()

--- a/gmso/lib/potential_templates.py
+++ b/gmso/lib/potential_templates.py
@@ -13,13 +13,14 @@ USER_TEMPLATE_PREFIX = 'potential_templates'
 
 def _create_hidden_dir(new_dir=None):
     gmso_dir = os.path.join(os.path.expanduser('~'), '.gmso')
-    if os.path.exists(gmso_dir) and os.path.isdir(gmso_dir):
-        return
+    if new_dir is None:
+        if os.path.exists(gmso_dir) and os.path.isdir(gmso_dir):
+            return gmso_dir
+        else:
+            os.makedirs(gmso_dir)
     else:
-        os.makedirs(gmso_dir)
-    if new_dir is not None:
         dir_loc = os.path.join(gmso_dir, new_dir)
-        if os.path.exists(dir_loc) and os.path.isdir(dir_loc):
+        if not os.path.exists(dir_loc) and not os.path.isdir(dir_loc):
             os.makedirs(dir_loc)
         return dir_loc
     return gmso_dir
@@ -76,7 +77,8 @@ class PotentialTemplates(Singleton):
     def load_user_templates(self):
         gmso_dir = _create_hidden_dir(USER_TEMPLATE_PREFIX)
         user_jsons = glob.glob(os.path.join(gmso_dir, '*.json'))
-        self.user_jsons = list(set(self.user_jsons.extend(user_jsons)))
+        self.user_jsons.extend(user_jsons)
+        self.user_jsons = list(set(self.user_jsons))
         user_potential_names = [(os.path.split(filename)[-1]).replace('.json', '') for filename in user_jsons]
         self._user_ref_dict.update({potential.replace('.json', ''): self._user_ref_dict.get(potential, None)
                                     for potential in user_potential_names})

--- a/gmso/tests/test_internal_conversions.py
+++ b/gmso/tests/test_internal_conversions.py
@@ -4,15 +4,18 @@ import numpy as np
 
 from gmso.tests.base_test import BaseTest
 from gmso.core.dihedral_type import DihedralType
-from gmso.lib.potential_templates import RyckaertBellemansTorsionPotential
-from gmso.lib.potential_templates import OPLSTorsionPotential
+from gmso.lib.potential_templates import PotentialTemplates
 from gmso.utils.conversions import convert_ryckaert_to_opls
 from gmso.utils.conversions import convert_opls_to_ryckaert
 from gmso.exceptions import GMSOError
 
 class TestInternalConversions(BaseTest):
 
-    def test_invalid_connection_type(self):
+    @pytest.fixture
+    def templates(self):
+        return PotentialTemplates()
+
+    def test_invalid_connection_type(self, templates):
         params = { 'c0' : 1.53  * u.Unit('kJ/mol'),
                    'c1' : 0.76  * u.Unit('kJ/mol'),
                    'c2' : -0.22 * u.Unit('kJ/mol'),
@@ -20,9 +23,10 @@ class TestInternalConversions(BaseTest):
                    'c4' : 0.94  * u.Unit('kJ/mol'),
                    'c5' : 0.0   * u.Unit('kJ/mol')
                  }
+        ryckaert_bellemans_torsion_potential = templates['RyckaertBellemansTorsionPotential']
 
-        name = RyckaertBellemansTorsionPotential().name
-        expression = RyckaertBellemansTorsionPotential().expression
+        name = ryckaert_bellemans_torsion_potential.name
+        expression = ryckaert_bellemans_torsion_potential.expression
         variables = ['phi','psi']
 
         ryckaert_connection_type = DihedralType(
@@ -36,7 +40,7 @@ class TestInternalConversions(BaseTest):
                     ryckaert_connection_type)
 
         expression = 'c0+c1+c2+c3+c4+c5+phi'
-        variables = RyckaertBellemansTorsionPotential().independent_variables
+        variables = ryckaert_bellemans_torsion_potential.independent_variables
         ryckaert_connection_type = DihedralType(
                 name=name,
                 expression=expression,
@@ -55,8 +59,9 @@ class TestInternalConversions(BaseTest):
                    'k4' : 1.44   * u.Unit('kJ/mol')
                  }
 
-        name = OPLSTorsionPotential().name
-        expression = OPLSTorsionPotential().expression
+        opls_torsion_potential = templates['OPLSTorsionPotential']
+        name = opls_torsion_potential.name
+        expression = opls_torsion_potential.expression
         variables = ['phi','psi']
 
         opls_connection_type = DihedralType(
@@ -69,7 +74,7 @@ class TestInternalConversions(BaseTest):
             ryckaert_connection_type = convert_opls_to_ryckaert(
                     opls_connection_type)
 
-        variables = OPLSTorsionPotential().independent_variables
+        variables = opls_torsion_potential.independent_variables
         expression = 'k0+k1+k2+k3+k4+phi'
         opls_connection_type = DihedralType(
                 name=name,
@@ -82,7 +87,7 @@ class TestInternalConversions(BaseTest):
                     opls_connection_type)
 
 
-    def test_ryckaert_to_opls(self):
+    def test_ryckaert_to_opls(self, templates):
 
         # Pick some RB parameters at random
         params = { 'c0' : 1.53  * u.Unit('kJ/mol'),
@@ -93,9 +98,11 @@ class TestInternalConversions(BaseTest):
                    'c5' : 0.0   * u.Unit('kJ/mol')
                  }
 
-        name = RyckaertBellemansTorsionPotential().name
-        expression = RyckaertBellemansTorsionPotential().expression
-        variables = RyckaertBellemansTorsionPotential().independent_variables
+        ryckaert_bellemans_torsion_potential = templates['RyckaertBellemansTorsionPotential']
+
+        name = ryckaert_bellemans_torsion_potential.name
+        expression = ryckaert_bellemans_torsion_potential.expression
+        variables = ryckaert_bellemans_torsion_potential.independent_variables
 
         ryckaert_connection_type = DihedralType(
                 name=name,
@@ -122,7 +129,7 @@ class TestInternalConversions(BaseTest):
                                 'phi':angle}.items()])),
             )
 
-    def test_opls_to_ryckaert(self):
+    def test_opls_to_ryckaert(self, templates):
 
         # Pick some OPLS parameters at random
         params = { 'k0' : 1.38   * u.Unit('kJ/mol'),
@@ -132,9 +139,10 @@ class TestInternalConversions(BaseTest):
                    'k4' : 1.44   * u.Unit('kJ/mol')
                  }
 
-        name = OPLSTorsionPotential().name
-        expression = OPLSTorsionPotential().expression
-        variables = OPLSTorsionPotential().independent_variables
+        opls_torsion_potential = templates['OPLSTorsionPotential']
+        name = opls_torsion_potential.name
+        expression = opls_torsion_potential.expression
+        variables = opls_torsion_potential.independent_variables
 
         opls_connection_type = DihedralType(
                 name=name,
@@ -161,7 +169,7 @@ class TestInternalConversions(BaseTest):
                                 'phi':angle}.items()])),
             )
 
-    def test_double_conversion(self):
+    def test_double_conversion(self, templates):
 
         # Pick some OPLS parameters at random
         params = { 'k0' : 1.38   * u.Unit('kJ/mol'),
@@ -171,9 +179,11 @@ class TestInternalConversions(BaseTest):
                    'k4' : 1.44   * u.Unit('kJ/mol')
                  }
 
-        name = OPLSTorsionPotential().name
-        expression = OPLSTorsionPotential().expression
-        variables = OPLSTorsionPotential().independent_variables
+        opls_torsion_potential = templates['OPLSTorsionPotential']
+
+        name = opls_torsion_potential.name
+        expression = opls_torsion_potential.expression
+        variables = opls_torsion_potential.independent_variables
 
         opls_connection_type = DihedralType(
                 name=name,

--- a/gmso/tests/test_internal_conversions.py
+++ b/gmso/tests/test_internal_conversions.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from gmso.tests.base_test import BaseTest
 from gmso.core.dihedral_type import DihedralType
-from gmso.lib.potential_templates import PotentialTemplates
+from gmso.lib.potential_templates import PotentialTemplateLibrary
 from gmso.utils.conversions import convert_ryckaert_to_opls
 from gmso.utils.conversions import convert_opls_to_ryckaert
 from gmso.exceptions import GMSOError
@@ -13,7 +13,7 @@ class TestInternalConversions(BaseTest):
 
     @pytest.fixture
     def templates(self):
-        return PotentialTemplates()
+        return PotentialTemplateLibrary()
 
     def test_invalid_connection_type(self, templates):
         params = { 'c0' : 1.53  * u.Unit('kJ/mol'),

--- a/gmso/tests/test_potential.py
+++ b/gmso/tests/test_potential.py
@@ -5,7 +5,7 @@ import pytest
 from gmso.core.potential import Potential
 from gmso.tests.base_test import BaseTest
 from gmso.utils.testing import allclose
-from gmso.lib.potential_templates import HarmonicBondPotential
+from gmso.lib.potential_templates import PotentialTemplateLibrary
 from gmso.exceptions import GMSOError
 
 
@@ -226,7 +226,7 @@ class TestPotential(BaseTest):
             )
 
     def test_class_method(self):
-        template = HarmonicBondPotential()
+        template = PotentialTemplateLibrary()['HarmonicBondPotential']
         params = {'k': 1.0 * u.dimensionless,
                   'r_eq': 1.0 * u.dimensionless}
         harmonic_potential_from_template = Potential.from_template(template, params)

--- a/gmso/tests/test_potential_templates.py
+++ b/gmso/tests/test_potential_templates.py
@@ -5,6 +5,7 @@ import pytest
 import sympy
 
 from gmso.lib.potential_templates import PotentialTemplates, JSON_DIR
+from gmso.exceptions import GMSOError
 from gmso.tests.base_test import BaseTest
 
 
@@ -101,3 +102,13 @@ class TestPotentialTemplates(BaseTest):
         names = templates.get_available_template_names()
         assert isinstance(names, tuple)
         assert len(names) == len(glob.glob(os.path.join(JSON_DIR, '*.json')))
+
+    def test_name_mismatch_in_templates(self):
+        wrong_ref_dict = {
+                'name': 'NameMismatchTemplate',
+                'expression': 'a+b+c',
+                'independent_variables': 'c, a'
+            }
+        with pytest.raises(GMSOError):
+            PotentialTemplates.save_potential_template('NameMismatch_Template', wrong_ref_dict, update=False)
+

--- a/gmso/tests/test_potential_templates.py
+++ b/gmso/tests/test_potential_templates.py
@@ -4,18 +4,18 @@ import pytest
 
 import sympy
 
-from gmso.lib.potential_templates import PotentialTemplates, JSON_DIR
+from gmso.lib.potential_templates import PotentialTemplateLibrary, JSON_DIR
 from gmso.tests.base_test import BaseTest
 
 
 class TestPotentialTemplates(BaseTest):
     @pytest.fixture
     def templates(self):
-        return PotentialTemplates()
+        return PotentialTemplateLibrary()
 
     def test_singleton_behavior(self, templates):
-        assert id(templates) == id(PotentialTemplates())
-        assert id(PotentialTemplates()) == id(PotentialTemplates())
+        assert id(templates) == id(PotentialTemplateLibrary())
+        assert id(PotentialTemplateLibrary()) == id(PotentialTemplateLibrary())
 
     def test_lennard_jones_potential(self, templates):
         lennard_jones_potential = templates['LennardJonesPotential']

--- a/gmso/tests/test_potential_templates.py
+++ b/gmso/tests/test_potential_templates.py
@@ -5,7 +5,6 @@ import pytest
 import sympy
 
 from gmso.lib.potential_templates import PotentialTemplates, JSON_DIR
-from gmso.exceptions import GMSOError
 from gmso.tests.base_test import BaseTest
 
 
@@ -34,10 +33,10 @@ class TestPotentialTemplates(BaseTest):
     def test_opls_torsion_potential(self, templates):
         opls_torsion_potential = templates['OPLSTorsionPotential']
         assert opls_torsion_potential.name == 'OPLSTorsionPotential'
-        assert opls_torsion_potential.expression == sympy.sympify('0.5 * k0 + 0.5 * k1 * (1 + cos(phi)) + '
+        assert opls_torsion_potential.expression == sympy.sympify('0.5 * k0 + 0.5 * k1 * (1 + cos(phi)) +'
                                                                   '0.5 * k2 * (1 - cos(2*phi)) +'
-                                                                  ' 0.5 * k3 * (1 + cos(3*phi))'
-                                                                  ' + 0.5 * k4 * (1 - cos(4*phi))')
+                                                                  '0.5 * k3 * (1 + cos(3*phi)) +'
+                                                                  '0.5 * k4 * (1 - cos(4*phi))')
         assert opls_torsion_potential.independent_variables == {sympy.sympify('phi')}
 
     def test_periodic_torsion_potential(self, templates):
@@ -84,46 +83,7 @@ class TestPotentialTemplates(BaseTest):
         assert buckingham_potential.expression == sympy.sympify('a*exp(-b*r) - c*r**-6')
         assert buckingham_potential.independent_variables == sympy.sympify({'r'})
 
-    def test_save_templates(self, templates):
-        PotentialTemplates.save_potential_template('TestTemplate',
-                                                   {
-                                                       'name': 'TestTemplate',
-                                                       'expression': 'a+b+c',
-                                                       'independent_variables': 'c,a'
-                                                   },
-                                                   update=True,
-                                                   user_template=False
-                                                   )
-
-        assert os.path.exists(os.path.join(JSON_DIR, 'TestTemplate.json'))
-        assert templates['TestTemplate']
-
     def test_available_template(self, templates):
         names = templates.get_available_template_names()
         assert isinstance(names, tuple)
         assert len(names) == len(glob.glob(os.path.join(JSON_DIR, '*.json')))
-
-    def test_name_mismatch_in_templates(self):
-        wrong_ref_dict = {
-                'name': 'NameMismatchTemplate',
-                'expression': 'a+b+c',
-                'independent_variables': 'c,a'
-            }
-        with pytest.raises(GMSOError):
-            PotentialTemplates.save_potential_template('NameMismatch_Template', wrong_ref_dict, update=False)
-
-    def test_user_defined_potential(self, templates):
-        user_potential_dict = {
-            'name': 'UserTemplate',
-            'expression': 'a*b*c',
-            'independent_variables': 'b'
-        }
-        PotentialTemplates.save_potential_template('UserTemplate', user_potential_dict, update=True, user_template=True)
-        assert os.path.exists(os.path.join(os.path.expanduser('~'),
-                                           '.gmso',
-                                           'potential_templates',
-                                           'UserTemplate.json'))
-        templates.load_user_templates()
-        assert templates['UserTemplate'].name == 'UserTemplate'
-        assert templates['UserTemplate'].expression == sympy.sympify('a*b*c')
-        assert templates['UserTemplate'].independent_variables == {sympy.sympify('b')}

--- a/gmso/tests/test_potential_templates.py
+++ b/gmso/tests/test_potential_templates.py
@@ -1,0 +1,103 @@
+import os
+import glob
+import pytest
+
+import sympy
+
+from gmso.lib.potential_templates import PotentialTemplates, JSON_DIR
+from gmso.tests.base_test import BaseTest
+
+
+class TestPotentialTemplates(BaseTest):
+    @pytest.fixture
+    def templates(self):
+        return PotentialTemplates()
+
+    def test_singleton_behavior(self, templates):
+        assert id(templates) == id(PotentialTemplates())
+        assert id(PotentialTemplates()) == id(PotentialTemplates())
+
+    def test_lennard_jones_potential(self, templates):
+        lennard_jones_potential = templates['LennardJonesPotential']
+        assert lennard_jones_potential.name == 'LennardJonesPotential'
+        assert lennard_jones_potential.expression == sympy.sympify('4*epsilon*((sigma/r)**12 - (sigma/r)**6)')
+        assert lennard_jones_potential.independent_variables == {sympy.sympify('r')}
+
+    def test_mie_potential(self, templates):
+        mie_potential = templates['MiePotential']
+        assert mie_potential.name == 'MiePotential'
+        assert mie_potential.expression == sympy.sympify(
+            '(n/(n-m)) * (n/m)**(m/(n-m)) * epsilon * ((sigma/r)**n - (sigma/r)**m)')
+        assert mie_potential.independent_variables == {sympy.sympify('r')}
+
+    def test_opls_torsion_potential(self, templates):
+        opls_torsion_potential = templates['OPLSTorsionPotential']
+        assert opls_torsion_potential.name == 'OPLSTorsionPotential'
+        assert opls_torsion_potential.expression == sympy.sympify('0.5 * k0 + 0.5 * k1 * (1 + cos(phi)) + '
+                                                                  '0.5 * k2 * (1 - cos(2*phi)) +'
+                                                                  ' 0.5 * k3 * (1 + cos(3*phi))'
+                                                                  ' + 0.5 * k4 * (1 - cos(4*phi))')
+        assert opls_torsion_potential.independent_variables == {sympy.sympify('phi')}
+
+    def test_periodic_torsion_potential(self, templates):
+        periodic_torsion_potential = templates['PeriodicTorsionPotential']
+        assert periodic_torsion_potential.name == 'PeriodicTorsionPotential'
+        assert periodic_torsion_potential.expression == sympy.sympify('k * (1 + cos(n * phi - phi_eq))**2')
+        assert periodic_torsion_potential.independent_variables == {sympy.sympify('phi')}
+
+    def test_ryckaert_bellemans_torsion_potential(self, templates):
+        ryckaert_bellemans_torsion_potential = templates['RyckaertBellemansTorsionPotential']
+        assert ryckaert_bellemans_torsion_potential.name == 'RyckaertBellemansTorsionPotential'
+        assert ryckaert_bellemans_torsion_potential.expression == sympy.sympify('c0 * cos(phi)**0 + c1 * cos(phi)**1 +'
+                                                                                ' c2 * cos(phi)**2 + c3 * cos(phi)**3 +'
+                                                                                ' c4 * cos(phi)**4 + c5 * cos(phi)**5')
+        assert ryckaert_bellemans_torsion_potential.independent_variables == {sympy.sympify('phi')}
+
+    def test_harmonic_torsion_potential(self, templates):
+        harmonic_torsion_potential = templates['HarmonicTorsionPotential']
+        assert harmonic_torsion_potential.name == 'HarmonicTorsionPotential'
+        assert harmonic_torsion_potential.expression == sympy.sympify('0.5 * k * (phi - phi_eq)**2')
+        assert harmonic_torsion_potential.independent_variables == {sympy.sympify('phi')}
+
+    def test_harmonic_improper_potential(self, templates):
+        harmonic_improper_potential = templates['HarmonicImproperPotential']
+        assert harmonic_improper_potential.name == 'HarmonicImproperPotential'
+        assert harmonic_improper_potential.expression == sympy.sympify('0.5 * k * (phi - phi_eq)**2')
+        assert harmonic_improper_potential.independent_variables == {sympy.sympify('phi')}
+
+    def test_harmonic_bond_potential(self, templates):
+        harmonic_bond_potential = templates['HarmonicBondPotential']
+        assert harmonic_bond_potential.name == 'HarmonicBondPotential'
+        assert harmonic_bond_potential.expression == sympy.sympify('0.5 * k * (r-r_eq)**2')
+        assert harmonic_bond_potential.independent_variables == {sympy.sympify('r')}
+
+    def test_harmonic_angle_potential(self, templates):
+        harmonic_bond_potential = templates['HarmonicAnglePotential']
+        assert harmonic_bond_potential.name == 'HarmonicAnglePotential'
+        assert harmonic_bond_potential.expression == sympy.sympify('0.5 * k * (theta-theta_eq)**2')
+        assert harmonic_bond_potential.independent_variables == {sympy.sympify('theta')}
+
+    def test_buckingham_potential(self, templates):
+        buckingham_potential = templates['BuckinghamPotential']
+        assert buckingham_potential.name == 'BuckinghamPotential'
+        assert buckingham_potential.expression == sympy.sympify('a*exp(-b*r) - c*r**-6')
+        assert buckingham_potential.independent_variables == sympy.sympify({'r'})
+
+    def test_save_templates(self, templates):
+        PotentialTemplates.save_potential_template('TestTemplate',
+                                                   {
+                                                       'name': 'TestTemplate',
+                                                       'expression': 'a+b+c',
+                                                       'independent_variables': 'c,a'
+                                                   },
+                                                   update=True,
+                                                   user_template=False
+                                                   )
+
+        assert os.path.exists(os.path.join(JSON_DIR, 'TestTemplate.json'))
+        assert templates['TestTemplate']
+
+    def test_available_template(self, templates):
+        names = templates.get_available_template_names()
+        assert isinstance(names, tuple)
+        assert len(names) == len(glob.glob(os.path.join(JSON_DIR, '*.json')))

--- a/gmso/tests/test_potential_templates.py
+++ b/gmso/tests/test_potential_templates.py
@@ -107,8 +107,23 @@ class TestPotentialTemplates(BaseTest):
         wrong_ref_dict = {
                 'name': 'NameMismatchTemplate',
                 'expression': 'a+b+c',
-                'independent_variables': 'c, a'
+                'independent_variables': 'c,a'
             }
         with pytest.raises(GMSOError):
             PotentialTemplates.save_potential_template('NameMismatch_Template', wrong_ref_dict, update=False)
 
+    def test_user_defined_potential(self, templates):
+        user_potential_dict = {
+            'name': 'UserTemplate',
+            'expression': 'a*b*c',
+            'independent_variables': 'b'
+        }
+        PotentialTemplates.save_potential_template('UserTemplate', user_potential_dict, update=True, user_template=True)
+        assert os.path.exists(os.path.join(os.path.expanduser('~'),
+                                           '.gmso',
+                                           'potential_templates',
+                                           'UserTemplate.json'))
+        templates.load_user_templates()
+        assert templates['UserTemplate'].name == 'UserTemplate'
+        assert templates['UserTemplate'].expression == sympy.sympify('a*b*c')
+        assert templates['UserTemplate'].independent_variables == {sympy.sympify('b')}

--- a/gmso/tests/test_reference_xmls.py
+++ b/gmso/tests/test_reference_xmls.py
@@ -6,7 +6,7 @@ from gmso.core.forcefield import ForceField
 from gmso.utils.testing import allclose
 from gmso.tests.utils import get_path
 from gmso.tests.base_test import BaseTest
-from gmso.lib.potential_templates import PotentialTemplates
+from gmso.lib.potential_templates import PotentialTemplateLibrary
 
 
 class TestForceFieldFromXML(BaseTest):
@@ -118,7 +118,7 @@ class TestForceFieldFromXML(BaseTest):
 
     def test_noble_mie_xml(self):
         ff = ForceField(get_path('noble_mie.xml'))
-        templates = PotentialTemplates()
+        templates = PotentialTemplateLibrary()
         ref_expr = templates['MiePotential'].expression
 
         assert len(ff.atom_types) == 4

--- a/gmso/tests/test_reference_xmls.py
+++ b/gmso/tests/test_reference_xmls.py
@@ -6,7 +6,7 @@ from gmso.core.forcefield import ForceField
 from gmso.utils.testing import allclose
 from gmso.tests.utils import get_path
 from gmso.tests.base_test import BaseTest
-from gmso.lib.potential_templates import MiePotential
+from gmso.lib.potential_templates import PotentialTemplates
 
 
 class TestForceFieldFromXML(BaseTest):
@@ -118,8 +118,8 @@ class TestForceFieldFromXML(BaseTest):
 
     def test_noble_mie_xml(self):
         ff = ForceField(get_path('noble_mie.xml'))
-
-        ref_expr = MiePotential().expression
+        templates = PotentialTemplates()
+        ref_expr = templates['MiePotential'].expression
 
         assert len(ff.atom_types) == 4
         assert len(ff.bond_types) == 0

--- a/gmso/tests/test_singleton.py
+++ b/gmso/tests/test_singleton.py
@@ -1,0 +1,8 @@
+from gmso.utils.singleton import Singleton
+from gmso.tests.base_test import BaseTest
+
+
+class TestSingleton(BaseTest):
+    def test_unique_id(self):
+        singletons = [id(Singleton()) for i in range(10)]
+        assert len(set(singletons)) == 1

--- a/gmso/utils/conversions.py
+++ b/gmso/utils/conversions.py
@@ -3,7 +3,7 @@ import sympy
 import unyt as u
 
 import gmso
-from gmso.lib.potential_templates import PotentialTemplates
+from gmso.lib.potential_templates import PotentialTemplateLibrary
 from gmso.exceptions import GMSOError 
 
 def convert_opls_to_ryckaert(opls_connection_type):
@@ -17,7 +17,7 @@ def convert_opls_to_ryckaert(opls_connection_type):
     for OPLS and RB torsions. OPLS torsions are defined with
     phi_cis = 0 while RB torsions are defined as phi_trans = 0.
     """
-    templates = PotentialTemplates()
+    templates = PotentialTemplateLibrary()
     opls_torsion_potential = templates['OPLSTorsionPotential']
     valid_connection_type = False
     if ( opls_connection_type.independent_variables ==
@@ -64,7 +64,7 @@ def convert_ryckaert_to_opls(ryckaert_connection_type):
     for OPLS and RB torsions. OPLS torsions are defined with
     phi_cis = 0 while RB torsions are defined as phi_trans = 0.
     """
-    templates = PotentialTemplates()
+    templates = PotentialTemplateLibrary()
     ryckaert_bellemans_torsion_potential = templates['RyckaertBellemansTorsionPotential']
     opls_torsion_potential = templates['OPLSTorsionPotential']
 

--- a/gmso/utils/conversions.py
+++ b/gmso/utils/conversions.py
@@ -3,8 +3,7 @@ import sympy
 import unyt as u
 
 import gmso
-from gmso.lib.potential_templates import RyckaertBellemansTorsionPotential
-from gmso.lib.potential_templates import OPLSTorsionPotential
+from gmso.lib.potential_templates import PotentialTemplates
 from gmso.exceptions import GMSOError 
 
 def convert_opls_to_ryckaert(opls_connection_type):
@@ -18,12 +17,13 @@ def convert_opls_to_ryckaert(opls_connection_type):
     for OPLS and RB torsions. OPLS torsions are defined with
     phi_cis = 0 while RB torsions are defined as phi_trans = 0.
     """
-
+    templates = PotentialTemplates()
+    opls_torsion_potential = templates['OPLSTorsionPotential']
     valid_connection_type = False
     if ( opls_connection_type.independent_variables ==
-         OPLSTorsionPotential().independent_variables ):
+         opls_torsion_potential.independent_variables ):
         if sympy.simplify(opls_connection_type.expression -
-                          OPLSTorsionPotential().expression) == 0:
+                          opls_torsion_potential.expression) == 0:
             valid_connection_type = True
     if not valid_connection_type:
         raise GMSOError('Cannot use convert_opls_to_ryckaert '
@@ -44,10 +44,10 @@ def convert_opls_to_ryckaert(opls_connection_type):
             'c4' : (-4. * f4),
             'c5' : 0. * u.Unit('kJ/mol')
     }
-
-    name = RyckaertBellemansTorsionPotential().name
-    expression = RyckaertBellemansTorsionPotential().expression
-    variables = RyckaertBellemansTorsionPotential().independent_variables
+    ryckaert_bellemans_torsion_potential = templates['RyckaertBellemansTorsionPotential']
+    name = ryckaert_bellemans_torsion_potential.name
+    expression = ryckaert_bellemans_torsion_potential.expression
+    variables = ryckaert_bellemans_torsion_potential.independent_variables
 
     ryckaert_connection_type = gmso.DihedralType(
             name=name,
@@ -64,12 +64,15 @@ def convert_ryckaert_to_opls(ryckaert_connection_type):
     for OPLS and RB torsions. OPLS torsions are defined with
     phi_cis = 0 while RB torsions are defined as phi_trans = 0.
     """
+    templates = PotentialTemplates()
+    ryckaert_bellemans_torsion_potential = templates['RyckaertBellemansTorsionPotential']
+    opls_torsion_potential = templates['OPLSTorsionPotential']
 
     valid_connection_type = False
     if ( ryckaert_connection_type.independent_variables ==
-         RyckaertBellemansTorsionPotential().independent_variables ):
+         ryckaert_bellemans_torsion_potential.independent_variables ):
         if sympy.simplify(ryckaert_connection_type.expression -
-                RyckaertBellemansTorsionPotential().expression) == 0:
+                ryckaert_bellemans_torsion_potential.expression) == 0:
             valid_connection_type = True
     if not valid_connection_type:
         raise GMSOError('Cannot use convert_ryckaert_to_opls '
@@ -96,9 +99,9 @@ def convert_ryckaert_to_opls(ryckaert_connection_type):
             'k4' : ((-1./4.) * c4)
     }
 
-    name = OPLSTorsionPotential().name
-    expression = OPLSTorsionPotential().expression
-    variables = OPLSTorsionPotential().independent_variables
+    name = opls_torsion_potential.name
+    expression = opls_torsion_potential.expression
+    variables = opls_torsion_potential.independent_variables
 
     opls_connection_type = gmso.DihedralType(
             name=name,

--- a/gmso/utils/singleton.py
+++ b/gmso/utils/singleton.py
@@ -1,4 +1,10 @@
 class Singleton(object):
+    """A helper super class to create singletons.
+
+    A singleton class is a class for which no more than one
+    instance can exist. Any class subclassing from Singleton
+    will have only one instance.
+    """
     _inst = None
 
     def __new__(cls):

--- a/gmso/utils/singleton.py
+++ b/gmso/utils/singleton.py
@@ -1,0 +1,7 @@
+class Singleton(object):
+    _inst = None
+
+    def __new__(cls):
+        if cls._inst is None:
+            cls._inst = super(Singleton, cls).__new__(cls)
+        return cls._inst

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ requirements = [
 setup(
     name='gmso',
     version=__version__,
-    include_package_data=True,
     packages=find_packages(),
     include_package_data=True,
     zip_safe=True,

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ requirements = [
 setup(
     name='gmso',
     version=__version__,
+    include_package_data=True,
     packages=find_packages(),
     zip_safe=True,
     author='Matthew W Thompson, Justin Gilmer',


### PR DESCRIPTION
This PR addresses #333, Refactors PotentialTemplate classes by consolidating them into a singleton instance that has a modified `__getitem__`. The information about `PotentialTemplates` is now saved as importable JSON files, which is loaded lazily on demand from the code base. This also adds documentation on how to contribute a `PotentialTemplate` as well as refactors few other files to incorporate the changed PotentialTemplates API. 