### PR TITLE
Fix indexing of connection types in `update_connection_types`

### DIFF
--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -504,13 +504,13 @@ class Topology(object):
                     self._bond_types_idx[c.connection_type] = len(self._bond_types) - 1
                 if isinstance(c.connection_type, AngleType):
                     self._angle_types[c.connection_type] = c.connection_type
-                    self._angle_types_idx[c.connection_type] = len(self._bond_types) - 1
+                    self._angle_types_idx[c.connection_type] = len(self._angle_types) - 1
                 if isinstance(c.connection_type, DihedralType):
                     self._dihedral_types[c.connection_type] = c.connection_type
-                    self._dihedral_types_idx[c.connection_type] = len(self._bond_types) - 1
+                    self._dihedral_types_idx[c.connection_type] = len(self._dihedral_types) - 1
                 if isinstance(c.connection_type, ImproperType):
                     self._improper_types[c.connection_type] = c.connection_type
-                    self._improper_types_idx[c.connection_type] = len(self._bond_types) - 1
+                    self._improper_types_idx[c.connection_type] = len(self._improper_types) - 1
             elif c.connection_type in self.connection_types:
                 if isinstance(c.connection_type, BondType):
                     c.connection_type = self._bond_types[c.connection_type]

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -479,8 +479,8 @@ class TestTopology(BaseTest):
         assert typed_methylnitroaniline.get_index(typed_methylnitroaniline.bonds[0].connection_type) != 0
 
     def test_topology_get_index_angle_type(self, typed_chloroethanol):
-        assert typed_chloroethanol.get_index(typed_chloroethanol.angles[0].connection_type)
-        assert typed_chloroethanol.get_index(typed_chloroethanol.angles[5].connection_type)
+        assert typed_chloroethanol.get_index(typed_chloroethanol.angles[0].connection_type) == 0
+        assert typed_chloroethanol.get_index(typed_chloroethanol.angles[5].connection_type) == 1
 
     def test_topology_get_index_angle_type_after_change(self, typed_methylnitroaniline):
         angle_type_to_test = typed_methylnitroaniline.angles[0].connection_type

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -487,3 +487,13 @@ class TestTopology(BaseTest):
         prev_idx = typed_methylnitroaniline.get_index(angle_type_to_test)
         typed_methylnitroaniline.angles[0].connection_type.name = 'changed name'
         assert typed_methylnitroaniline.get_index(angle_type_to_test) != prev_idx
+
+    def test_topology_get_index_dihedral_type(self, typed_chloroethanol):
+        assert typed_chloroethanol.get_index(typed_chloroethanol.dihedrals[0].connection_type) == 0
+        assert typed_chloroethanol.get_index(typed_chloroethanol.dihedrals[5].connection_type) == 3
+
+    def test_topology_get_index_dihedral_type_after_change(self, typed_methylnitroaniline):
+        dihedral_type_to_test = typed_methylnitroaniline.dihedrals[0].connection_type
+        prev_idx = typed_methylnitroaniline.get_index(dihedral_type_to_test)
+        typed_methylnitroaniline.dihedrals[0].connection_type.name = 'changed name'
+        assert typed_methylnitroaniline.get_index(dihedral_type_to_test) != prev_idx


### PR DESCRIPTION
Originally added in #367, dictionaries of connection types were created to keep track of indexing.  The `_connection_types_idx` for angles and dihedrals are being set by `len(self._bond_types)` which seems to just be a typo.  This PR fixes the indexing for these connection types.