### PR TITLE
Add link to github/homepage in docs footer (Implements #427)

### DIFF
--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -1,0 +1,23 @@
+{%extends "!footer.html" %}
+{% block extrafooter %}
+  <script>
+    const $footer = $('footer');
+    const $contentInfoDiv = $footer.find('div[role="contentinfo"]');
+    if($contentInfoDiv){
+          const $paragraph = $contentInfoDiv.find('p')
+          $paragraph ? $paragraph.append(
+            `
+            |<a href="https://github.com/mosdef-hub/gmso" target="_blank">
+                <i class="fa fa-github-square"></i>
+                Github
+            </a>
+            |<a href="https://mosdef.org" target="_blank">
+                <i class="fa fa-globe"></i>
+                MoSDeF Home
+            </a>|
+            `
+        ): null ;
+    }
+  </script>
+{{ super() }}
+{% endblock %}

--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -4,19 +4,20 @@
     const $footer = $('footer');
     const $contentInfoDiv = $footer.find('div[role="contentinfo"]');
     if($contentInfoDiv){
-          const $paragraph = $contentInfoDiv.find('p')
-          $paragraph ? $paragraph.append(
-            `
-            |<a href="https://github.com/mosdef-hub/gmso" target="_blank">
+      const $paragraph = $contentInfoDiv.find('p');
+      if($paragraph) {
+        $paragraph.remove('.commit');
+        $paragraph.append(
+            `|<a href="https://github.com/mosdef-hub/gmso" target="_blank">
                 <i class="fa fa-github-square"></i>
                 GitHub
             </a>
             |<a href="https://mosdef.org" target="_blank">
                 <i class="fa fa-globe"></i>
                 MoSDeF Home
-            </a>|
-            `
-        ): null ;
+            </a>|`
+        );
+      }
     }
   </script>
 {{ super() }}

--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -6,7 +6,7 @@
     if($contentInfoDiv){
       const $paragraph = $contentInfoDiv.find('p');
       if($paragraph) {
-        $paragraph.remove('.commit');
+        $paragraph.find('.commit').remove();
         $paragraph.append(
             `|<a href="https://github.com/mosdef-hub/gmso" target="_blank">
                 <i class="fa fa-github-square"></i>

--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -9,7 +9,7 @@
             `
             |<a href="https://github.com/mosdef-hub/gmso" target="_blank">
                 <i class="fa fa-github-square"></i>
-                Github
+                GitHub
             </a>
             |<a href="https://mosdef.org" target="_blank">
                 <i class="fa fa-globe"></i>


### PR DESCRIPTION
Implements the links to github/homepage in docs footer. See #427.

![image](https://user-images.githubusercontent.com/11476842/87993979-7d64c680-cab1-11ea-9a8f-38f0696abe70.png)
