### PR TITLE
Add pydantic to dev requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ sympy
 unyt >= 2.4
 boltons
 lxml
+pydantic
 pytest
 mbuild >= 0.10.6
 openbabel


### PR DESCRIPTION
Self explanatory. `pydantic` was missing from `requirements-dev.txt`. I checked the other deps in requirements, requirements-dev, and requirements-test to make sure the rest was consistent. 