### PR TITLE
Fix element parsing by iter_subtrees_topdown 

### DIFF
--- a/gmso/core/element.py
+++ b/gmso/core/element.py
@@ -192,16 +192,21 @@ def element_by_smarts_string(smarts_string):
     PARSER = SMARTS()
 
     symbols = PARSER.parse(smarts_string).iter_subtrees_topdown()
+
+    first_symbol = None
     for symbol in symbols:
         if symbol.data == 'atom_symbol':
+            first_symbol = symbol.children[0]
             break
-    symbol = symbol.children[0]
-    matched_element = element_by_symbol(symbol)
+
+    matched_element = None
+    if first_symbol is not None:
+        matched_element = element_by_symbol(first_symbol)
     
     if matched_element is None:
-        raise GMSOError(f''
-            'Failed to find an element from SMARTS string {smarts_string). The'
-            'parser detected a central node with name {symbol}'
+        raise GMSOError(
+            f'Failed to find an element from SMARTS string {smarts_string}. The '
+            f'parser detected a central node with name {first_symbol}'
         )
 
     return matched_element

--- a/gmso/core/element.py
+++ b/gmso/core/element.py
@@ -191,8 +191,11 @@ def element_by_smarts_string(smarts_string):
 
     PARSER = SMARTS()
 
-    symbol = next(PARSER.parse(smarts_string).find_data('atom_symbol')).children[0]
-    print(symbol)
+    symbols = PARSER.parse(smarts_string).iter_subtrees_topdown()
+    for symbol in symbols:
+        if symbol.data == 'atom_symbol':
+            break
+    symbol = symbol.children[0]
     matched_element = element_by_symbol(symbol)
     
     if matched_element is None:

--- a/gmso/core/element.py
+++ b/gmso/core/element.py
@@ -182,10 +182,13 @@ def element_by_smarts_string(smarts_string):
 
     Returns
     -------
-    matched_element : element.Element or None
-        Return an element from the periodict table if we find a match,
-        otherwise return None
+    matched_element : element.Element
+        Return an element from the periodic table if we find a match
 
+    Raises
+    ------
+    GMSOError
+        If no matching element is found for the provided smarts string
     """
     from foyer.smarts import SMARTS
 


### PR DESCRIPTION
In recent updates to foyer because of lark parser (see https://github.com/mosdef-hub/foyer/pull/341), `elements_by_smarts_string` is failing in gmso. An attempt to fix it is made here.