### PR TITLE
Remove connection reference from Site (closes #389)

### DIFF
--- a/gmso/core/connection.py
+++ b/gmso/core/connection.py
@@ -27,7 +27,6 @@ class Connection(object):
         self._connection_members = _validate_connection_members(connection_members)
         self._connection_type = _validate_connection_type(connection_type)
         self._name = _validate_name(name)
-        self._update_members()
 
     @property
     def connection_members(self):
@@ -52,11 +51,6 @@ class Connection(object):
     @name.setter
     def name(self, conname):
         self._name = _validate_name(conname)
-
-    def _update_members(self):
-        for partner in self.connection_members:
-            if self not in partner.connections:
-                partner.add_connection(self)
 
     def __repr__(self):
         descr = '<{}-partner Connection, id {}, '.format(

--- a/gmso/core/site.py
+++ b/gmso/core/site.py
@@ -35,11 +35,6 @@ class Site(object):
        The atom type of the site containing functional forms, interaction parameters, and other properties such as mass and charge.  
        See `atom_type.py` for more information.
 
-    Attributes
-    ----------
-    n_connections : int
-       Number of connections for the site
-
     """
     def __init__(self,
                  name='Site',

--- a/gmso/core/site.py
+++ b/gmso/core/site.py
@@ -1,13 +1,9 @@
 import warnings
-from functools import reduce
-
 
 import numpy as np
 import unyt as u
-from boltons.setutils import IndexedSet
 
 from gmso.core.atom_type import AtomType
-from gmso.exceptions import GMSOError
 
 
 class Site(object):
@@ -41,8 +37,6 @@ class Site(object):
 
     Attributes
     ----------
-    connections : IndexedSet
-       Set that contains connection information for the site
     n_connections : int
        Number of connections for the site
 
@@ -67,12 +61,6 @@ class Site(object):
         self._atom_type = _validate_atom_type(atom_type)
         self._charge = _validate_charge(charge)
         self._mass = _validate_mass(mass)
-        self._connections = IndexedSet()
-
-    def add_connection(self, connection):
-        connection = _validate_connection(self, connection)
-        if connection:
-            self._connections.add(connection)
 
     @property
     def element(self):
@@ -81,14 +69,6 @@ class Site(object):
     @element.setter
     def element(self, element):
         self._element = element
-
-    @property
-    def connections(self):
-        return self._connections
-
-    @property
-    def n_connections(self):
-        return len(self._connections)
 
     @property
     def charge(self):
@@ -181,16 +161,3 @@ def _validate_atom_type(val):
         raise ValueError("Passed value {} is not an AtomType".format(val))
     else:
         return val
-
-
-def _validate_connection(site, connection):
-    if not isinstance(site, Site):
-        raise ValueError("Passed value {} is not a site".format(site))
-    from gmso.core.connection import Connection
-    if not isinstance(connection, Connection):
-        raise ValueError("Passed value {} is not a Connection".format(connection))
-    if site not in connection.connection_members:
-        raise GMSOError("Error: Site not in connection members. Cannot add the connection.")
-    if connection in site.connections:
-        return None
-    return connection

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -357,8 +357,6 @@ class Topology(object):
 
         See Also
         --------
-        gmso.Topology.update_connections :
-            Update the connections in the topology to reflect any added sites connections
         gmso.Topology.add_site : Add a site to the topology.
         gmso.Topology.add_connection : Add a Bond, an Angle or a Dihedral to the topology.
         gmso.Topology.update_topology : Update the entire topology.

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -403,82 +403,6 @@ class Topology(object):
         if update_types:
             self.update_connection_types()
 
-    def update_connections(self, update_types=False):
-        """Update the topology's connections(bonds, angles, dihedrals, impropers) from its sites.
-
-        This method takes all the sites in the current topology and if any connection
-        (Bond, Angle, Dihedral) is present in the site but not in the topology's connection
-        collection, this method will add to that collection. If update_types is True (default
-        behavior is False), this method will also add the Potential objects(AtomType, BondType,
-        AngleType, DihedralType) to the topology's respective collection.
-
-        Parameters
-        ----------
-        update_types : bool, default=False
-
-        See Also
-        --------
-        gmso.Topology.update_sites :
-            Update the sites in the topology to reflect any added connection's sites
-        gmso.Topology.add_connection : Add a Bond, an Angle or a Dihedral to the topology.
-        gmso.Topology.add_site : Add a site to the topology.
-        gmso.Topology.update_connection_types :
-            Update the connection types based on the connection collection in the topology.
-        gmso.Topology.update_topology : Update the entire topology.
-
-        """
-        for site in self.sites:
-            for conn in site.connections:
-                if conn not in self.connections:
-                    self.add_connection(conn, update_types=False)
-        if update_types:
-            self.update_connection_types()
-            self.is_typed()
-
-    def update_bonds(self, update_types=False):
-        """Uses gmso.Topology.update_connections to update bonds in the topology.
-
-        This method is an alias for gmso.Topology.update_connections.
-
-        See Also
-        --------
-        gmso.Topology.update_connections : Update all the Bonds, Angles, Dihedrals, and Impropers in the topology.
-        """
-        self.update_connections(update_types)
-
-    def update_angles(self, update_types=False):
-        """Uses gmso.Topology.update_connections to update angles in the topology.
-
-        This method is an alias for gmso.Topology.update_connections.
-
-        See Also
-        --------
-        gmso.Topology.update_connections : Update all the Bonds, Angles, Dihedrals, and Impropers in the topology.
-        """
-        self.update_connections(update_types)
-
-    def update_dihedrals(self, update_types=False):
-        """Uses gmso.Topology.update_connections to update dihedrals in the topology.
-
-        This method is an alias for gmso.Topology.update_connections.
-
-        See Also
-        --------
-        gmso.Topology.update_connections : Update all the Bonds, Angles, Dihedrals, and Impropers in the topology.
-        """
-        self.update_connections(update_types)
-
-    def update_impropers(self, update_types=False):
-        """Uses gmso.Topology.update_connections to update impropers in the topology.
-
-        This method is an alias for gmso.Topology.update_connections.
-
-        See Also
-        --------
-        gmso.Topology.update_connections : Update all the Bonds, Angles, Dihedrals, and Impropers in the topology.
-        """
-        self.update_connections(update_types)
-
     def update_connection_types(self):
         """Update the connection types based on the connection collection in the topology.
 
@@ -628,7 +552,6 @@ class Topology(object):
     def update_topology(self):
         """Update the entire topology"""
         self.update_sites()
-        self.update_connections()
         self.update_atom_types()
         self.update_connection_types()
         self.is_typed(updated=True)

--- a/gmso/tests/test_angle.py
+++ b/gmso/tests/test_angle.py
@@ -14,15 +14,8 @@ class TestAngle(BaseTest):
         site2 = Site(name='site2')
         site3 = Site(name='site3')
 
-        assert site1.n_connections == 0
-        assert site2.n_connections == 0
-        assert site3.n_connections == 0
-
         connect = Angle(connection_members=[site1, site2, site3])
 
-        assert site1.n_connections == 1
-        assert site2.n_connections == 1
-        assert site3.n_connections == 1
         assert connect.connection_type is None
 
     def test_angle_parametrized(self):
@@ -30,26 +23,17 @@ class TestAngle(BaseTest):
         site2 = Site(name='site2')
         site3 = Site(name='site3')
 
-        assert site1.n_connections == 0
-        assert site2.n_connections == 0
-        assert site3.n_connections == 0
         angle_type = AngleType()
 
         connect = Angle(connection_members=[site1, site2, site3],
                         connection_type=angle_type,
                         name='angle_name')
 
-        assert site1.n_connections == 1
-        assert site2.n_connections == 1
-        assert site3.n_connections == 1
         assert len(connect.connection_members) == 3
         assert connect.connection_type is not None
         assert connect.name == 'angle_name'
 
     def test_angle_fake(self):
-        site1 = Site(name='site1')
-        site2 = Site(name='site2')
-        site3 = Site(name='site3')
         with pytest.raises(GMSOError):
             Angle(connection_members=['fakesite1', 'fakesite2', 4.2])
 

--- a/gmso/tests/test_angle.py
+++ b/gmso/tests/test_angle.py
@@ -15,7 +15,9 @@ class TestAngle(BaseTest):
         site3 = Site(name='site3')
 
         connect = Angle(connection_members=[site1, site2, site3])
-
+        assert site1 in connect.connection_members
+        assert site2 in connect.connection_members
+        assert site3 in connect.connection_members
         assert connect.connection_type is None
 
     def test_angle_parametrized(self):

--- a/gmso/tests/test_bond.py
+++ b/gmso/tests/test_bond.py
@@ -13,36 +13,25 @@ class TestBond(BaseTest):
         site1 = Site(name='site1')
         site2 = Site(name='site2')
 
-        assert site1.n_connections == 0
-        assert site2.n_connections == 0
-
         connect = Bond(connection_members=[site1, site2])
 
-        assert site1.n_connections == 1
-        assert site2.n_connections == 1
         assert connect.connection_type is None
 
     def test_bond_parametrized(self):
         site1 = Site(name='site1')
         site2 = Site(name='site2')
 
-        assert site1.n_connections == 0
-        assert site2.n_connections == 0
         bond_type = BondType()
 
         connect = Bond(connection_members=[site1, site2],
                        connection_type=bond_type,
                        name='bond_name')
 
-        assert site1.n_connections == 1
-        assert site2.n_connections == 1
         assert len(connect.connection_members) == 2
         assert connect.connection_type is not None
         assert connect.name == 'bond_name'
 
     def test_bond_fake(self):
-        site1 = Site(name='site1')
-        site2 = Site(name='site2')
         with pytest.raises(GMSOError):
             Bond(connection_members=['fakesite1', 'fakesite2'])
 

--- a/gmso/tests/test_bond.py
+++ b/gmso/tests/test_bond.py
@@ -14,7 +14,8 @@ class TestBond(BaseTest):
         site2 = Site(name='site2')
 
         connect = Bond(connection_members=[site1, site2])
-
+        assert site1 in connect.connection_members
+        assert site2 in connect.connection_members
         assert connect.connection_type is None
 
     def test_bond_parametrized(self):
@@ -28,6 +29,8 @@ class TestBond(BaseTest):
                        name='bond_name')
 
         assert len(connect.connection_members) == 2
+        assert site1 in connect.connection_members
+        assert site2 in connect.connection_members
         assert connect.connection_type is not None
         assert connect.name == 'bond_name'
 

--- a/gmso/tests/test_connection.py
+++ b/gmso/tests/test_connection.py
@@ -12,21 +12,14 @@ class TestConnection(BaseTest):
         site1 = Site(name='site1')
         site2 = Site(name='site2')
 
-        assert site1.n_connections == 0
-        assert site2.n_connections == 0
-
         connect = Connection(connection_members=[site1, site2])
 
-        assert site1.n_connections == 1
-        assert site2.n_connections == 1
         assert connect.connection_type is None
 
     def test_connection_parametrized(self):
         site1 = Site(name='site1')
         site2 = Site(name='site2')
 
-        assert site1.n_connections == 0
-        assert site2.n_connections == 0
         c_type = Potential()
         name = 'name'
 
@@ -34,15 +27,11 @@ class TestConnection(BaseTest):
                              connection_type=c_type,
                              name=name)
 
-        assert site1.n_connections == 1
-        assert site2.n_connections == 1
         assert len(connect.connection_members) == 2
         assert connect.connection_type is not None
         assert connect.name == name
 
     def test_connection_fake(self):
-        site1 = Site(name='site1')
-        site2 = Site(name='site2')
         with pytest.raises(GMSOError):
             Connection(connection_members=['fakesite1', 'fakesite2'])
 

--- a/gmso/tests/test_dihedral.py
+++ b/gmso/tests/test_dihedral.py
@@ -15,17 +15,8 @@ class TestDihedral(BaseTest):
         site3 = Site(name='site3')
         site4 = Site(name='site4')
 
-        assert site1.n_connections == 0
-        assert site2.n_connections == 0
-        assert site3.n_connections == 0
-        assert site4.n_connections == 0
-
         connect = Dihedral(connection_members=[site1, site2, site3, site4])
 
-        assert site1.n_connections == 1
-        assert site2.n_connections == 1
-        assert site3.n_connections == 1
-        assert site4.n_connections == 1
         assert connect.connection_type is None
 
     def test_dihedral_parametrized(self):
@@ -34,29 +25,17 @@ class TestDihedral(BaseTest):
         site3 = Site(name='site3')
         site4 = Site(name='site4')
 
-        assert site1.n_connections == 0
-        assert site2.n_connections == 0
-        assert site3.n_connections == 0
-        assert site4.n_connections == 0
         dihedral_type = DihedralType()
 
         connect = Dihedral(connection_members=[site1, site2, site3, site4],
-                        connection_type=dihedral_type,
-                        name='dihedral_name')
+                           connection_type=dihedral_type,
+                           name='dihedral_name')
 
-        assert site1.n_connections == 1
-        assert site2.n_connections == 1
-        assert site3.n_connections == 1
-        assert site4.n_connections == 1
         assert len(connect.connection_members) == 4
         assert connect.connection_type is not None
         assert connect.name == 'dihedral_name'
 
     def test_dihedral_fake(self):
-        site1 = Site(name='site1')
-        site2 = Site(name='site2')
-        site3 = Site(name='site3')
-        site4 = Site(name='site4')
         with pytest.raises(GMSOError):
             Dihedral(connection_members=['fakesite1', 'fakesite2', 4.2])
 

--- a/gmso/tests/test_dihedral.py
+++ b/gmso/tests/test_dihedral.py
@@ -16,7 +16,10 @@ class TestDihedral(BaseTest):
         site4 = Site(name='site4')
 
         connect = Dihedral(connection_members=[site1, site2, site3, site4])
-
+        assert site1 in connect.connection_members
+        assert site2 in connect.connection_members
+        assert site3 in connect.connection_members
+        assert site4 in connect.connection_members
         assert connect.connection_type is None
 
     def test_dihedral_parametrized(self):
@@ -32,6 +35,10 @@ class TestDihedral(BaseTest):
                            name='dihedral_name')
 
         assert len(connect.connection_members) == 4
+        assert site1 in connect.connection_members
+        assert site2 in connect.connection_members
+        assert site3 in connect.connection_members
+        assert site4 in connect.connection_members
         assert connect.connection_type is not None
         assert connect.name == 'dihedral_name'
 

--- a/gmso/tests/test_improper.py
+++ b/gmso/tests/test_improper.py
@@ -17,6 +17,11 @@ class TestImproper(BaseTest):
 
         connect = Improper(connection_members=[site1, site2, site3, site4])
 
+        assert site1 in connect.connection_members
+        assert site2 in connect.connection_members
+        assert site3 in connect.connection_members
+        assert site4 in connect.connection_members
+
         assert connect.connection_type is None
 
     def test_improper_parametrized(self):
@@ -32,6 +37,10 @@ class TestImproper(BaseTest):
                         name='improper_name')
 
         assert len(connect.connection_members) == 4
+        assert site1 in connect.connection_members
+        assert site2 in connect.connection_members
+        assert site3 in connect.connection_members
+        assert site4 in connect.connection_members
         assert connect.connection_type is not None
         assert connect.name == 'improper_name'
 

--- a/gmso/tests/test_improper.py
+++ b/gmso/tests/test_improper.py
@@ -15,17 +15,8 @@ class TestImproper(BaseTest):
         site3 = Site(name='site3')
         site4 = Site(name='site4')
 
-        assert site1.n_connections == 0
-        assert site2.n_connections == 0
-        assert site3.n_connections == 0
-        assert site4.n_connections == 0
-
         connect = Improper(connection_members=[site1, site2, site3, site4])
 
-        assert site1.n_connections == 1
-        assert site2.n_connections == 1
-        assert site3.n_connections == 1
-        assert site4.n_connections == 1
         assert connect.connection_type is None
 
     def test_improper_parametrized(self):
@@ -34,20 +25,12 @@ class TestImproper(BaseTest):
         site3 = Site(name='site3')
         site4 = Site(name='site4')
 
-        assert site1.n_connections == 0
-        assert site2.n_connections == 0
-        assert site3.n_connections == 0
-        assert site4.n_connections == 0
         improper_type = ImproperType()
 
         connect = Improper(connection_members=[site1, site2, site3, site4],
                         connection_type=improper_type,
                         name='improper_name')
 
-        assert site1.n_connections == 1
-        assert site2.n_connections == 1
-        assert site3.n_connections == 1
-        assert site4.n_connections == 1
         assert len(connect.connection_members) == 4
         assert connect.connection_type is not None
         assert connect.name == 'improper_name'

--- a/gmso/tests/test_site.py
+++ b/gmso/tests/test_site.py
@@ -72,24 +72,3 @@ class TestSite(BaseTest):
         assert ref != same_site
         assert ref != other_pos
         assert ref != other_name
-
-    def test_add_connection_redundant(self):
-        site1, site2, site3 = (Site(), Site(), Site())
-        bond1, bond2, bond3 = (Bond([site1, site2]), Bond([site2, site3]), Bond([site1, site3]))
-        assert site1.n_connections == site2.n_connections == site3.n_connections == 2
-        site1.add_connection(bond1)
-        site1.add_connection(bond3)
-        site2.add_connection(bond1)
-        site2.add_connection(bond2)
-        site3.add_connection(bond3)
-        site3.add_connection(bond2)
-        assert site1.n_connections == site2.n_connections == site3.n_connections == 2
-
-    def test_add_connection_non_member(self):
-        site1, site2, site3 = (Site(), Site(), Site())
-        bond1, bond2, bond3 = (Bond([site1, site2]), Bond([site2, site3]), Bond([site1, site3]))
-        assert site1.n_connections == site2.n_connections == site3.n_connections == 2
-        with pytest.raises(GMSOError):
-            site3.add_connection(bond1)
-            site2.add_connection(bond3)
-            site1.add_connection(bond2)

--- a/gmso/tests/test_top.py
+++ b/gmso/tests/test_top.py
@@ -57,7 +57,6 @@ class TestTop(BaseTest):
         for bond in top.bonds:
             bond.bond_type = bond.connection_type = ff.bond_types['opls_111~opls_112']
 
-        top.update_bonds()
         top.update_bond_types()
 
         for subtop in top.subtops:
@@ -68,7 +67,6 @@ class TestTop(BaseTest):
             )
             top.add_connection(angle)
 
-        top.update_angles()
         top.update_angle_types()
 
         write_top(top, 'water.top')


### PR DESCRIPTION
* As discussed over #385, #387, #389, refactor sites such that they are not able to reference their connections
* Refactor tests such that they are passing