### PR TITLE
Add get_associations method to topology class (Closes #375)

### DIFF
--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -538,15 +538,16 @@ class Topology(object):
 
             elif c.connection_type in self._connection_types:
                 if isinstance(c.connection_type, BondType):
+                    c.connection_type = self._bond_types[c.connection_type]
                     self._bond_types_associations[c.connection_type].add(c)
                 if isinstance(c.connection_type, AngleType):
-                    self._angle_types[c.connection_type] = c.connection_type
+                    c.connection_type = self._angle_types[c.connection_type]
                     self._angle_type_associations[c.connection_type].add(c)
                 if isinstance(c.connection_type, DihedralType):
-                    self._dihedral_types[c.connection_type] = c.connection_type
+                    c.connection_type = self._dihedral_types[c.connection_type]
                     self._dihedral_types_associations[c.connection_type].add(c)
                 if isinstance(c.connection_type, ImproperType):
-                    self._improper_types[c.connection_type] = c.connection_type
+                    c.connection_type = self._improper_types[c.connection_type]
                     self._improper_types_associations[c.connection_type].add(c)
 
     def update_atom_types(self):
@@ -597,7 +598,7 @@ class Topology(object):
         subtop.parent = self
         self._sites.union(subtop.sites)
 
-    def is_typed(self, updated=False, ):
+    def is_typed(self, updated=False):
         if not updated:
             self.update_connection_types()
             self.update_atom_types()

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -418,4 +418,23 @@ class TestTopology(BaseTest):
         assert top.sites[10].atom_type.name == 'atom_type_changed'
         assert top.is_typed()
 
+    def test_get_associations_atom_types(self):
+        top = Topology()
+        atom_type = AtomType(name='test_atomtype')
+        for i in range(10):
+            top.add_site(Site(name=f'site{i+1}', atom_type=atom_type), update_types=True)
+        assert len(top.get_associations(atom_type)) == 10
+
+    def test_get_association_atom_types_after_changes(self, typed_ar_system):
+        typed_ar_system.atom_types[0].name = 'Typed Ar System'
+        assert typed_ar_system.get_associations(typed_ar_system.atom_types[0]) == set(typed_ar_system.sites)
+
+    def test_get_association_bond_types(self, typed_water_system):
+        bond_type = typed_water_system.bond_types[0]
+        assert len(typed_water_system.get_associations(bond_type)) == 4
+
+    def test_get_association_bond_types_after_changes(self, typed_water_system):
+        bond_type = typed_water_system.bond_types[0]
+        bond_type.name = 'Typed water system'
+        assert type(typed_water_system.get_associations(bond_type)) == set
 

--- a/gmso/utils/decorators.py
+++ b/gmso/utils/decorators.py
@@ -10,8 +10,10 @@ def confirm_dict_existence(setter_function):
     def setter_with_dict_removal(self, *args, **kwargs):
         if self._topology:
             self._topology._set_refs[self._set_ref].pop(self, None)
+            prev_associations = self._topology._association_refs[self._set_ref].pop(self, set())
             setter_function(self, *args, **kwargs)
             self._topology._set_refs[self._set_ref][self] = (self)
+            self._topology._association_refs[self._set_ref][self] = prev_associations
         else:
             setter_function(self, *args, **kwargs)
     return setter_with_dict_removal


### PR DESCRIPTION
adds `get_association` method to return a set of sites associated with an `atomtype` or
a set of bonds associated with a bond_type and so on.