### PR TITLE
Allow topology to update single atomtype for a site (Closes #392)

### DIFF
--- a/gmso/core/atom_type.py
+++ b/gmso/core/atom_type.py
@@ -6,6 +6,7 @@ from gmso.core.potential import Potential
 from gmso.utils.misc import unyt_to_hashable
 from gmso.utils.decorators import confirm_dict_existence
 from gmso.utils._constants import ATOM_TYPE_DICT
+from gmso.exceptions import GMSOError
 
 
 class AtomType(Potential):
@@ -180,6 +181,48 @@ class AtomType(Potential):
     def __repr__(self):
         desc = "<AtomType {}, id {}>".format(self._name, id(self))
         return desc
+
+    def as_dict(self):
+        props_dict = super().as_dict()
+        props_dict.update({
+            'charge': self.charge,
+            'mass': self.mass,
+            'atomclass': self.atomclass,
+            'doi': self.doi,
+            'overrides': self.overrides,
+            'description': self.description,
+            'definition': self.definition,
+        })
+        props_dict.pop('template')
+        return props_dict
+
+    @classmethod
+    def return_copy(cls, atom_type, **kwargs):
+        """Returns a new AtomType that is a copy of atom_type
+
+        This method takes in an gmso.core.AtomType object and returns a copy
+        of the `atom_type` with changed properties (provided as keyword arguments) (optional).
+
+        Parameters
+        ----------
+        atom_type : gmso.core.AtomType
+            The AtomType object to return the copy of
+        **kwargs
+            The keyword arguments to the new AtomType constructor returned
+
+        Returns
+        -------
+        gmso.core.AtomType
+                A copy of the atomType passed as input
+        """
+        if not isinstance(atom_type, cls):
+            raise TypeError(f'Object {type(atom_type).__name__} is not of type AtomType.')
+        props_dict = atom_type.as_dict()
+        for kwarg in kwargs:
+            if kwarg not in props_dict:
+                raise GMSOError(f'Cannot set property {kwarg} for an AtomType')
+        props_dict.update(kwargs)
+        return cls(**props_dict)
 
 
 def _validate_charge(charge):

--- a/gmso/core/potential.py
+++ b/gmso/core/potential.py
@@ -209,6 +209,16 @@ class Potential(object):
         desc = "<Potential {}, id {}>".format(self._name, id(self))
         return desc
 
+    def as_dict(self):
+        return {
+            'name': self.name,
+            'parameters': self.parameters,
+            'independent_variables': self.independent_variables,
+            'template': self.template,
+            'expression': self.expression,
+            'topology': self.topology
+        }
+
     @classmethod
     def from_template(cls, potential_template, parameters, topology=None):
         """Create a potential object from the potential_template

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -377,10 +377,17 @@ class Topology(object):
 
         Examples
         ---------
-                >>> from gmso import Topology
-                >>> top = Topology()
-                >>> site1 = Site()
+                >>> site = Site()
                 >>> site2 = Site()
+                >>> atom_type = AtomType()
+                >>> site.atom_type = atom_type
+                >>> site2.atom_type = atom_type
+                >>> top = Topology()
+                >>> top.add_site(site)
+                >>> top.add_site(site2)
+                >>> top.change_atom_type_properties(site2, should_propagate=False, name='AtomType2', charge=2.0)
+                >>> print(site2.atom_type.charge, site.atom_type.charge)
+
         Parameters
         ----------
         site : gmso.core.Site

--- a/gmso/tests/test_atom_type.py
+++ b/gmso/tests/test_atom_type.py
@@ -7,6 +7,7 @@ from gmso.core.site import Site
 from gmso.core.topology import Topology
 from gmso.tests.base_test import BaseTest
 from gmso.utils.testing import allclose
+from gmso.exceptions import GMSOError
 
 
 class TestAtomType(BaseTest):
@@ -213,3 +214,31 @@ class TestAtomType(BaseTest):
         assert len(top.atom_types) == 1
         assert top.n_sites == 1000
 
+    def test_copy_no_change(self):
+        atom_type = AtomType()
+        atom_type_copy = AtomType.return_copy(atom_type)
+        assert atom_type == atom_type_copy
+        assert id(atom_type) != id(atom_type_copy)
+
+    def test_copy_with_change(self):
+        atom_type = AtomType('AtomType')
+        atom_type_copy = AtomType.return_copy(atom_type, name='AtomType2')
+        assert atom_type != atom_type_copy
+
+    def test_copy_non_atom_type(self):
+        a = object()
+        with pytest.raises(TypeError) as type_error:
+            assert AtomType.return_copy(a)
+        assert f'Object {type(a).__name__} is not of type AtomType.' in str(type_error)
+
+    def test_atom_type_copy_non_existent_property(self):
+        atom_type = AtomType(name='AtomType1')
+        with pytest.raises(GMSOError) as e:
+            AtomType.return_copy(atom_type, non_existent_property='1')
+        assert 'Cannot set property non_existent_property for an AtomType' in str(e)
+
+    def test_as_dict(self):
+        props_dict = AtomType().as_dict()
+        assert 'name' in props_dict
+        assert 'charge' in props_dict
+        assert 'description' in props_dict


### PR DESCRIPTION
As discussed in #392, this PR adds a  method called `change_atom_type_properties` in topology with the following signature:
```py
change_atom_type_properties(site, should_propoagate=False, **kwargs)
```
This method takes in an individual site and changes the atomtype properties for it (provided via) kwargs. Flag `should_propagate` can be used to control whether the property changes are for this site only (default behaviour) or the entire topology.
If this method passes the scrutiny and becomes usable, this will close #392 and similar extensions can be provided to hold `BondType/AngleType/DihedralType/ImproperType` changes from the topology. 
 One example snippet to test this branch is given below:
```py
    from gmso import Topology, Site, AtomType
    site = Site()
    site2 = Site()
    atom_type = AtomType()
    site.atom_type = atom_type
    site2.atom_type = atom_type
    top = Topology()
    top.add_site(site)
    top.add_site(site2)
    top.change_atom_type_properties(site2, should_propagate=False,
                                    name='AtomType2',
                                    charge=2.0)
    print(site2.atom_type.charge, site.atom_type.charge)
```