### PR TITLE
Add delete site method in topology (Closes #161)

### DIFF
--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -642,17 +642,19 @@ class Topology(object):
         site : gmso.Site
             A Site object that exists on the topology.
 
-        Returns
+        Raises
         -------
-        gmso.Site
-            The site object removed from the topology.
+        GMSOError
+            If `site` doesn't exist in the topology's sites.
 
         Notes
         -----
         Removing a site from the topology removes any bond,
         angles, dihedrals and impropers associated with the site.
         """
-        if site in self._sites:
+        if site not in self._sites:
+            raise GMSOError(f"Site {site} does not exist in the topology")
+        else:
             self._sites.discard(site)
             self._dead_sites.add(site)
             for connection in site.connections:
@@ -678,7 +680,7 @@ class Topology(object):
 
     def _compact_set(self, member, member_type='sites'):
         current_dead, current_set = self._del_ref_sets[member_type]
-        if (member in current_dead) and (member in current_set.item_index_map):
+        if member in current_dead:
             current_set._compact()
             current_dead.discard(member)
 

--- a/gmso/tests/base_test.py
+++ b/gmso/tests/base_test.py
@@ -9,7 +9,9 @@ from gmso.core.box import Box
 from gmso.core.topology import Topology
 from gmso.core.element import Hydrogen, Oxygen
 from gmso.core.site import Site
+from gmso.core.bond import Bond
 from gmso.core.angle import Angle
+from gmso.core.dihedral import Dihedral
 from gmso.core.atom_type import AtomType
 from gmso.core.forcefield import ForceField
 from gmso.external.convert_mbuild import from_mbuild
@@ -153,3 +155,30 @@ class BaseTest:
 
         top.update_topology()
         return top
+
+    @pytest.fixture(scope='function')
+    def random_topology(self):
+        top = Topology()
+        sites = [Site() for i in range(10)]
+        bond_idx = [1, 4]
+        angle_idx = [1, 6, 8]
+        dihedral_idx = [2, 1, 9, 5]
+        bond = Bond(connection_members=[sites[bond_idx[0]],
+                                        sites[bond_idx[1]]])
+        angle = Angle(connection_members=[sites[angle_idx[0]],
+                                          sites[angle_idx[1]],
+                                          sites[angle_idx[2]]])
+        dihedral = Dihedral(connection_members=[sites[dihedral_idx[0]],
+                                                sites[dihedral_idx[1]],
+                                                sites[dihedral_idx[2]],
+                                                sites[dihedral_idx[3]]])
+        top.add_connection(bond)
+        top.add_connection(angle)
+        top.add_connection(dihedral)
+        for site in sites:
+            top.add_site(site)
+        return {
+            'top': top,
+            'sites': sites,
+            'idxes': (bond_idx, angle_idx, dihedral_idx)
+        }

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -428,3 +428,48 @@ class TestTopology(BaseTest):
         assert site2.n_connections == 0
         assert site1.n_connections == 0
         assert top.n_bonds == 0
+
+    def test_topology_delete_non_exsiting_site(self):
+        top = Topology()
+        site1 = Site()
+        with pytest.raises(GMSOError):
+            assert top.delete_site(site1)
+
+    def test_topology_random_site_bond_deletion(self, random_topology):
+        top = random_topology['top']
+        sites = random_topology['sites']
+        (bond_idx, angle_idx, dihedral_idx) = random_topology['idxes']
+        prev_connections_for_a_bonded_site = sites[bond_idx[1]].n_connections
+        print(prev_connections_for_a_bonded_site)
+        top.delete_site(sites[bond_idx[0]])
+        assert top.n_bonds == 0
+        assert sites[bond_idx[1]].n_connections == prev_connections_for_a_bonded_site - 1
+
+    def test_topology_random_site_deletion_angle(self, random_topology):
+        top = random_topology['top']
+        sites = random_topology['sites']
+        (bond_idx, angle_idx, dihedral_idx) = random_topology['idxes']
+        prev_connections_for_a_angle_site = sites[angle_idx[1]].n_connections
+        print(prev_connections_for_a_angle_site)
+        top.delete_site(sites[angle_idx[0]])
+        assert top.n_angles == 0
+        assert sites[angle_idx[1]].n_connections == prev_connections_for_a_angle_site - 1
+
+    def test_topology_random_site_deletion_dihedral(self, random_topology):
+        top = random_topology['top']
+        sites = random_topology['sites']
+        (bond_idx, angle_idx, dihedral_idx) = random_topology['idxes']
+        prev_connections_for_a_dihedral_site = sites[dihedral_idx[1]].n_connections
+        top.delete_site(sites[dihedral_idx[0]])
+        print(prev_connections_for_a_dihedral_site, sites[dihedral_idx[1]].n_connections)
+        assert top.n_dihedrals == 0
+        assert sites[dihedral_idx[1]].n_connections == (prev_connections_for_a_dihedral_site - 1)
+
+    def test_topology_site_deletion_and_addition(self, random_topology):
+        top = random_topology['top']
+        sites = random_topology['sites']
+        top.delete_site(sites[0])
+        assert sites[0] in top._dead_sites
+        sites[0].name = 'Changed Site'
+        top.add_site(sites[0])
+        assert top._sites[top._sites.index(sites[0])]

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -418,4 +418,13 @@ class TestTopology(BaseTest):
         assert top.sites[10].atom_type.name == 'atom_type_changed'
         assert top.is_typed()
 
-
+    def test_topology_delete_site(self):
+        top = Topology()
+        site1 = Site()
+        site2 = Site()
+        bond1 = Bond(connection_members=[site1, site2])
+        top.add_connection(bond1)
+        top.delete_site(site1)
+        assert site2.n_connections == 0
+        assert site1.n_connections == 0
+        assert top.n_bonds == 0


### PR DESCRIPTION
Closes #161. Adds `delete_site` method and a simple test. 