### PR TITLE
Remove topology_site fixture from base_test

### DIFF
--- a/gmso/tests/base_test.py
+++ b/gmso/tests/base_test.py
@@ -49,15 +49,7 @@ class BaseTest:
 
     @pytest.fixture
     def ar_system(self, n_ar_system):
-        #ar = mb.Compound(name='Ar')
-
-        #packed_system = mb.fill_box(
-        #    compound=ar,
-        #    n_compounds=10,
-        #    box=mb.Box([3, 3, 3]),
-        #)
-
-        return from_mbuild(n_ar_system(n_sites=100))
+        return from_mbuild(n_ar_system())
 
     @pytest.fixture
     def n_ar_system(self):

--- a/gmso/tests/base_test.py
+++ b/gmso/tests/base_test.py
@@ -48,7 +48,19 @@ class BaseTest:
 
 
     @pytest.fixture
-    def ar_system(self):
+    def ar_system(self, n_ar_system):
+        #ar = mb.Compound(name='Ar')
+
+        #packed_system = mb.fill_box(
+        #    compound=ar,
+        #    n_compounds=10,
+        #    box=mb.Box([3, 3, 3]),
+        #)
+
+        return from_mbuild(n_ar_system(n_sites=100))
+
+    @pytest.fixture
+    def n_ar_system(self):
         def _topology(n_sites=100):
             ar = mb.Compound(name='Ar')
 
@@ -63,41 +75,57 @@ class BaseTest:
         return _topology
 
     @pytest.fixture
-    def typed_single_ar(self):
-        top = from_mbuild(mb.Compound(name="Ar"))
+    def n_typed_xe_mie(self):
+        def _typed_topology(n_sites=1):
+            xe = mb.Compound(name="Xe")
 
-        ff = ForceField(get_fn("ar.xml"))
+            packed_system = mb.fill_box(
+                compound=xe,
+                n_compounds=n_sites,
+                box=mb.Box([3, 3, 3]),
+            )
 
-        for site in top.sites:
-            site.atom_type = ff.atom_types["Ar"]
+            top = from_mbuild(packed_system)
 
-        top.update_topology()
-        return top
+            ff = ForceField(get_path("noble_mie.xml"))
+
+            for site in top.sites:
+                site.atom_type = ff.atom_types["Xe"]
+
+            top.update_topology()
+
+            return top
+
+        return _typed_topology
 
     @pytest.fixture
-    def typed_single_xe_mie(self):
-        top = from_mbuild(mb.Compound(name="Xe"))
+    def typed_ar_system(self, n_typed_ar_system):
+        #@top = ar_system
 
-        ff = ForceField(get_path("noble_mie.xml"))
+        #@ff = ForceField(get_fn('ar.xml'))
 
-        for site in top.sites:
-            site.atom_type = ff.atom_types["Xe"]
+        #@for site in top.sites:
+        #@    site.atom_type = ff.atom_types['Ar']
 
-        top.update_topology()
-        return top
+        #@top.update_topology()
+
+        return n_typed_ar_system(n_sites=100)
 
     @pytest.fixture
-    def typed_ar_system(self, ar_system):
-        top = from_mbuild(ar_system())
+    def n_typed_ar_system(self, n_ar_system):
+        def _typed_topology(n_sites=100):
+            top = from_mbuild(n_ar_system(n_sites=n_sites))
 
-        ff = ForceField(get_fn('ar.xml'))
+            ff = ForceField(get_fn('ar.xml'))
 
-        for site in top.sites:
-            site.atom_type = ff.atom_types['Ar']
+            for site in top.sites:
+                site.atom_type = ff.atom_types['Ar']
 
-        top.update_topology()
+            top.update_topology()
 
-        return top
+            return top
+
+        return _typed_topology
 
     @pytest.fixture
     def water_system(self):

--- a/gmso/tests/base_test.py
+++ b/gmso/tests/base_test.py
@@ -46,24 +46,6 @@ class BaseTest:
     def top(self):
         return Topology(name='mytop')
 
-    @pytest.fixture
-    def topology_site(self):
-        def _topology(sites=1):
-            top = Topology()
-            top.box = Box(lengths=[1, 1, 1])
-            H = Hydrogen
-            site1 = Site(name='site1',
-                         element=H,
-                         atom_type=AtomType(name="at1",
-                                            mass=H.mass),
-                         )
-            for i in range(sites):
-                top.add_site(site1)
-
-            return top
-
-        return _topology
-
 
     @pytest.fixture
     def ar_system(self):

--- a/gmso/tests/base_test.py
+++ b/gmso/tests/base_test.py
@@ -100,16 +100,7 @@ class BaseTest:
 
     @pytest.fixture
     def typed_ar_system(self, n_typed_ar_system):
-        #@top = ar_system
-
-        #@ff = ForceField(get_fn('ar.xml'))
-
-        #@for site in top.sites:
-        #@    site.atom_type = ff.atom_types['Ar']
-
-        #@top.update_topology()
-
-        return n_typed_ar_system(n_sites=100)
+        return n_typed_ar_system()
 
     @pytest.fixture
     def n_typed_ar_system(self, n_ar_system):

--- a/gmso/tests/base_test.py
+++ b/gmso/tests/base_test.py
@@ -49,15 +49,18 @@ class BaseTest:
 
     @pytest.fixture
     def ar_system(self):
-        ar = mb.Compound(name='Ar')
+        def _topology(n_sites=100):
+            ar = mb.Compound(name='Ar')
 
-        packed_system = mb.fill_box(
-            compound=ar,
-            n_compounds=100,
-            box=mb.Box([3, 3, 3]),
-        )
+            packed_system = mb.fill_box(
+                compound=ar,
+                n_compounds=n_sites,
+                box=mb.Box([3, 3, 3]),
+            )
 
-        return from_mbuild(packed_system)
+            return packed_system
+
+        return _topology
 
     @pytest.fixture
     def typed_single_ar(self):
@@ -85,7 +88,7 @@ class BaseTest:
 
     @pytest.fixture
     def typed_ar_system(self, ar_system):
-        top = ar_system
+        top = from_mbuild(ar_system())
 
         ff = ForceField(get_fn('ar.xml'))
 

--- a/gmso/tests/test_convert_openmm.py
+++ b/gmso/tests/test_convert_openmm.py
@@ -14,41 +14,38 @@ if has_openmm and has_simtk_unit:
 @pytest.mark.skipif(not has_openmm, reason="OpenMM is not installed")
 @pytest.mark.skipif(not has_simtk_unit, reason="SimTK is not installed")
 class TestOpenMM(BaseTest):
-    def test_openmm_modeller(self, topology_site):
-        to_openmm(topology_site(), openmm_object='modeller')
+    def test_openmm_modeller(self, typed_ar_system):
+        to_openmm(typed_ar_system, openmm_object='modeller')
 
-    def test_openmm_topology(self, topology_site):
-        to_openmm(topology_site(), openmm_object='topology')
+    def test_openmm_topology(self, typed_ar_system):
+        to_openmm(typed_ar_system, openmm_object='topology')
 
-    def test_n_atoms(self, topology_site):
-        top = topology_site(sites=10)
-        n_topology_sites = len(top.sites)
-        modeller = to_openmm(top, openmm_object='modeller')
+    def test_n_atoms(self, typed_ar_system):
+        n_topology_sites = len(typed_ar_system.sites)
+        modeller = to_openmm(typed_ar_system, openmm_object='modeller')
         n_modeller_atoms = len([i for i in modeller.topology.atoms()])
 
         assert n_topology_sites == n_modeller_atoms
 
-    def test_box_dims(self, topology_site):
-        top = topology_site(sites=10)
-        n_topology_sites = len(top.sites)
-        omm_top = to_openmm(top)
-        topology_lengths = top.box.lengths
+    def test_box_dims(self, typed_ar_system):
+        n_topology_sites = len(typed_ar_system.sites)
+        omm_top = to_openmm(typed_ar_system)
+        topology_lengths = typed_ar_system.box.lengths
         omm_lengths = omm_top.getUnitCellDimensions()
 
         assert np.allclose(topology_lengths.value, omm_lengths._value)
 
-    def test_particle_positions(self, topology_site):
-        top = topology_site()
-        top.sites[0].position = (1,1,1) * u.nanometer
-        omm_top = to_openmm(top, openmm_object='modeller')
+    def test_particle_positions(self, typed_ar_system):
+        typed_ar_system.sites[0].position = (1,1,1) * u.nanometer
+        omm_top = to_openmm(typed_ar_system, openmm_object='modeller')
 
-        assert np.allclose(omm_top.positions._value, top.positions.value)
+        assert np.allclose(omm_top.positions._value,
+                typed_ar_system.positions.value)
 
-    def test_position_units(self, topology_site):
-        top = topology_site(sites=10)
-        top.box = Box(lengths=[1,1,1])
+    def test_position_units(self, typed_ar_system):
+        typed_ar_system.box = Box(lengths=[1,1,1])
 
-        n_topology_sites = len(top.sites)
-        omm_top = to_openmm(top, openmm_object='modeller')
+        n_topology_sites = len(typed_ar_system.sites)
+        omm_top = to_openmm(typed_ar_system, openmm_object='modeller')
 
         assert isinstance(omm_top.positions.unit, type(simtk_unit.nanometer))

--- a/gmso/tests/test_lammps.py
+++ b/gmso/tests/test_lammps.py
@@ -6,13 +6,12 @@ from gmso.tests.utils import get_path
 import unyt as u
 
 class TestLammpsWriter(BaseTest):
-    def test_write_lammps(self, topology_site):
-        write_lammpsdata(topology_site(), filename='data.lammps')
+    def test_write_lammps(self, typed_ar_system):
+        write_lammpsdata(typed_ar_system, filename='data.lammps')
 
-    def test_write_lammps_triclinic(self, topology_site):
-        top = topology_site()
-        top.box = Box(lengths=[1,1,1], angles=[60,90,120])
-        write_lammpsdata(top, filename='data.triclinic')
+    def test_write_lammps_triclinic(self, typed_ar_system):
+        typed_ar_system.box = Box(lengths=[1,1,1], angles=[60,90,120])
+        write_lammpsdata(typed_ar_system, filename='data.triclinic')
 
     def test_water_lammps(self, typed_water_system):
         write_lammpsdata(typed_water_system, 'data.water')

--- a/gmso/tests/test_mcf.py
+++ b/gmso/tests/test_mcf.py
@@ -8,16 +8,16 @@ from gmso.exceptions import EngineIncompatibilityError
 
 
 class TestMCF(BaseTest):
-    def test_write_lj_simple(self, typed_single_ar):
-        top = typed_single_ar
+    def test_write_lj_simple(self, n_typed_ar_system):
+        top = n_typed_ar_system(n_sites=1)
         write_mcf(top, "ar.mcf")
 
-    def test_write_mie_simple(self, typed_single_xe_mie):
-        top = typed_single_xe_mie
+    def test_write_mie_simple(self, n_typed_xe_mie):
+        top = n_typed_xe_mie()
         write_mcf(top, "xe.mcf")
 
-    def test_write_lj_full(self, typed_single_ar):
-        top = typed_single_ar
+    def test_write_lj_full(self, n_typed_ar_system):
+        top = n_typed_ar_system(n_sites=1)
         write_mcf(top, "ar.mcf")
 
         mcf_data = []
@@ -53,8 +53,8 @@ class TestMCF(BaseTest):
             top.sites[0].atom_type.parameters["sigma"].in_units(u.Angstrom).value,
         )
 
-    def test_write_mie_full(self, typed_single_xe_mie):
-        top = typed_single_xe_mie
+    def test_write_mie_full(self, n_typed_xe_mie):
+        top = n_typed_xe_mie()
         write_mcf(top, "xe.mcf")
 
         mcf_data = []
@@ -99,8 +99,8 @@ class TestMCF(BaseTest):
             top.sites[0].atom_type.parameters["m"],
         )
 
-    def test_modified_potentials(self, typed_single_ar):
-        top = typed_single_ar
+    def test_modified_potentials(self, n_typed_ar_system):
+        top = n_typed_ar_system(n_sites=1)
 
         top.atom_types[0].set_expression("sigma + epsilon")
 

--- a/gmso/tests/test_top.py
+++ b/gmso/tests/test_top.py
@@ -7,7 +7,6 @@ from gmso.tests.base_test import BaseTest
 from gmso.utils.io import get_fn
 from gmso.tests.utils import get_path
 from gmso.exceptions import EngineIncompatibilityError
-from gmso.external import from_mbuild
 
 
 class TestTop(BaseTest):

--- a/gmso/tests/test_top.py
+++ b/gmso/tests/test_top.py
@@ -24,7 +24,7 @@ class TestTop(BaseTest):
 
 
     def test_modified_potentials(self, ar_system):
-        top = from_mbuild(ar_system())
+        top = ar_system
 
         ff = gmso.ForceField(get_fn('ar.xml'))
 

--- a/gmso/tests/test_top.py
+++ b/gmso/tests/test_top.py
@@ -7,6 +7,7 @@ from gmso.tests.base_test import BaseTest
 from gmso.utils.io import get_fn
 from gmso.tests.utils import get_path
 from gmso.exceptions import EngineIncompatibilityError
+from gmso.external import from_mbuild
 
 
 class TestTop(BaseTest):
@@ -23,7 +24,7 @@ class TestTop(BaseTest):
 
 
     def test_modified_potentials(self, ar_system):
-        top = ar_system
+        top = from_mbuild(ar_system())
 
         ff = gmso.ForceField(get_fn('ar.xml'))
 


### PR DESCRIPTION
Resolving #354 by removing the `topology_site` fixture and replacing with `typed_ar_system` in the LAMMPS and OpenMM tests.  Going to work on adding a `n_sites` argument as well.