### PR TITLE
Add support for periodic potentials in top writer

### DIFF
--- a/gmso/external/convert_parmed.py
+++ b/gmso/external/convert_parmed.py
@@ -173,6 +173,8 @@ def from_parmed(structure, refer_type=True):
         top.add_connection(top_connection, update_types=False)
 
     top.update_topology()
+
+    top.combining_rule = structure.combining_rule
     return top
 
 
@@ -482,7 +484,7 @@ def _atom_types_from_gmso(top, structure, atom_map):
         atype.set_lj_params(atype_epsilon, atype_rmin)
         # Type map to match AtomType to its name
         atype_map[atype_name] = atype
-        
+
     for site in top.sites:
         #Assign atom_type to atom
         pmd_atom = atom_map[site]

--- a/gmso/formats/top.py
+++ b/gmso/formats/top.py
@@ -188,10 +188,13 @@ def _accepted_potentials():
     harmonic_bond_potential = templates['HarmonicBondPotential']
     harmonic_angle_potential = templates['HarmonicAnglePotential']
     periodic_torsion_potential = templates['PeriodicTorsionPotential']
+    rb_torsion_potential = templates['RyckaertBellemansTorsionPotential']
     accepted_potentials = [lennard_jones_potential,
                            harmonic_bond_potential,
                            harmonic_angle_potential,
-                           periodic_torsion_potential]
+                           periodic_torsion_potential,
+                           rb_torsion_potential,
+                           ]
     return accepted_potentials
 
 def _validate_compatibility(top):
@@ -229,7 +232,7 @@ def _write_connection(top, connection):
     """
 
     accepted_potentials = _accepted_potentials()
-    for ref in _accepted_potentials():
+    for ref in accepted_potentials:
         if sympy.simplify(ref.expression - connection.connection_type.expression) == 0:
             potential_name = ref.name
             break

--- a/gmso/formats/top.py
+++ b/gmso/formats/top.py
@@ -1,12 +1,11 @@
 import datetime
 
 import unyt as u
-import sympy
 
 from gmso.core.element import element_by_atom_type
 from gmso.lib.potential_templates import PotentialTemplateLibrary
 from gmso.utils.compatibility import check_compatibility
-from gmso.exceptions import GMSOError, EngineIncompatibilityError
+from gmso.exceptions import GMSOError
 
 
 def write_top(top, filename, top_vars=None):

--- a/gmso/formats/top.py
+++ b/gmso/formats/top.py
@@ -107,7 +107,6 @@ def write_top(top, filename):
             '; nr\t\ttype\tresnr\tresidue\t\tatom\tcgnr\tcharge\t\tmass\n'
         )
         for site in top.sites:
-            print(top.name)
             out_file.write(
                 '{0}\t\t\t'
                 '{1}\t\t'

--- a/gmso/formats/top.py
+++ b/gmso/formats/top.py
@@ -1,11 +1,12 @@
 import datetime
 
 import unyt as u
+import sympy
 
 from gmso.core.element import element_by_atom_type
 from gmso.lib.potential_templates import PotentialTemplateLibrary
 from gmso.utils.compatibility import check_compatibility
-from gmso.exceptions import GMSOError
+from gmso.exceptions import GMSOError, EngineIncompatibilityError
 
 
 def write_top(top, filename):
@@ -57,11 +58,11 @@ def write_top(top, filename):
             out_file.write(
                 '{0}\t\t\t'
                 '{1}\t\t\t'
-                '{2}\t\t'
-                '{3}\t\t'
+                '{2:.5f}\t\t'
+                '{3:.5f}\t\t'
                 '{4}\t\t\t'
-                '{5}\t\t\t'
-                '{6}\n'.format(
+                '{5:.5f}\t\t\t'
+                '{6:.5f}\n'.format(
                     atom_type.name,
                     _lookup_atomic_number(atom_type),
                     atom_type.mass.in_units(u.amu).value,
@@ -105,7 +106,8 @@ def write_top(top, filename):
             '[ atoms ]\n'
             '; nr\t\ttype\tresnr\tresidue\t\tatom\tcgnr\tcharge\t\tmass\n'
         )
-        for idx, site in enumerate(top.sites):
+        for site in top.sites:
+            print(top.name)
             out_file.write(
                 '{0}\t\t\t'
                 '{1}\t\t'
@@ -113,9 +115,9 @@ def write_top(top, filename):
                 '{3}\t'
                 '{4}\t\t'
                 '{5}\t\t'
-                '{6}\t\t'
-                '{7}\n'.format(
-                    idx+1,
+                '{6:.5f}\t\t'
+                '{7:.5f}\n'.format(
+                    top.get_index(site) + 1,
                     site.atom_type.name,
                     1, # TODO: subtop idx
                     top.name, # TODO: subtop.name
@@ -132,18 +134,7 @@ def write_top(top, filename):
         )
         for bond in top.bonds:
             out_file.write(
-                '\t{0}'
-                '\t{1}'
-                '\t{2}'
-                '\t{3}'
-                '\t{4}\n'.format(
-                    top.sites.index(bond.connection_members[0]),
-                    top.sites.index(bond.connection_members[1]),
-                    '1',
-                    bond.connection_type.parameters['r_eq'].in_units(u.nm).value,
-                    bond.connection_type.parameters['k'].in_units(
-                        u.Unit('kJ / (mol*nm**2)')).value,
-                )
+                _write_connection(top, bond)
             )
 
         out_file.write(
@@ -152,20 +143,7 @@ def write_top(top, filename):
         )
         for angle in top.angles:
             out_file.write(
-                '\t{0}'
-                '\t{1}'
-                '\t{2}'
-                '\t{3}'
-                '\t{4}'
-                '\t{5}\n'.format(
-                    top.sites.index(angle.connection_members[0]),
-                    top.sites.index(angle.connection_members[1]),
-                    top.sites.index(angle.connection_members[2]),
-                    '1',
-                    angle.connection_type.parameters['theta_eq'].in_units(u.degree).value,
-                    angle.connection_type.parameters['k'].in_units(
-                        u.Unit('kJ/(mol*rad**2)')).value,
-                )
+                _write_connection(top, angle)
             )
 
         out_file.write(
@@ -174,29 +152,7 @@ def write_top(top, filename):
         )
         for dihedral in top.dihedrals:
             out_file.write(
-                '\t{0}'
-                '\t{1}'
-                '\t{2}'
-                '\t{3}'
-                '\t{4}'
-                '\t{5}'
-                '\t{6}'
-                '\t{7}'
-                '\t{8}'
-                '\t{9}'
-                '\t{10}\n'.format(
-                    top.sites.index(dihedral.connection_members[0]),
-                    top.sites.index(dihedral.connection_members[1]),
-                    top.sites.index(dihedral.connection_members[2]),
-                    top.sites.index(dihedral.connection_members[3]),
-                    '3',
-                    dihedral.connection_type.parameters['c0'],
-                    dihedral.connection_type.parameters['c1'],
-                    dihedral.connection_type.parameters['c2'],
-                    dihedral.connection_type.parameters['c3'],
-                    0,
-                    0,
-                )
+                _write_connection(top, dihedral)
             )
 
         out_file.write(
@@ -226,14 +182,21 @@ def write_top(top, filename):
         #    )
 
 
-def _validate_compatibility(top):
-    """Check compatability of topology object with GROMACS TOP format"""
+def _accepted_potentials():
     templates = PotentialTemplateLibrary()
     lennard_jones_potential = templates['LennardJonesPotential']
     harmonic_bond_potential = templates['HarmonicBondPotential']
     harmonic_angle_potential = templates['HarmonicAnglePotential']
-    accepted_potentials = [lennard_jones_potential, harmonic_bond_potential, harmonic_angle_potential]
-    check_compatibility(top, accepted_potentials)
+    periodic_torsion_potential = templates['PeriodicTorsionPotential']
+    accepted_potentials = [lennard_jones_potential,
+                           harmonic_bond_potential,
+                           harmonic_angle_potential,
+                           periodic_torsion_potential]
+    return accepted_potentials
+
+def _validate_compatibility(top):
+    """Check compatability of topology object with GROMACS TOP format"""
+    check_compatibility(top, _accepted_potentials())
 
 
 def _get_top_vars():
@@ -256,3 +219,88 @@ def _lookup_atomic_number(atom_type):
         return element.atomic_number
     except GMSOError:
         return 0
+
+
+def _write_connection(top, connection):
+    """ Worker function to write a single dihedral
+
+    This first gets the form of the dihedral and then sends to form-specific
+    worker function to return the line to be written out
+    """
+
+    accepted_potentials = _accepted_potentials()
+    for ref in _accepted_potentials():
+        if sympy.simplify(ref.expression - connection.connection_type.expression) == 0:
+            potential_name = ref.name
+            break
+        else:
+            potential_name = None
+
+    if not potential_name:
+        raise EngineIncompatibilityError
+
+    worker_functions = {
+            "HarmonicBondPotential": _harmonic_bond_potential_writer,
+            "HarmonicAnglePotential": _harmonic_angle_potential_writer,
+            "RyckaertBellemansTorsionPotential": _ryckaert_bellemans_torsion_writer,
+            "PeriodicTorsionPotential": _periodic_torsion_writer,
+            }
+
+    return worker_functions[potential_name](top, connection)
+
+
+def _harmonic_bond_potential_writer(top, bond):
+    line = "\t{0}\t{1}\t{2}\t{3:.5f}\t{4:.5f}\n".format(
+            top.get_index(bond.connection_members[0]) + 1,
+            top.get_index(bond.connection_members[1]) + 1,
+            '1',
+            bond.connection_type.parameters['r_eq'].in_units(u.nm).value,
+            bond.connection_type.parameters['k'].in_units(
+                u.Unit('kJ / (mol*nm**2)')).value,
+            )
+    return line
+
+
+def _harmonic_angle_potential_writer(top, angle):
+    line = "\t{0}\t{1}\t{2}\t{3}\t{4:.5f}\t{5:.5f}\n".format(
+            top.get_index(angle.connection_members[0]) + 1,
+            top.get_index(angle.connection_members[1]) + 1,
+            top.get_index(angle.connection_members[2]) + 1,
+            '1',
+            angle.connection_type.parameters['theta_eq'].in_units(u.degree).value,
+            angle.connection_type.parameters['k'].in_units(
+                u.Unit('kJ/(mol*rad**2)')).value,
+            )
+    return line
+
+
+def _ryckaert_bellemans_torsion_writer(top, dihedral):
+    line = "\t{0}\t{1}\t{2}\t{3}\t{4}\t{5:.5f}\t{6:.5f}\t{7:.5f}\t{8:.5f}\t{9:.5f}\t{10:.5f}\n".format(
+            top.get_index(dihedral.connection_members[0]) + 1,
+            top.get_index(dihedral.connection_members[1]) + 1,
+            top.get_index(dihedral.connection_members[2]) + 1,
+            top.get_index(dihedral.connection_members[3]) + 1,
+            '3',
+            dihedral.connection_type.parameters['c0'].in_units(u.Unit('kJ/mol')).value,
+            dihedral.connection_type.parameters['c1'].in_units(u.Unit('kJ/mol')).value,
+            dihedral.connection_type.parameters['c2'].in_units(u.Unit('kJ/mol')).value,
+            dihedral.connection_type.parameters['c3'].in_units(u.Unit('kJ/mol')).value,
+            dihedral.connection_type.parameters['c4'].in_units(u.Unit('kJ/mol')).value,
+            dihedral.connection_type.parameters['c5'].in_units(u.Unit('kJ/mol')).value,
+            )
+    return line
+
+
+def _periodic_torsion_writer(top, dihedral):
+    line = "\t{0}\t{1}\t{2}\t{3}\t{4}\t{5:.5f}\t{6:.5f}\t{7}\n".format(
+            top.get_index(dihedral.connection_members[0]) + 1,
+            top.get_index(dihedral.connection_members[1]) + 1,
+            top.get_index(dihedral.connection_members[2]) + 1,
+            top.get_index(dihedral.connection_members[3]) + 1,
+            '1',
+            dihedral.connection_type.parameters['phi_eq'].in_units(u.degree).value,
+            dihedral.connection_type.parameters['k'].in_units(u.Unit('kJ/(mol)')).value,
+            dihedral.connection_type.parameters['n'].value,
+            )
+    return line
+

--- a/gmso/tests/base_test.py
+++ b/gmso/tests/base_test.py
@@ -141,6 +141,7 @@ class BaseTest:
         # atomtyping on gmso Topology
         pmd_ethane = oplsaa.apply(mb_ethane)
         top = from_parmed(pmd_ethane)
+        top.name = "ethane"
         return top
 
     @pytest.fixture

--- a/gmso/tests/test_top.py
+++ b/gmso/tests/test_top.py
@@ -88,7 +88,7 @@ class TestTop(BaseTest):
         for dihedral in typed_ethane.dihedrals:
             dihedral.connection_type = periodic_dihedral_type
 
-        typed_ethane.update_connections()
+        typed_ethane.update_connection_types()
 
         write_top(typed_ethane, 'system.top')
         struct = pmd.load_file('system.top')

--- a/gmso/tests/test_top.py
+++ b/gmso/tests/test_top.py
@@ -76,6 +76,7 @@ class TestTop(BaseTest):
 
         write_top(top, 'water.top')
 
+
     def test_ethane_periodic(self, typed_ethane):
         from gmso.lib.potential_templates import PotentialTemplateLibrary
         per_torsion = PotentialTemplateLibrary()["PeriodicTorsionPotential"]
@@ -92,3 +93,12 @@ class TestTop(BaseTest):
         write_top(typed_ethane, 'system.top')
         struct = pmd.load_file('system.top')
         assert len(struct.dihedrals) == 9
+
+
+    def test_custom_defaults(self, typed_ethane):
+        write_top(typed_ethane, 'system.top',
+                top_vars={"gen-pairs": "yes", "fudgeLJ": 0.5, "fudgeQQ":0.5})
+        struct = pmd.load_file('system.top')
+        assert struct.defaults.gen_pairs == "yes"
+        assert struct.defaults.fudgeLJ == 0.5
+        assert struct.defaults.fudgeQQ == 0.5

--- a/gmso/tests/test_top.py
+++ b/gmso/tests/test_top.py
@@ -16,9 +16,11 @@ class TestTop(BaseTest):
 
 
     @pytest.mark.parametrize('top', ['typed_ar_system',
-        'typed_water_system'])
+        'typed_water_system', 'typed_ethane'])
     def test_pmd_loop(self, top, request):
-        write_top(request.getfixturevalue(top), 'system.top')
+        top = request.getfixturevalue(top)
+        assert len(top.name) > 3
+        write_top(top, 'system.top')
         pmd.load_file('system.top')
 
 
@@ -72,3 +74,4 @@ class TestTop(BaseTest):
         top.update_angle_types()
 
         write_top(top, 'water.top')
+

--- a/gmso/utils/compatibility.py
+++ b/gmso/utils/compatibility.py
@@ -4,14 +4,41 @@ from gmso.exceptions import EngineIncompatibilityError
 
 
 def check_compatibility(topology, accepted_potentials):
-    """Compare the potentials in a topology against a list of accepted potential templates"""
+    """
+    Compare the potentials in a topology against a list of accepted potential templates
+
+    Parameters
+    ----------
+    topology: gmso.Topology
+        The topology whose potentials to check.
+    accepted_potentials: list
+        A list of gmso.Potential objects to check against
+
+    Returns
+    -------
+    potential_forms_dict: dict
+        A dictionary mapping the atom_types and connection_types to the names
+        of their matching template potential. Provides a standardized naming
+        scheme for the potentials in the topology.
+
+    """
+
+    potential_forms_dict = dict()
     for atom_type in topology.atom_types:
-        if not _check_single_potential(atom_type, accepted_potentials):
+        potential_form = _check_single_potential(atom_type, accepted_potentials)
+        if not potential_form:
             raise EngineIncompatibilityError
+        else:
+            potential_forms_dict.update(potential_form)
 
     for connection_type in topology.connection_types:
-        if not _check_single_potential(connection_type, accepted_potentials):
+        potential_form = _check_single_potential(connection_type, accepted_potentials)
+        if not potential_form:
             raise EngineIncompatibilityError
+        else:
+            potential_forms_dict.update(potential_form)
+
+    return potential_forms_dict
 
 
 def _check_single_potential(potential, accepted_potentials):
@@ -19,5 +46,5 @@ def _check_single_potential(potential, accepted_potentials):
     for ref in accepted_potentials:
         if ref.independent_variables == potential.independent_variables:
             if sympy.simplify(ref.expression - potential.expression) == 0:
-                return True
+                return {potential: ref.name}
     return False


### PR DESCRIPTION
This was inspired by our workflow for SciPy 2020. Just wanted to extend the support of the top writer to periodic potentials and also clean up some of the functions to make them more modular. 

* Add PeriodicTorsionPotential to accepted_potentials
* Make accepted potentials accessible to all functions
* Add a connection writer that determines the potential form and chooses the correct gmx potential type
* Ensure that units are converted correctly for dihedrals