### PR TITLE
Module gmso.abc

### DIFF
--- a/gmso/__init__.py
+++ b/gmso/__init__.py
@@ -13,7 +13,7 @@ from .core.improper import Improper
 from .core.forcefield import ForceField
 
 
-from .core.potential import Potential
+from .core.potential import ParametricPotential
 from .core.atom_type import AtomType
 from .core.bond_type import BondType
 from .core.angle_type import AngleType

--- a/gmso/abc/abstract_potential.py
+++ b/gmso/abc/abstract_potential.py
@@ -1,0 +1,120 @@
+from abc import ABC, abstractmethod
+
+import sympy
+
+
+class AbstractPotential(ABC):
+    """An abstract potential class
+
+    Potential stores a general interaction between components of a chemical
+    topology that can be specified by a mathematical expression. The functional
+    form of the potential is stored as a `sympy` expression and the parameters
+    are stored explicitly. This class is agnostic to the instantiation of the
+    potential, which can be e.g. a non-bonded potential, a bonded potential, an
+    angle potential, a dihedral potential, etc. and is designed to be inherited
+    by classes that represent these potentials.
+
+    Parameters
+    ----------
+    name : str, default="Potential"
+        The name of the potential.
+    expression : str or sympy.Expr, default='a*x+b'
+        The mathematical expression describing the functional form of the
+        potential.
+    independent_variables : str or sympy.Symbol or list or set thereof
+        The independent variables in the expression of the potential.
+    """
+    __slots__ = (
+        '_name',
+        '_expression',
+        '_independent_variables'
+    )
+
+    @abstractmethod
+    def __init__(self,
+                 name='Potential',
+                 expression=None,
+                 independent_variables=None):
+        if expression is None:
+            assert independent_variables is None,\
+                'Cannot specify an independent variable when expression is not provided.'
+            expression, independent_variables = self._default_expression()
+
+        if independent_variables is None:
+            assert expression is None,\
+                'Cannot specify an expression when independent variable is not provided.'
+            expression, independent_variables = self._default_expression()
+
+        self._name = name
+        self._expression = self._validate_expression(expression)
+        self._independent_variables = self._validate_independent_variables(independent_variables)
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, new_name):
+        self._name = new_name
+
+    @property
+    def expression(self):
+        return self._expression
+
+    @expression.setter
+    def expression(self, expression):
+        self._expression = self._validate_expression(expression)
+
+    @property
+    def independent_variables(self):
+        return self._independent_variables
+
+    @independent_variables.setter
+    def independent_variables(self, independent_variables):
+        self._independent_variables = self._validate_independent_variables(independent_variables)
+
+    @abstractmethod
+    def set_expression(self, **kwargs):
+        raise NotImplementedError
+
+    @staticmethod
+    def _validate_independent_variables(indep_vars):
+        """Check to see that independent_variables is a set of valid sympy symbols"""
+        if isinstance(indep_vars, str):
+            indep_vars = {sympy.symbols(indep_vars)}
+        elif isinstance(indep_vars, sympy.symbol.Symbol):
+            indep_vars = {indep_vars}
+        elif isinstance(indep_vars, (list, set)):
+            if all([isinstance(val, sympy.symbol.Symbol) for val in indep_vars]):
+                pass
+            elif all([isinstance(val, str) for val in indep_vars]):
+                indep_vars = set([sympy.symbols(val) for val in indep_vars])
+            else:
+                raise ValueError('`independent_variables` argument was a list '
+                                 'or set of mixed variables. Please enter a '
+                                 'list or set of either only strings or only '
+                                 'sympy symbols')
+        else:
+            raise ValueError("Please enter a string, sympy expression, "
+                             "or list or set thereof for independent_variables")
+
+        return indep_vars
+
+    @staticmethod
+    def _validate_expression(expression):
+        """Check to see that an expression is a valid sympy expression"""
+        if expression is None or isinstance(expression, sympy.Expr):
+            pass
+        elif isinstance(expression, str):
+            expression = sympy.sympify(expression)
+        else:
+            raise ValueError("Please enter a string, sympy expression, "
+                             "or None for expression")
+
+        return expression
+
+    @staticmethod
+    def _default_expression():
+        expression = sympy.sympify('a*x+b')
+        independent_variables = {'x'}
+        return expression, independent_variables

--- a/gmso/core/angle_type.py
+++ b/gmso/core/angle_type.py
@@ -62,13 +62,9 @@ class AngleType(ParametricPotential):
             member_types = list()
         super(AngleType, self).__init__(name=name, expression=expression,
                                         parameters=parameters, independent_variables=independent_variables,
-                                        topology=topology)
+                                        topology=topology,
+                                        dict_ref=ANGLE_TYPE_DICT)
         self._member_types = _validate_three_member_type_names(member_types)
-        self._set_ref = ANGLE_TYPE_DICT
-
-    @property
-    def set_ref(self):
-        return self._set_ref
 
     @property
     def member_types(self):

--- a/gmso/core/angle_type.py
+++ b/gmso/core/angle_type.py
@@ -1,13 +1,13 @@
 import warnings
 import unyt as u
 
-from gmso.core.potential import Potential
+from gmso.core.potential import ParametricPotential
 from gmso.exceptions import GMSOError
 from gmso.utils.decorators import confirm_dict_existence
 from gmso.utils._constants import ANGLE_TYPE_DICT
 
 
-class AngleType(Potential):
+class AngleType(ParametricPotential):
     """A descripton of the interaction between 3 bonded partners.
 
     This is a subclass of the gmso.core.Potential superclass.

--- a/gmso/core/atom_type.py
+++ b/gmso/core/atom_type.py
@@ -2,13 +2,13 @@ import warnings
 
 import unyt as u
 
-from gmso.core.potential import Potential
+from gmso.core.potential import ParametricPotential
 from gmso.utils.misc import unyt_to_hashable
 from gmso.utils.decorators import confirm_dict_existence
 from gmso.utils._constants import ATOM_TYPE_DICT
 
 
-class AtomType(Potential):
+class AtomType(ParametricPotential):
     """A description of non-bonded interacitons between sites.
 
     This is a subclass of the gmso.core.Potential superclass.

--- a/gmso/core/atom_type.py
+++ b/gmso/core/atom_type.py
@@ -50,10 +50,8 @@ class AtomType(ParametricPotential):
         Set of other atom types that this atom type overrides
     definition : str
         SMARTS string defining this atom type
-    topology: gmso.core.Topology, default=None
+    topology : gmso.core.Topology, default=None
         The topology of which this atom_type is a part of, default=None
-    set_ref: str
-        The string name of the bookkeeping set in gmso class.
 
     """
 
@@ -81,7 +79,8 @@ class AtomType(ParametricPotential):
             expression=expression,
             parameters=parameters,
             independent_variables=independent_variables,
-            topology=topology)
+            topology=topology,
+            dict_ref=ATOM_TYPE_DICT)
         self._mass = _validate_mass(mass)
         self._charge = _validate_charge(charge)
         self._atomclass = _validate_str(atomclass)
@@ -89,12 +88,7 @@ class AtomType(ParametricPotential):
         self._overrides = _validate_set(overrides)
         self._description = _validate_str(description)
         self._definition = _validate_str(definition)
-        self._set_ref = ATOM_TYPE_DICT
         self._validate_expression_parameters()
-
-    @property
-    def set_ref(self):
-        return self._set_ref
 
     @property
     def charge(self):

--- a/gmso/core/bond_type.py
+++ b/gmso/core/bond_type.py
@@ -1,13 +1,13 @@
 import unyt as u
 import warnings
 
-from gmso.core.potential import Potential
+from gmso.core.potential import ParametricPotential
 from gmso.utils.decorators import confirm_dict_existence
 from gmso.exceptions import GMSOError
 from gmso.utils._constants import BOND_TYPE_DICT
 
 
-class BondType(Potential):
+class BondType(ParametricPotential):
     """A descripton of the interaction between 2 bonded partners.
 
     This is a subclass of the gmso.core.Potential superclass.

--- a/gmso/core/bond_type.py
+++ b/gmso/core/bond_type.py
@@ -45,8 +45,7 @@ class BondType(ParametricPotential):
                  parameters=None,
                  independent_variables=None,
                  member_types=None,
-                 topology=None,
-                 set_ref='bond_type_set'):
+                 topology=None):
         if parameters is None:
             parameters = {
                 'k': 1000 * u.Unit('kJ / (nm**2)'),
@@ -60,13 +59,9 @@ class BondType(ParametricPotential):
 
         super(BondType, self).__init__(name=name, expression=expression,
                                        parameters=parameters, independent_variables=independent_variables,
-                                       topology=topology)
-        self._set_ref = BOND_TYPE_DICT
+                                       topology=topology,
+                                       dict_ref=BOND_TYPE_DICT)
         self._member_types = _validate_two_member_type_names(member_types)
-
-    @property
-    def set_ref(self):
-        return self._set_ref
 
     @property
     def member_types(self):

--- a/gmso/core/connection.py
+++ b/gmso/core/connection.py
@@ -1,5 +1,5 @@
 import warnings
-from gmso.core.potential import Potential
+from gmso.core.potential import ParametricPotential
 from gmso.core.site import Site
 from gmso.exceptions import GMSOError
 
@@ -15,7 +15,7 @@ class Connection(object):
 
     connection_members : list of gmso.Site
         A list of constituents in this connection, in order.
-    connection_type : gmso.Potential
+    connection_type : gmso.ParametricPotential
         An instance of gmso.Potential that describes the potential, function and parameters of this interaction
     name : str, optional, default="Connection"
         A unique name for the connection. Used for writing hoomdxml bonds/angles/dihedrals.
@@ -84,7 +84,7 @@ def _validate_connection_type(c_type):
     """Ensure given connection_type is the gmso.Potential"""
     if c_type is None:
         warnings.warn("Non-parametrized Connection detected")
-    elif not isinstance(c_type, Potential):
+    elif not isinstance(c_type, ParametricPotential):
         raise GMSOError("Supplied non-Potential {}".format(c_type))
     return c_type
 

--- a/gmso/core/dihedral_type.py
+++ b/gmso/core/dihedral_type.py
@@ -1,11 +1,11 @@
 import warnings
 import unyt as u
 
-from gmso.core.potential import Potential
+from gmso.core.potential import ParametricPotential
 from gmso.exceptions import GMSOError
 from gmso.utils._constants import DIHEDRAL_TYPE_DICT
 
-class DihedralType(Potential):
+class DihedralType(ParametricPotential):
     """A descripton of the interaction between 4 bonded partners.
 
     This is a subclass of the gmso.core.Potential superclass.

--- a/gmso/core/dihedral_type.py
+++ b/gmso/core/dihedral_type.py
@@ -52,8 +52,7 @@ class DihedralType(ParametricPotential):
                  parameters=None,
                  independent_variables=None,
                  member_types=None,
-                 topology=None,
-                 set_ref='dihedral_type_set'):
+                 topology=None):
         if parameters is None:
             parameters = {
                 'k': 1000 * u.Unit('kJ / (deg**2)'),
@@ -67,9 +66,10 @@ class DihedralType(ParametricPotential):
             member_types = list()
 
         super(DihedralType, self).__init__(name=name, expression=expression,
-                                           parameters=parameters, independent_variables=independent_variables,
-                                           topology=topology)
-        self._set_ref = DIHEDRAL_TYPE_DICT
+                                           parameters=parameters,
+                                           independent_variables=independent_variables,
+                                           topology=topology,
+                                           dict_ref=DIHEDRAL_TYPE_DICT)
         self._member_types = _validate_four_member_type_names(member_types)
 
     @property

--- a/gmso/core/improper_type.py
+++ b/gmso/core/improper_type.py
@@ -72,13 +72,9 @@ class ImproperType(ParametricPotential):
 
         super(ImproperType, self).__init__(name=name, expression=expression,
                                            parameters=parameters, independent_variables=independent_variables,
-                                           topology=topology)
-        self._set_ref = IMPROPER_TYPE_DICT
+                                           topology=topology,
+                                           dict_ref=IMPROPER_TYPE_DICT)
         self._member_types = _validate_four_member_type_names(member_types)
-
-    @property
-    def set_ref(self):
-        return self._set_ref
 
     @property
     def member_types(self):

--- a/gmso/core/improper_type.py
+++ b/gmso/core/improper_type.py
@@ -1,11 +1,11 @@
 import warnings
 import unyt as u
 
-from gmso.core.potential import Potential
+from gmso.core.potential import ParametricPotential
 from gmso.exceptions import GMSOError
 from gmso.utils._constants import IMPROPER_TYPE_DICT
 
-class ImproperType(Potential):
+class ImproperType(ParametricPotential):
     """A descripton of the interaction between 4 bonded partners.
 
     This is a subclass of the gmso.core.Potential superclass.

--- a/gmso/core/potential.py
+++ b/gmso/core/potential.py
@@ -47,7 +47,7 @@ class ParametricPotential(AbstractPotential):
                  parameters=None,
                  independent_variables=None,
                  topology=None,
-                 set_ref=None
+                 dict_ref=None
                  ):
         super(ParametricPotential, self).__init__(
             name=name,
@@ -61,13 +61,8 @@ class ParametricPotential(AbstractPotential):
 
         self._parameters = _validate_parameters(parameters)
         self._validate_expression_parameters()
-
-        if topology is not None:
-            self._topology = topology
-            self._dict_ref = set_ref
-        else:
-            self._topology = None
-            self._dict_ref = None
+        self._topology = topology
+        self._dict_ref = dict_ref
 
     @AbstractPotential.name.setter
     @confirm_dict_existence
@@ -104,6 +99,10 @@ class ParametricPotential(AbstractPotential):
     @topology.setter
     def topology(self, top):
         self._topology = top
+
+    @property
+    def dict_ref(self):
+        return self._dict_ref
 
     @confirm_dict_existence
     def set_expression(self,

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -149,7 +149,7 @@ class Topology(object):
         self._improper_types = {}
         self._improper_types_idx = {}
         self._combining_rule = 'lorentz'
-        self._set_refs = {
+        self._dict_refs = {
             ATOM_TYPE_DICT: self._atom_types,
             BOND_TYPE_DICT: self._bond_types,
             ANGLE_TYPE_DICT: self._angle_types,
@@ -678,7 +678,7 @@ class Topology(object):
             raise GMSOError(f'cannot reindex {ref}. It should be one of '
                             f'{ANGLE_TYPE_DICT}, {BOND_TYPE_DICT}, '
                             f'{ANGLE_TYPE_DICT}, {DIHEDRAL_TYPE_DICT}, {IMPROPER_TYPE_DICT}')
-        for i, ref_member in enumerate(self._set_refs[ref].keys()):
+        for i, ref_member in enumerate(self._dict_refs[ref].keys()):
             self._index_refs[ref][ref_member] = i
 
     def __repr__(self):

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -9,7 +9,7 @@ from gmso.core.bond import Bond
 from gmso.core.angle import Angle
 from gmso.core.dihedral import Dihedral
 from gmso.core.improper import Improper
-from gmso.core.potential import Potential
+from gmso.core.potential import ParametricPotential
 from gmso.core.atom_type import AtomType
 from gmso.core.bond_type import BondType
 from gmso.core.angle_type import AngleType
@@ -493,7 +493,7 @@ class Topology(object):
         for c in self.connections:
             if c.connection_type is None:
                 warnings.warn('Non-parametrized Connection {} detected'.format(c))
-            elif not isinstance(c.connection_type, Potential):
+            elif not isinstance(c.connection_type, ParametricPotential):
                 raise GMSOError('Non-Potential {} found'
                                     'in Connection {}'.format(c.connection_type, c))
             elif c.connection_type not in self._connection_types:

--- a/gmso/lib/potential_templates.py
+++ b/gmso/lib/potential_templates.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from collections import namedtuple
 
 from gmso.abc.abstract_potential import AbstractPotential
 from gmso.utils.singleton import Singleton

--- a/gmso/lib/potential_templates.py
+++ b/gmso/lib/potential_templates.py
@@ -1,7 +1,8 @@
 import json
 from pathlib import Path
+from collections import namedtuple
 
-from gmso.core.potential import Potential
+from gmso.abc.abstract_potential import AbstractPotential
 from gmso.utils.singleton import Singleton
 from gmso.exceptions import GMSOError
 
@@ -24,21 +25,44 @@ def _load_template_json(item, json_dir=JSON_DIR):
         return potential_dict
 
 
-class PotentialTemplate(Potential):
+class PotentialTemplate(AbstractPotential):
+    """A Template Potential class
+
+    This class inherits from the abstract Potential class and is an immutable,
+    readonly container for storing expressions and independent variables for a
+    potential. `ParametricPotential.from_template`, this can be used to form a
+    meaningful parametric Potential Type using objects from this instance.
+    """
     def __init__(self,
                  name='PotentialTemplate',
                  expression='4*epsilon*((sigma/r)**12 - (sigma/r)**6)',
-                 independent_variables='r',
-                 template=True):
+                 independent_variables='r'):
         if not isinstance(independent_variables, set):
             independent_variables = set(independent_variables.split(','))
 
         super(PotentialTemplate, self).__init__(
             name=name,
             expression=expression,
-            independent_variables=independent_variables,
-            template=template,
-        )
+            independent_variables=independent_variables)
+
+    @AbstractPotential.name.setter
+    def name(self, name):
+        raise AttributeError('Properties for a potential template cannot be changed')
+
+    @AbstractPotential.expression.setter
+    def expression(self):
+        raise AttributeError('Properties for a potential template cannot be changed')
+
+    @AbstractPotential.independent_variables.setter
+    def independent_variables(self):
+        raise AttributeError('Properties for a potential template cannot be changed')
+
+    def set_expression(self, **kwargs):
+        raise NotImplementedError
+
+    def __repr__(self):
+        desc = "<PotentialTemplate {}, id {}>".format(self._name, id(self))
+        return desc
 
 
 class PotentialTemplateLibrary(Singleton):

--- a/gmso/lib/potential_templates.py
+++ b/gmso/lib/potential_templates.py
@@ -49,11 +49,11 @@ class PotentialTemplate(AbstractPotential):
         raise AttributeError('Properties for a potential template cannot be changed')
 
     @AbstractPotential.expression.setter
-    def expression(self):
+    def expression(self, expression):
         raise AttributeError('Properties for a potential template cannot be changed')
 
     @AbstractPotential.independent_variables.setter
-    def independent_variables(self):
+    def independent_variables(self, independent_variables):
         raise AttributeError('Properties for a potential template cannot be changed')
 
     def set_expression(self, **kwargs):

--- a/gmso/tests/test_connection.py
+++ b/gmso/tests/test_connection.py
@@ -1,7 +1,7 @@
 import pytest
 
 from gmso.core.connection import Connection
-from gmso.core.potential import Potential
+from gmso.core.potential import ParametricPotential
 from gmso.core.site import Site
 from gmso.tests.base_test import BaseTest
 from gmso.exceptions import GMSOError
@@ -27,7 +27,7 @@ class TestConnection(BaseTest):
 
         assert site1.n_connections == 0
         assert site2.n_connections == 0
-        c_type = Potential()
+        c_type = ParametricPotential()
         name = 'name'
 
         connect = Connection(connection_members=[site1, site2],

--- a/gmso/tests/test_potential.py
+++ b/gmso/tests/test_potential.py
@@ -2,7 +2,7 @@ import unyt as u
 import sympy
 import pytest
 
-from gmso.core.potential import Potential
+from gmso.core.potential import ParametricPotential
 from gmso.tests.base_test import BaseTest
 from gmso.utils.testing import allclose
 from gmso.lib.potential_templates import PotentialTemplateLibrary
@@ -11,7 +11,7 @@ from gmso.exceptions import GMSOError
 
 class TestPotential(BaseTest):
     def test_new_potential(self):
-        new_potential = Potential(
+        new_potential = ParametricPotential(
             name='mypotential',
             expression='a*x+b',
             parameters={
@@ -26,7 +26,7 @@ class TestPotential(BaseTest):
         assert new_potential.independent_variables == {sympy.symbols('x')}
 
     def test_setters(self):
-        new_potential = Potential()
+        new_potential = ParametricPotential()
         new_potential.name = "SettingName"
         new_potential.parameters = {
             'sigma': 1 * u.nm,
@@ -47,14 +47,14 @@ class TestPotential(BaseTest):
 
     def test_incorrect_indep_vars(self):
         with pytest.raises(ValueError):
-            Potential(expression='x*y', independent_variables='z')
+            ParametricPotential(expression='x*y', independent_variables='z')
 
     def test_incorrect_expression(self):
         with pytest.raises(ValueError):
-            Potential(name='mytype', expression=4.2)
+            ParametricPotential(name='mytype', expression=4.2, independent_variables={'a'})
 
     def test_expression_consistency(self):
-        new_potential = Potential(
+        new_potential = ParametricPotential(
             name='mypotential',
             parameters={'x': 1*u.m, 'y': 10*u.m},
             expression='x + y * z',
@@ -67,7 +67,7 @@ class TestPotential(BaseTest):
         assert correct_expr == new_potential.expression
 
     def test_equivalance(self):
-        ref_potential = Potential(
+        ref_potential = ParametricPotential(
             name='mypotential',
             expression='a*x+b',
             parameters={
@@ -75,7 +75,7 @@ class TestPotential(BaseTest):
                 'b': 1.0*u.m},
             independent_variables={'x'}
         )
-        same_potential = Potential(
+        same_potential = ParametricPotential(
             name='mypotential',
             expression='a*x+b',
             parameters={
@@ -83,7 +83,7 @@ class TestPotential(BaseTest):
                 'b': 1.0*u.m},
             independent_variables={'x'}
         )
-        diff_name = Potential(
+        diff_name = ParametricPotential(
             name='nopotential',
             expression='a*x+b',
             parameters={
@@ -91,7 +91,7 @@ class TestPotential(BaseTest):
                 'b': 1.0*u.m},
             independent_variables={'x'}
         )
-        diff_expression = Potential(
+        diff_expression = ParametricPotential(
             name='mypotential',
             expression='a+x*b',
             parameters={
@@ -99,7 +99,7 @@ class TestPotential(BaseTest):
                 'b': 1.0*u.m},
             independent_variables={'x'}
         )
-        diff_params = Potential(
+        diff_params = ParametricPotential(
             name='mypotential',
             expression='a*x+b',
             parameters={
@@ -120,7 +120,7 @@ class TestPotential(BaseTest):
 
     def test_set_expression(self):
         # Try changing the expression but keep the parameters
-        potential = Potential(
+        potential = ParametricPotential(
             name='mypotential',
             expression='a*x+b',
             parameters={
@@ -134,7 +134,7 @@ class TestPotential(BaseTest):
         assert potential.parameters == {'a': 1*u.g, 'b': 1*u.m}
 
     def test_set_expression_bad(self):
-        potential = Potential(
+        potential = ParametricPotential(
             name='mypotential',
             expression='a*x+b',
             parameters={
@@ -147,7 +147,7 @@ class TestPotential(BaseTest):
             potential.set_expression(expression='a*x**2+b*x+c')
 
     def test_set_params(self):
-        potential = Potential(
+        potential = ParametricPotential(
             name='mypotential',
             expression='a*x+b',
             parameters={
@@ -161,7 +161,7 @@ class TestPotential(BaseTest):
         assert potential.parameters == {'a': 4*u.g, 'b': 4*u.m}
 
     def test_set_params_bad(self):
-        potential = Potential(
+        potential = ParametricPotential(
             name='mypotential',
             expression='a*x+b',
             parameters={
@@ -174,7 +174,7 @@ class TestPotential(BaseTest):
             potential.set_expression(parameters={'aa': 4.0*u.g, 'bb': 4.0*u.m})
 
     def test_set_params_partial(self):
-        potential = Potential(
+        potential = ParametricPotential(
             name='mypotential',
             expression='a*x+b',
             parameters={
@@ -188,7 +188,7 @@ class TestPotential(BaseTest):
         assert potential.parameters == {'a': 4*u.g, 'b': 1*u.m}
 
     def test_set_expression_and_params(self):
-        potential = Potential(
+        potential = ParametricPotential(
             name='mypotential',
             expression='a*x+b',
             parameters={
@@ -208,7 +208,7 @@ class TestPotential(BaseTest):
         assert potential.parameters == {'a': 1*u.g, 'b': 1*u.m, 'u': 1*u.g, 'v': 1*u.m}
 
     def test_set_expression_and_params_mismatch(self):
-        potential = Potential(
+        potential = ParametricPotential(
             name='mypotential',
             expression='a*x+b',
             parameters={
@@ -229,12 +229,11 @@ class TestPotential(BaseTest):
         template = PotentialTemplateLibrary()['HarmonicBondPotential']
         params = {'k': 1.0 * u.dimensionless,
                   'r_eq': 1.0 * u.dimensionless}
-        harmonic_potential_from_template = Potential.from_template(template, params)
-        harmonic_potential = Potential(name='HarmonicBondPotential',
-                                       expression='0.5 * k * (r-r_eq)**2',
-                                       independent_variables={'r'},
-                                       parameters=params,
-                                       template=False)
+        harmonic_potential_from_template = ParametricPotential.from_template(template, params)
+        harmonic_potential = ParametricPotential(name='HarmonicBondPotential',
+                                                 expression='0.5 * k * (r-r_eq)**2',
+                                                 independent_variables={'r'},
+                                                 parameters=params)
         assert harmonic_potential.name == harmonic_potential_from_template.name
         assert harmonic_potential.expression == harmonic_potential_from_template.expression
         assert harmonic_potential.independent_variables == harmonic_potential_from_template.independent_variables
@@ -242,4 +241,4 @@ class TestPotential(BaseTest):
     def test_class_method_with_error(self):
         template = object()
         with pytest.raises(GMSOError):
-            Potential.from_template(template, parameters=None)
+            ParametricPotential.from_template(template, parameters=None)

--- a/gmso/tests/test_template.py
+++ b/gmso/tests/test_template.py
@@ -1,16 +1,42 @@
 import sympy
 
+import pytest
+
 from gmso.lib.potential_templates import PotentialTemplate
 from gmso.tests.base_test import BaseTest
 
 
 class TestTemplate(BaseTest):
-    def test_potential_template(self):
+
+    @pytest.fixture()
+    def template(self):
         template = PotentialTemplate(
             expression='a*x+b',
             independent_variables={'x'},
         )
+        return template
+
+    def test_potential_template(self, template):
     
         assert template.expression == sympy.sympify('a*x+b')
 
         assert template.expression.free_symbols - template.independent_variables is not None
+
+    def test_potential_template_name_change(self, template):
+        with pytest.raises(AttributeError) as e:
+            template.name = 'new_name'
+            assert 'Properties for a potential template cannot be changed' in str(e.value)
+
+    def test_potential_template_expression_change(self, template):
+        with pytest.raises(AttributeError) as e:
+            template.expression = 'new_expression'
+            assert 'Properties for a potential template cannot be changed' in str(e.value)
+
+    def test_template_independent_variables_change(self, template):
+        with pytest.raises(AttributeError) as e:
+            template.independent_variables = 'new_variables'
+            assert 'Properties for a potential template cannot be changed' in str(e.value)
+
+    def test_call_to_set_expression(self, template):
+        with pytest.raises(NotImplementedError):
+            template.set_expression()

--- a/gmso/tests/test_template.py
+++ b/gmso/tests/test_template.py
@@ -12,6 +12,5 @@ class TestTemplate(BaseTest):
         )
     
         assert template.expression == sympy.sympify('a*x+b')
-        assert template.template
-    
+
         assert template.expression.free_symbols - template.independent_variables is not None

--- a/gmso/utils/decorators.py
+++ b/gmso/utils/decorators.py
@@ -9,10 +9,10 @@ def confirm_dict_existence(setter_function):
     @wraps(setter_function)
     def setter_with_dict_removal(self, *args, **kwargs):
         if self._topology:
-            self._topology._set_refs[self._set_ref].pop(self, None)
+            self._topology._dict_refs[self.dict_ref].pop(self, None)
             setter_function(self, *args, **kwargs)
-            self._topology._set_refs[self._set_ref][self] = (self)
-            self._topology._reindex_connection_types(self._set_ref)
+            self._topology._dict_refs[self.dict_ref][self] = (self)
+            self._topology._reindex_connection_types(self.dict_ref)
         else:
             setter_function(self, *args, **kwargs)
     return setter_with_dict_removal


### PR DESCRIPTION
This is a draft PR for implementing abc for gmso. I have started with `potential`. 

1. Create an abstract base class called `AbstractPotential` (similar functionality with the potential class)
2. Previous class `Potential` renamed as `ParametricPotential`. (Only implements extra functionality for parameters/unyts)
3. `PotentialTemplate` subclasses out of `AbstractPotential` and its readonly.