### PR TITLE
Make Element class hashable

### DIFF
--- a/gmso/core/element.py
+++ b/gmso/core/element.py
@@ -6,6 +6,7 @@ from collections import namedtuple
 import unyt as u
 
 from gmso.exceptions import GMSOError
+from gmso.utils.misc import unyt_to_hashable
 
 class Element(namedtuple('Element', 'atomic_number, name, symbol, mass')):
     """Chemical element object
@@ -41,7 +42,7 @@ class Element(namedtuple('Element', 'atomic_number, name, symbol, mass')):
     def __hash__(self):
         return hash((self.name, self.symbol,
                      self.atomic_number,
-                float(self.mass.to('amu').value)))
+                unyt_to_hashable(self.mass)))
 
 
 def element_by_symbol(symbol):

--- a/gmso/core/element.py
+++ b/gmso/core/element.py
@@ -36,11 +36,7 @@ class Element(namedtuple('Element', 'atomic_number, name, symbol, mass')):
                                                                       self.atomic_number,
                                                                       self.mass)
     def __eq__(self, other):
-        return (self.__class__ == other.__class__ and
-        self.name == other.name and
-        self.symbol == other.symbol and
-        self.atomic_number == other.atomic_number and
-        self.mass == self.mass)
+        return hash(self) == hash(other)
 
     def __hash__(self):
         return hash((self.name, self.symbol,

--- a/gmso/core/element.py
+++ b/gmso/core/element.py
@@ -35,6 +35,17 @@ class Element(namedtuple('Element', 'atomic_number, name, symbol, mass')):
                                                                       self.name, self.symbol,
                                                                       self.atomic_number,
                                                                       self.mass)
+    def __eq__(self, other):
+        return (self.__class__ == other.__class__ and
+        self.name == other.name and
+        self.symbol == other.symbol and
+        self.atomic_number == other.atomic_number and
+        self.mass == self.mass)
+
+    def __hash__(self):
+        return hash((self.name, self.symbol,
+                     self.atomic_number,
+                float(self.mass.to('amu').value)))
 
 
 def element_by_symbol(symbol):

--- a/gmso/tests/test_element.py
+++ b/gmso/tests/test_element.py
@@ -87,6 +87,7 @@ class TestElement(BaseTest):
         for num in range(1, 119):
             elem = element.element_by_atomic_number(num)
             assert elem.atomic_number == num
+            assert element.__hash__
 
     @pytest.mark.parametrize('atomic_number', [0, -1, 1000, 17.02])
     def test_bad_atomic_number(self, atomic_number):


### PR DESCRIPTION
I notice that our Element class is not hashable and comparable so I just added the __eq__ and __hash__ method for our Element class.