### PR TITLE
Ensure that all connections are unique

### DIFF
--- a/gmso/core/angle.py
+++ b/gmso/core/angle.py
@@ -35,13 +35,13 @@ class Angle(Connection):
         super(Angle, self).__init__(connection_members=connection_members,
                 connection_type=connection_type, name=name)
 
-    def get_equivalent_members(self):
-        """Get a unique dataset representing the connection
+    def equivalent_members(self):
+        """Get a set of the equivalent connection member tuples
 
         Returns
         _______
-        tuple
-            A unique tuple to represent the connection members
+        frozenset
+            A unique set of tuples of equivalent connection members
 
         Notes
         _____
@@ -49,12 +49,32 @@ class Angle(Connection):
             i, j, k == k, j, i
         where i, j, and k are the connection members.
         """
+        return frozenset([
+                tuple(self.connection_members),
+                tuple(reversed(self.connection_members))
+                ])
 
-        return tuple([
+    def _equivalent_member_hash(self):
+        """Get a hash representing the connection
+
+        Returns
+        _______
+        int (hash)
+            A unique hash to represent the connection members
+
+        Notes
+        _____
+        For an angle:
+            i, j, k == k, j, i
+        where i, j, and k are the connection members.
+        Here, j is fixed and i and k are replaceable.
+        """
+
+        return hash(tuple([
             self.connection_members[1],
             frozenset([self.connection_members[0],
                        self.connection_members[2]])
-            ])
+            ]))
 
 def _validate_three_partners(connection_members):
     """Ensure 3 partners are involved in Angle"""

--- a/gmso/core/angle.py
+++ b/gmso/core/angle.py
@@ -19,7 +19,7 @@ class Angle(Connection):
     connection_type : gmso.AngleType, optional, default=None
         AngleType of this angle.
     name : str, optional, default="Angle"
-        Name of the angle. 
+        Name of the angle.
 
     Notes
     -----
@@ -35,6 +35,26 @@ class Angle(Connection):
         super(Angle, self).__init__(connection_members=connection_members,
                 connection_type=connection_type, name=name)
 
+    def get_equivalent_members(self):
+        """Get a unique dataset representing the connection
+
+        Returns
+        _______
+        tuple
+            A unique tuple to represent the connection members
+
+        Notes
+        _____
+        For an angle:
+            i, j, k == k, j, i
+        where i, j, and k are the connection members.
+        """
+
+        return tuple([
+            self.connection_members[1],
+            frozenset([self.connection_members[0],
+                       self.connection_members[2]])
+            ])
 
 def _validate_three_partners(connection_members):
     """Ensure 3 partners are involved in Angle"""

--- a/gmso/core/bond.py
+++ b/gmso/core/bond.py
@@ -35,6 +35,25 @@ class Bond(Connection):
         super(Bond, self).__init__(connection_members=connection_members,
                 connection_type=connection_type, name=name)
 
+    def get_equivalent_members(self):
+        """Get a unique dataset representing the connection
+
+        Returns
+        _______
+        tuple
+            A unique tuple to represent the connection members
+
+        Notes
+        _____
+        For a bond:
+            i, j == j, i
+        where i and j are the connection members.
+        """
+
+        return tuple([
+            frozenset([self.connection_members[0],
+                      self.connection_members[1]])
+            ])
 
 def _validate_two_partners(connection_members):
     """Ensure 2 partners are involved in Bond"""

--- a/gmso/core/bond.py
+++ b/gmso/core/bond.py
@@ -35,13 +35,13 @@ class Bond(Connection):
         super(Bond, self).__init__(connection_members=connection_members,
                 connection_type=connection_type, name=name)
 
-    def get_equivalent_members(self):
-        """Get a unique dataset representing the connection
+    def equivalent_members(self):
+        """Get a set of the equivalent connection member tuples
 
         Returns
         _______
-        tuple
-            A unique tuple to represent the connection members
+        frozenset
+            A unique set of tuples of equivalent connection members
 
         Notes
         _____
@@ -49,11 +49,31 @@ class Bond(Connection):
             i, j == j, i
         where i and j are the connection members.
         """
+        return frozenset([
+                tuple(self.connection_members),
+                tuple(reversed(self.connection_members))
+                ])
 
-        return tuple([
+    def _equivalent_member_hash(self):
+        """Get a unique hash representing the connection
+
+        Returns
+        _______
+        int
+            A unique hash to represent the connection members
+
+        Notes
+        _____
+        For a bond:
+            i, j == j, i
+        where i and j are the connection members.
+        Here, i and j are interchangeable.
+        """
+
+        return hash(tuple([
             frozenset([self.connection_members[0],
                       self.connection_members[1]])
-            ])
+            ]))
 
 def _validate_two_partners(connection_members):
     """Ensure 2 partners are involved in Bond"""

--- a/gmso/core/connection.py
+++ b/gmso/core/connection.py
@@ -53,6 +53,23 @@ class Connection(object):
     def name(self, conname):
         self._name = _validate_name(conname)
 
+    def get_equivalent_members(self):
+        """Get a unique dataset representing the connection
+
+        Returns
+        _______
+        tuple
+            A unique tuple to represent the connection members
+
+        Notes
+        _____
+        Generalized for all connections, this is just a tuple of
+        the members. For specific connections (i.e. Bonds, Angles,
+        Dihedrals, and Impropers), this function is overridden.
+        """
+
+        return tuple(self.connection_members)
+
     def _update_members(self):
         for partner in self.connection_members:
             if self not in partner.connections:

--- a/gmso/core/connection.py
+++ b/gmso/core/connection.py
@@ -53,22 +53,41 @@ class Connection(object):
     def name(self, conname):
         self._name = _validate_name(conname)
 
-    def get_equivalent_members(self):
-        """Get a unique dataset representing the connection
+    def equivalent_members(self):
+        """Get a set of the equivalent connection member tuples
 
         Returns
         _______
-        tuple
-            A unique tuple to represent the connection members
+        frozenset
+            A unique set of tuples of equivalent connection members
 
         Notes
         _____
-        Generalized for all connections, this is just a tuple of
-        the members. For specific connections (i.e. Bonds, Angles,
+        For a bond:
+            i, j == j, i
+        where i and j are the connection members.
+        """
+        return frozenset(
+                tuple(self.connection_members),
+                tuple(reversed(self.connection_members))
+                )
+
+    def _equivalent_member_hash(self):
+        """Get a unique hash representing the connection
+
+        Returns
+        _______
+        int
+            A unique hash to represent the connection members
+
+        Notes
+        _____
+        Generalized for all connections, this is just a hashed tuple
+        of the members. For specific connections (i.e. Bonds, Angles,
         Dihedrals, and Impropers), this function is overridden.
         """
 
-        return tuple(self.connection_members)
+        return hash(tuple(self.connection_members))
 
     def _update_members(self):
         for partner in self.connection_members:

--- a/gmso/core/dihedral.py
+++ b/gmso/core/dihedral.py
@@ -40,6 +40,29 @@ class Dihedral(Connection):
         super(Dihedral, self).__init__(connection_members=connection_members,
                 connection_type=connection_type, name=name)
 
+    def get_equivalent_members(self):
+        """Get a unique dataset representing the connection
+
+        Returns
+        _______
+        tuple
+            A unique tuple to represent the connection members
+
+        Notes
+        _____
+        For an dihedral:
+            i, j, k, l == l, k, j, i
+        where i, j, k, and l are the connection members.
+        """
+
+        return tuple([frozenset([
+            frozenset([self.connection_members[0],
+                       self.connection_members[1]]),
+            frozenset([self.connection_members[1],
+                       self.connection_members[2]]),
+            frozenset([self.connection_members[2],
+                       self.connection_members[3]])
+            ])])
 
 def _validate_four_partners(connection_members):
     """Ensure 4 partners are involved in Dihedral"""

--- a/gmso/core/dihedral.py
+++ b/gmso/core/dihedral.py
@@ -40,13 +40,13 @@ class Dihedral(Connection):
         super(Dihedral, self).__init__(connection_members=connection_members,
                 connection_type=connection_type, name=name)
 
-    def get_equivalent_members(self):
-        """Get a unique dataset representing the connection
+    def equivalent_members(self):
+        """Get a set of the equivalent connection member tuples
 
         Returns
         _______
-        tuple
-            A unique tuple to represent the connection members
+        frozenset
+            A unique set of tuples of equivalent connection members
 
         Notes
         _____
@@ -54,15 +54,37 @@ class Dihedral(Connection):
             i, j, k, l == l, k, j, i
         where i, j, k, and l are the connection members.
         """
+        return frozenset([
+                tuple(self.connection_members),
+                tuple(reversed(self.connection_members))
+                ])
 
-        return tuple([frozenset([
+    def _equivalent_member_hash(self):
+        """Get a unique hash representing the connection
+
+        Returns
+        _______
+        int
+            A unique hash to represent the connection members
+
+        Notes
+        _____
+        For an dihedral:
+            i, j, k, l == l, k, j, i
+        where i, j, k, and l are the connection members.
+        Here i and j are interchangeable, j and k are interchangeable,
+        and k and l are interchangeble, as long as each are adjacent to
+        one another.
+        """
+
+        return hash(tuple([frozenset([
             frozenset([self.connection_members[0],
                        self.connection_members[1]]),
             frozenset([self.connection_members[1],
                        self.connection_members[2]]),
             frozenset([self.connection_members[2],
                        self.connection_members[3]])
-            ])])
+            ])]))
 
 def _validate_four_partners(connection_members):
     """Ensure 4 partners are involved in Dihedral"""

--- a/gmso/core/improper.py
+++ b/gmso/core/improper.py
@@ -45,6 +45,27 @@ class Improper(Connection):
         super(Improper, self).__init__(connection_members=connection_members,
                 connection_type=connection_type, name=name)
 
+    def get_equivalent_members(self):
+        """Get a unique dataset representing the connection
+
+        Returns
+        _______
+        tuple
+            A unique tuple to represent the connection members
+
+        Notes
+        _____
+        For an improper:
+            i, j, k, l == i, k, j, l
+        where i, j, k, and l are the connection members.
+        """
+
+        return tuple([
+            self.connection_members[0],
+            self.connection_members[3],
+            frozenset([self.connection_members[1],
+                       self.connection_members[2]])
+            ])
 
 def _validate_four_partners(connection_members):
     """Ensure 4 partners are involved in Improper"""

--- a/gmso/core/improper.py
+++ b/gmso/core/improper.py
@@ -45,13 +45,13 @@ class Improper(Connection):
         super(Improper, self).__init__(connection_members=connection_members,
                 connection_type=connection_type, name=name)
 
-    def get_equivalent_members(self):
-        """Get a unique dataset representing the connection
+    def equivalent_members(self):
+        """Get a set of the equivalent connection member tuples
 
         Returns
         _______
-        tuple
-            A unique tuple to represent the connection members
+        frozenset
+            A unique set of tuples of equivalent connection members
 
         Notes
         _____
@@ -59,13 +59,38 @@ class Improper(Connection):
             i, j, k, l == i, k, j, l
         where i, j, k, and l are the connection members.
         """
+        equiv_members = [self.connection_members[0],
+                         self.connection_members[2],
+                         self.connection_members[1],
+                         self.connection_members[3]]
 
-        return tuple([
+        return frozenset([
+                tuple(self.connection_members),
+                tuple(equiv_members)
+                ])
+
+    def _equivalent_member_hash(self):
+        """Get a unique hash representing the connection
+
+        Returns
+        _______
+        int
+            A unique hash to represent the connection members
+
+        Notes
+        _____
+        For an improper:
+            i, j, k, l == i, k, j, l
+        where i, j, k, and l are the connection members.
+        Here j and k are interchangeable and i and l are fixed.
+        """
+
+        return hash(tuple([
             self.connection_members[0],
             self.connection_members[3],
             frozenset([self.connection_members[1],
                        self.connection_members[2]])
-            ])
+            ]))
 
 def _validate_four_partners(connection_members):
     """Ensure 4 partners are involved in Improper"""

--- a/gmso/core/site.py
+++ b/gmso/core/site.py
@@ -73,11 +73,10 @@ class Site(object):
     def add_connection(self, connection):
         connection = _validate_connection(self, connection)
 
-        if connection:
-            equivalent_members = connection.get_equivalent_members()
-            self._unique_connections.update(
-                {equivalent_members : connection})
-            self._connections.add(connection)
+        equivalent_members = connection._equivalent_member_hash()
+        self._unique_connections.update(
+            {equivalent_members : connection})
+        self._connections.add(connection)
 
 
     @property
@@ -201,9 +200,10 @@ def _validate_connection(site, connection):
         raise GMSOError("Error: Site not in connection members. Cannot add the connection.")
 
     # Check if an equivalent connection is in the topology
-    equivalent_members = connection.get_equivalent_members()
+    equivalent_members = connection._equivalent_member_hash()
     if equivalent_members in site._unique_connections:
-        warnings.warn('An equivalent connection already exists.')
+        warnings.warn('An equivalent Connection already exists. '
+                        'Providing the existing equivalent Connection.')
         return site._unique_connections[equivalent_members]
 
     return connection

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -373,14 +373,15 @@ class Topology(object):
 
         Returns
         _______
-        Connection
+        gmso.Connection
             The Connection object or equivalent Connection object that
             is in the topology
         """
         # Check if an equivalent connection is in the topology
-        equivalent_members = connection.get_equivalent_members()
+        equivalent_members = connection._equivalent_member_hash()
         if equivalent_members in self._unique_connections:
-            warnings.warn('An equivalent connection already exists.')
+            warnings.warn('An equivalent connection already exists. '
+                        'Providing the existing equivalent Connection.')
             return self._unique_connections[equivalent_members]
 
         for conn_member in connection.connection_members:

--- a/gmso/tests/test_angle.py
+++ b/gmso/tests/test_angle.py
@@ -110,3 +110,19 @@ class TestAngle(BaseTest):
 
         top.add_connection(angle_not_eq)
         assert top.n_angles == 2
+
+    def test_equivalent_members_set(self):
+        site1 = Site(name="SiteA")
+        site2 = Site(name="SiteB")
+        site3 = Site(name="SiteC")
+
+        angle = Angle([site1, site2, site3])
+        angle_eq = Angle([site3, site2, site1])
+        angle_not_eq = Angle([site1, site3, site2])
+
+        assert (tuple(angle_eq.connection_members)
+                in angle.equivalent_members())
+        assert (tuple(angle.connection_members)
+                in angle_eq.equivalent_members())
+        assert not (tuple(angle.connection_members)
+                in angle_not_eq.equivalent_members())

--- a/gmso/tests/test_angle.py
+++ b/gmso/tests/test_angle.py
@@ -1,5 +1,6 @@
 import pytest
 
+from gmso.core.topology import Topology
 from gmso.core.angle import Angle
 from gmso.core.angle_type import AngleType
 from gmso.core.atom_type import AtomType
@@ -67,7 +68,7 @@ class TestAngle(BaseTest):
         site3 = Site(name='site3', position=[1,1,0], atom_type=AtomType(name='C'))
         angtype = AngleType(member_types=[site1.atom_type.name, site2.atom_type.name,
             site3.atom_type.name])
-        ang = Angle(connection_members=[site1, site2, site3], 
+        ang = Angle(connection_members=[site1, site2, site3],
                 connection_type=angtype)
         assert 'A' in ang.connection_type.member_types
         assert 'B' in ang.connection_type.member_types
@@ -92,3 +93,20 @@ class TestAngle(BaseTest):
 
         assert ref_angle != same_angle
         assert ref_angle != diff_angle
+
+    def test_add_equivalent_connections(self):
+        site1 = Site(name="SiteA")
+        site2 = Site(name="SiteB")
+        site3 = Site(name="SiteC")
+
+        angle = Angle([site1, site2, site3])
+        angle_eq = Angle([site3, site2, site1])
+        angle_not_eq = Angle([site1, site3, site2])
+
+        top = Topology()
+        top.add_connection(angle)
+        top.add_connection(angle_eq)
+        assert top.n_angles == 1
+
+        top.add_connection(angle_not_eq)
+        assert top.n_angles == 2

--- a/gmso/tests/test_bond.py
+++ b/gmso/tests/test_bond.py
@@ -1,5 +1,6 @@
 import pytest
 
+from gmso.core.topology import Topology
 from gmso.core.bond import Bond
 from gmso.core.atom_type import AtomType
 from gmso.core.bond_type import BondType
@@ -79,3 +80,15 @@ class TestBond(BaseTest):
 
         assert ref_connection != same_connection
         assert ref_connection != diff_connection
+
+    def test_add_equivalent_connections(self):
+        site1 = Site(name="SiteA")
+        site2 = Site(name="SiteB")
+
+        bond = Bond([site1, site2])
+        bond_eq = Bond([site2, site1])
+
+        top = Topology()
+        top.add_connection(bond)
+        top.add_connection(bond_eq)
+        assert top.n_bonds == 1

--- a/gmso/tests/test_bond.py
+++ b/gmso/tests/test_bond.py
@@ -92,3 +92,16 @@ class TestBond(BaseTest):
         top.add_connection(bond)
         top.add_connection(bond_eq)
         assert top.n_bonds == 1
+
+    def test_equivalent_members_set(self):
+        site1 = Site(name="SiteA")
+        site2 = Site(name="SiteB")
+
+        bond = Bond([site1, site2])
+        bond_eq = Bond([site2, site1])
+
+        assert (tuple(bond_eq.connection_members)
+                in bond.equivalent_members())
+        assert (tuple(bond.connection_members)
+                in bond_eq.equivalent_members())
+

--- a/gmso/tests/test_connection.py
+++ b/gmso/tests/test_connection.py
@@ -68,6 +68,10 @@ class TestConnection(BaseTest):
         # Two connections are never equal
         assert ref_connection != same_connection
 
+        # Members may be equivalent
+        assert (ref_connection._equivalent_member_hash ==
+                same_connection._equivalent_member_hash)
+
     def test_add_connection_same_sites(self):
         site1 = Site()
         site2 = Site()

--- a/gmso/tests/test_connection.py
+++ b/gmso/tests/test_connection.py
@@ -69,8 +69,8 @@ class TestConnection(BaseTest):
         assert ref_connection != same_connection
 
         # Members may be equivalent
-        assert (ref_connection._equivalent_member_hash ==
-                same_connection._equivalent_member_hash)
+        assert (ref_connection._equivalent_member_hash() ==
+                same_connection._equivalent_member_hash())
 
     def test_add_connection_same_sites(self):
         site1 = Site()

--- a/gmso/tests/test_dihedral.py
+++ b/gmso/tests/test_dihedral.py
@@ -1,5 +1,6 @@
 import pytest
 
+from gmso.core.topology import Topology
 from gmso.core.dihedral import Dihedral
 from gmso.core.dihedral_type import DihedralType
 from gmso.core.atom_type import AtomType
@@ -74,11 +75,11 @@ class TestDihedral(BaseTest):
         site2 = Site(name='site2', position=[1,0,0], atom_type=AtomType(name='B'))
         site3 = Site(name='site3', position=[1,1,0], atom_type=AtomType(name='C'))
         site4 = Site(name='site4', position=[1,1,4], atom_type=AtomType(name='D'))
-        dihtype = DihedralType(member_types=[site1.atom_type.name, 
+        dihtype = DihedralType(member_types=[site1.atom_type.name,
                                              site2.atom_type.name,
                                              site3.atom_type.name,
                                              site4.atom_type.name])
-        dih = Dihedral(connection_members=[site1, site2, site3, site4], 
+        dih = Dihedral(connection_members=[site1, site2, site3, site4],
                 connection_type=dihtype)
         assert 'A' in dih.connection_type.member_types
         assert 'B' in dih.connection_type.member_types
@@ -105,3 +106,21 @@ class TestDihedral(BaseTest):
 
         assert ref_dihedral != same_dihedral
         assert ref_dihedral != diff_dihedral
+
+    def test_add_equivalent_connections(self):
+        site1 = Site(name="SiteA")
+        site2 = Site(name="SiteB")
+        site3 = Site(name="SiteC")
+        site4 = Site(name="SiteD")
+
+        dihedral = Dihedral([site1, site2, site3, site4])
+        dihedral_eq = Dihedral([site4, site3, site2, site1])
+        dihedral_not_eq = Dihedral([site4, site2, site3, site1])
+
+        top = Topology()
+        top.add_connection(dihedral)
+        top.add_connection(dihedral_eq)
+        assert top.n_dihedrals == 1
+
+        top.add_connection(dihedral_not_eq)
+        assert top.n_dihedrals == 2

--- a/gmso/tests/test_dihedral.py
+++ b/gmso/tests/test_dihedral.py
@@ -124,3 +124,22 @@ class TestDihedral(BaseTest):
 
         top.add_connection(dihedral_not_eq)
         assert top.n_dihedrals == 2
+
+    def test_equivalent_members_set(self):
+        site1 = Site(name="SiteA")
+        site2 = Site(name="SiteB")
+        site3 = Site(name="SiteC")
+        site4 = Site(name="SiteD")
+
+        dihedral = Dihedral([site1, site2, site3, site4])
+        dihedral_eq = Dihedral([site4, site3, site2, site1])
+        dihedral_not_eq = Dihedral([site4, site2, site3, site1])
+
+
+        assert (tuple(dihedral_eq.connection_members)
+                in dihedral.equivalent_members())
+        assert (tuple(dihedral.connection_members)
+                in dihedral_eq.equivalent_members())
+        assert not (tuple(dihedral.connection_members)
+                in dihedral_not_eq.equivalent_members())
+

--- a/gmso/tests/test_improper.py
+++ b/gmso/tests/test_improper.py
@@ -123,3 +123,20 @@ class TestImproper(BaseTest):
         assert top.n_impropers == 1
         top.add_connection(improper_not_eq)
         assert top.n_impropers == 2
+
+    def test_equivalent_members_set(self):
+        site1 = Site(name="SiteA")
+        site2 = Site(name="SiteB")
+        site3 = Site(name="SiteC")
+        site4 = Site(name="SiteD")
+
+        improper = Improper([site1, site2, site3, site4])
+        improper_eq = Improper([site1, site3, site2, site4])
+        improper_not_eq = Improper([site2, site3, site1, site4])
+
+        assert (tuple(improper_eq.connection_members)
+                in improper.equivalent_members())
+        assert (tuple(improper.connection_members)
+                in improper_eq.equivalent_members())
+        assert not (tuple(improper.connection_members)
+                in improper_not_eq.equivalent_members())

--- a/gmso/tests/test_improper.py
+++ b/gmso/tests/test_improper.py
@@ -1,5 +1,6 @@
 import pytest
 
+from gmso.core.topology import Topology
 from gmso.core.improper import Improper
 from gmso.core.improper_type import ImproperType
 from gmso.core.atom_type import AtomType
@@ -74,11 +75,11 @@ class TestImproper(BaseTest):
         site2 = Site(name='site2', position=[1,0,0], atom_type=AtomType(name='B'))
         site3 = Site(name='site3', position=[1,1,0], atom_type=AtomType(name='C'))
         site4 = Site(name='site4', position=[1,1,4], atom_type=AtomType(name='D'))
-        imptype = ImproperType(member_types=[site1.atom_type.name, 
+        imptype = ImproperType(member_types=[site1.atom_type.name,
                                              site2.atom_type.name,
                                              site3.atom_type.name,
                                              site4.atom_type.name])
-        imp = Improper(connection_members=[site1, site2, site3, site4], 
+        imp = Improper(connection_members=[site1, site2, site3, site4],
                 connection_type=imptype)
         assert 'A' in imp.connection_type.member_types
         assert 'B' in imp.connection_type.member_types
@@ -105,3 +106,20 @@ class TestImproper(BaseTest):
 
         assert ref_improper != same_improper
         assert ref_improper != diff_improper
+
+    def test_add_equivalent_connections(self):
+        site1 = Site(name="SiteA")
+        site2 = Site(name="SiteB")
+        site3 = Site(name="SiteC")
+        site4 = Site(name="SiteD")
+
+        improper = Improper([site1, site2, site3, site4])
+        improper_eq = Improper([site1, site3, site2, site4])
+        improper_not_eq = Improper([site2, site3, site1, site4])
+
+        top = Topology()
+        top.add_connection(improper)
+        top.add_connection(improper_eq)
+        assert top.n_impropers == 1
+        top.add_connection(improper_not_eq)
+        assert top.n_impropers == 2

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -418,4 +418,17 @@ class TestTopology(BaseTest):
         assert top.sites[10].atom_type.name == 'atom_type_changed'
         assert top.is_typed()
 
+    def test_add_duplicate_connected_site(self):
+        top = Topology()
+        site1 = Site(name="SiteA")
+        site2 = Site(name="SiteB")
+        bond = Bond([site1, site2])
+        bond_eq = Bond([site1, site2])
+        assert site1.n_connections == 1
+        assert site2.n_connections == 1
 
+        top.add_site(site1)
+        top.add_site(site2)
+        top.update_topology()
+        assert top.n_connections == 1
+        assert top.connections[0] == site1.connections[0]

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -436,22 +436,43 @@ class TestTopology(BaseTest):
 
     def test_topology_get_index(self):
         top = Topology()
-        conn_members = [Site(), Site(), Site(), Site()]
+        conn_members = [Site() for _ in range(10)]
+        for site in conn_members:
+            top.add_site(site)
+
         for i in range(5):
-            top.add_site(Site())
             top.add_connection(Bond(
-                connection_members=[conn_members[0], conn_members[1]]))
+                connection_members=[conn_members[i], conn_members[i+1]]))
             top.add_connection(Angle(
-                connection_members=[conn_members[0], conn_members[1], conn_members[2]]))
+                connection_members=[conn_members[i],
+                                    conn_members[i+1],
+                                    conn_members[i+2]]))
             top.add_connection(Dihedral(
-                connection_members=[conn_members[0], conn_members[1], conn_members[2], conn_members[3]]))
+                connection_members=[conn_members[i],
+                                    conn_members[i+1],
+                                    conn_members[i+2],
+                                    conn_members[i+3]]))
             top.add_connection(Improper(
-                connection_members=[conn_members[0], conn_members[1], conn_members[2], conn_members[3]]))
-        a_bond = Bond(connection_members=[conn_members[0], conn_members[1]])
-        an_angle = Angle(connection_members=[conn_members[0], conn_members[1], conn_members[2]])
+                connection_members=[conn_members[i],
+                                    conn_members[i+1],
+                                    conn_members[i+2],
+                                    conn_members[i+3]]))
+
+
         a_site = Site()
-        a_dihedral = Dihedral(connection_members=[conn_members[0], conn_members[1], conn_members[2], conn_members[3]])
-        an_improper = Improper(connection_members=[conn_members[0], conn_members[1], conn_members[2], conn_members[3]])
+        a_bond = Bond(connection_members=[conn_members[6],
+                                          conn_members[7]])
+        an_angle = Angle(connection_members=[conn_members[6],
+                                             conn_members[7],
+                                             conn_members[8]])
+        a_dihedral = Dihedral(connection_members=[conn_members[6],
+                                                  conn_members[7],
+                                                  conn_members[8],
+                                                  conn_members[9]])
+        an_improper = Improper(connection_members=[conn_members[6],
+                                                   conn_members[7],
+                                                   conn_members[8],
+                                                   conn_members[9]])
 
         top.add_site(a_site)
         top.add_connection(a_bond)
@@ -459,7 +480,7 @@ class TestTopology(BaseTest):
         top.add_connection(a_dihedral)
         top.add_connection(an_improper)
 
-        assert top.get_index(a_site) == 9
+        assert top.get_index(a_site) == 10
         assert top.get_index(a_bond) == 5
         assert top.get_index(an_angle) == 5
         assert top.get_index(a_dihedral) == 5


### PR DESCRIPTION
Related to #380 and #377. 

This PR makes sure that equivalent connections are not added based on the connection rules defined in https://github.com/mosdef-hub/gmso/issues/361#issuecomment-601473060. 

So far, merging this PR will...
* add get_equivalent_members function to get a unique data structure to represent the connection members.
* modify topology.add_connection to prevent adding an existing connection or equivalent connection to the topology.
* add tests to verify that equivalent connection aren't added to the topology.