### PR TITLE
Fix bug found in lammps writer

### DIFF
--- a/gmso/formats/lammpsdata.py
+++ b/gmso/formats/lammpsdata.py
@@ -17,7 +17,7 @@ from gmso.core.topology import Topology
 from gmso.core.box import Box
 from gmso.core.element import element_by_mass
 from gmso.utils.conversions import convert_opls_to_ryckaert, convert_ryckaert_to_opls
-
+from gmso.lib.potential_templates import PotentialTemplateLibrary
 
 def write_lammpsdata(topology, filename, atom_style='full'):
     """Output a LAMMPS data file.
@@ -172,10 +172,9 @@ def write_lammpsdata(topology, filename, atom_style='full'):
             if topology.dihedrals:
                 data.write('\nDihedral Coeffs\n\n')
                 for idx, dihedral_type in enumerate(topology.dihedral_types):
-                    if dihedral_type.expression == sympify('c0 * cos(phi)**0' \
-                                    ' + c1 * cos(phi)**1 + c2 * cos(phi)**2' \
-                                    '+ c3 * cos(phi)**3 + c4 * cos(phi)**4' \
-                                    ' + c5 * cos(phi)**5'):
+                    rbtorsion = PotentialTemplateLibrary()['RyckaertBellemansTorsionPotential']
+                    if (dihedral_type.expression == sympify(rbtorsion.expression) or
+                        dihedral_type.name == rbtorsion.name):
                         dihedral_type = convert_ryckaert_to_opls(dihedral_type)
                     data.write('{}\t{:.5f}\t{:5f}\t{:5f}\t{:.5f}\n'.format(
                         idx+1,

--- a/gmso/formats/lammpsdata.py
+++ b/gmso/formats/lammpsdata.py
@@ -4,6 +4,7 @@ import warnings
 import numpy as np
 import unyt as u
 import datetime
+from sympy import sympify
 
 from unyt.array import allclose_units
 from gmso.core.atom import Atom
@@ -15,6 +16,7 @@ from gmso.core.angle import Angle
 from gmso.core.topology import Topology
 from gmso.core.box import Box
 from gmso.core.element import element_by_mass
+from gmso.utils.conversions import convert_opls_to_ryckaert, convert_ryckaert_to_opls
 
 
 def write_lammpsdata(topology, filename, atom_style='full'):
@@ -170,7 +172,10 @@ def write_lammpsdata(topology, filename, atom_style='full'):
             if topology.dihedrals:
                 data.write('\nDihedral Coeffs\n')
                 for idx, dihedral_type in enumerate(topology.dihedral_types):
-                    if dihedral_type.name == 'RyckaertBellemansTorsionPotential':
+                    if dihedral_type.expression == sympify('c0 * cos(phi)**0' \
+                                    ' + c1 * cos(phi)**1 + c2 * cos(phi)**2' \
+                                    '+ c3 * cos(phi)**3 + c4 *     cos(phi)**4' \
+                                    ' + c5 * cos(phi)**5'):
                         dihedral_type = convert_ryckaert_to_opls(dihedral_type)
                     data.write('{}\t{:.5f}\t{:5f}\t{:5f}\t{:.5f}\n'.format(
                         idx+1,

--- a/gmso/formats/lammpsdata.py
+++ b/gmso/formats/lammpsdata.py
@@ -179,10 +179,10 @@ def write_lammpsdata(topology, filename, atom_style='full'):
                         dihedral_type = convert_ryckaert_to_opls(dihedral_type)
                     data.write('{}\t{:.5f}\t{:5f}\t{:5f}\t{:.5f}\n'.format(
                         idx+1,
-                        dihedral_type.parameters['k1'].in_units(u.Unit('kcal/mol')).value/2,
-                        dihedral_type.parameters['k2'].in_units(u.Unit('kcal/mol')).value/2,
-                        dihedral_type.parameters['k3'].in_units(u.Unit('kcal/mol')).value/2,
-                        dihedral_type.parameters['k4'].in_units(u.Unit('kcal/mol')).value/2
+                        dihedral_type.parameters['k1'].in_units(u.Unit('kcal/mol')).value,
+                        dihedral_type.parameters['k2'].in_units(u.Unit('kcal/mol')).value,
+                        dihedral_type.parameters['k3'].in_units(u.Unit('kcal/mol')).value,
+                        dihedral_type.parameters['k4'].in_units(u.Unit('kcal/mol')).value,
                         ))
 
 

--- a/gmso/formats/lammpsdata.py
+++ b/gmso/formats/lammpsdata.py
@@ -170,19 +170,19 @@ def write_lammpsdata(topology, filename, atom_style='full'):
 
             # TODO: Write out multiple dihedral styles
             if topology.dihedrals:
-                data.write('\nDihedral Coeffs\n')
+                data.write('\nDihedral Coeffs\n\n')
                 for idx, dihedral_type in enumerate(topology.dihedral_types):
                     if dihedral_type.expression == sympify('c0 * cos(phi)**0' \
                                     ' + c1 * cos(phi)**1 + c2 * cos(phi)**2' \
-                                    '+ c3 * cos(phi)**3 + c4 *     cos(phi)**4' \
+                                    '+ c3 * cos(phi)**3 + c4 * cos(phi)**4' \
                                     ' + c5 * cos(phi)**5'):
                         dihedral_type = convert_ryckaert_to_opls(dihedral_type)
                     data.write('{}\t{:.5f}\t{:5f}\t{:5f}\t{:.5f}\n'.format(
                         idx+1,
-                        dihedral_type.parameters['k1']/2,
-                        dihedral_type.parameters['k2']/2,
-                        dihedral_type.parameters['k3']/2,
-                        dihedral_type.parameters['k4']/2
+                        dihedral_type.parameters['k1'].in_units(u.Unit('kcal/mol')).value/2,
+                        dihedral_type.parameters['k2'].in_units(u.Unit('kcal/mol')).value/2,
+                        dihedral_type.parameters['k3'].in_units(u.Unit('kcal/mol')).value/2,
+                        dihedral_type.parameters['k4'].in_units(u.Unit('kcal/mol')).value/2
                         ))
 
 

--- a/gmso/tests/test_lammps.py
+++ b/gmso/tests/test_lammps.py
@@ -14,6 +14,9 @@ class TestLammpsWriter(BaseTest):
         typed_ar_system.box = Box(lengths=[1,1,1], angles=[60,90,120])
         write_lammpsdata(typed_ar_system, filename='data.triclinic')
 
+    def test_ethane_lammps(self, typed_ethane):
+        write_lammpsdata(typed_ethane, 'data.ethane')
+
     def test_water_lammps(self, typed_water_system):
         write_lammpsdata(typed_water_system, 'data.water')
 


### PR DESCRIPTION
Relate to this issue #452. Added missing import statement. Changed from comparing dihedral_type.name to comparing dihedral_type.expression for more general case. Add extra test for lammps writer (typed ethane system)