### PR TITLE
Ensure that duplicate connections are pruned

### DIFF
--- a/gmso/core/angle.py
+++ b/gmso/core/angle.py
@@ -53,7 +53,7 @@ class Angle(Connection):
         """
 
         return frozenset([
-                tuple(self.connection_members),
+                self.connection_members,
                 tuple(reversed(self.connection_members))
                 ])
 

--- a/gmso/core/angle.py
+++ b/gmso/core/angle.py
@@ -13,7 +13,7 @@ class Angle(Connection):
     This is a subclass of the gmso.Connection superclass.
     This class has strictly 3 members in its connection members.
     The connection_type in this class corresponds to gmso.AngleType.
-    
+
     Notes
     -----
     Inherits some methods from Connection:
@@ -38,6 +38,44 @@ class Angle(Connection):
     @property
     def connection_type(self):
         return self.__dict__.get('angle_type_')
+
+    def equivalent_members(self):
+        """Get a set of the equivalent connection member tuples
+        Returns
+        _______
+        frozenset
+            A unique set of tuples of equivalent connection members
+        Notes
+        _____
+        For an angle:
+            i, j, k == k, j, i
+        where i, j and k are the connection members.
+        """
+
+        return frozenset([
+                tuple(self.connection_members),
+                tuple(reversed(self.connection_members))
+                ])
+
+    def _equivalent_members_hash(self):
+        """Returns a unique hash representing the connection
+        Returns
+        _______
+        int
+            A unique hash to represent the connection members
+        Notes
+        _____
+        For an angle:
+            i, j, k == k, j, i
+        where i, j, and k are the connection members.
+        Here, j is fixed and i and k are replaceable.
+        """
+
+        return hash(tuple([
+            self.connection_members[1],
+            frozenset([self.connection_members[0],
+                       self.connection_members[2]])
+            ]))
 
     def __setattr__(self, key, value):
         if key == 'connection_type':

--- a/gmso/core/bond.py
+++ b/gmso/core/bond.py
@@ -52,7 +52,7 @@ class Bond(Connection):
         where i and j are the connection members.
         """
         return frozenset([
-                tuple(self.connection_members),
+                self.connection_members,
                 tuple(reversed(self.connection_members))
                 ])
 
@@ -70,10 +70,10 @@ class Bond(Connection):
         Here, i and j are interchangeable.
         """
 
-        return hash(tuple([
+        return hash(
             frozenset([self.connection_members[0],
                       self.connection_members[1]])
-            ]))
+            )
 
     def __setattr__(self, key, value):
         if key == 'connection_type':

--- a/gmso/core/bond.py
+++ b/gmso/core/bond.py
@@ -39,6 +39,42 @@ class Bond(Connection):
         # ToDo: Deprecate this?
         return self.__dict__.get('bond_type_')
 
+    def equivalent_members(self):
+        """Get a set of the equivalent connection member tuples
+        Returns
+        _______
+        frozenset
+            A unique set of tuples of equivalent connection members
+        Notes
+        _____
+        For a bond:
+            i, j == j, i
+        where i and j are the connection members.
+        """
+        return frozenset([
+                tuple(self.connection_members),
+                tuple(reversed(self.connection_members))
+                ])
+
+    def _equivalent_members_hash(self):
+        """Returns a unique hash representing the connection
+        Returns
+        _______
+        int
+            A unique hash to represent the connection members
+        Notes
+        _____
+        For a bond:
+            i, j == j, i
+        where i and j are the connection members.
+        Here, i and j are interchangeable.
+        """
+
+        return hash(tuple([
+            frozenset([self.connection_members[0],
+                      self.connection_members[1]])
+            ]))
+
     def __setattr__(self, key, value):
         if key == 'connection_type':
             super(Bond, self).__setattr__('bond_type', value)

--- a/gmso/core/dihedral.py
+++ b/gmso/core/dihedral.py
@@ -44,6 +44,48 @@ class Dihedral(Connection):
         # ToDo: Deprecate this?
         return self.__dict__.get('dihedral_type_')
 
+    def equivalent_members(self):
+        """Get a set of the equivalent connection member tuples
+        Returns
+        _______
+        frozenset
+            A unique set of tuples of equivalent connection members
+        Notes
+        _____
+        For an dihedral:
+            i, j, k, l == l, k, j, i
+        where i, j, k, and l are the connection members.
+        """
+        return frozenset([
+                tuple(self.connection_members),
+                tuple(reversed(self.connection_members))
+                ])
+
+    def _equivalent_members_hash(self):
+        """Returns a unique hash representing the connection
+        Returns
+        _______
+        int
+            A unique hash to represent the connection members
+        Notes
+        _____
+        For an dihedral:
+            i, j, k, l == l, k, j, i
+        where i, j, k, and l are the connection members.
+        Here i and j are interchangeable, j and k are interchangeable,
+        and k and l are interchangeble, as long as each are adjacent to
+        one another.
+        """
+
+        return hash(tuple([frozenset([
+            frozenset([self.connection_members[0],
+                       self.connection_members[1]]),
+            frozenset([self.connection_members[1],
+                       self.connection_members[2]]),
+            frozenset([self.connection_members[2],
+                       self.connection_members[3]])
+            ])]))
+
     def __setattr__(self, key, value):
         if key == 'connection_type':
             super(Dihedral, self).__setattr__('dihedral_type', value)

--- a/gmso/core/dihedral.py
+++ b/gmso/core/dihedral.py
@@ -57,7 +57,7 @@ class Dihedral(Connection):
         where i, j, k, and l are the connection members.
         """
         return frozenset([
-                tuple(self.connection_members),
+                self.connection_members,
                 tuple(reversed(self.connection_members))
                 ])
 
@@ -77,14 +77,14 @@ class Dihedral(Connection):
         one another.
         """
 
-        return hash(tuple([frozenset([
+        return hash(frozenset([
             frozenset([self.connection_members[0],
                        self.connection_members[1]]),
             frozenset([self.connection_members[1],
                        self.connection_members[2]]),
             frozenset([self.connection_members[2],
                        self.connection_members[3]])
-            ])]))
+            ]))
 
     def __setattr__(self, key, value):
         if key == 'connection_type':

--- a/gmso/core/improper.py
+++ b/gmso/core/improper.py
@@ -67,7 +67,7 @@ class Improper(Connection):
                          self.connection_members[3]]
 
         return frozenset([
-                tuple(self.connection_members),
+                self.connection_members,
                 tuple(equiv_members)
                 ])
 

--- a/gmso/core/improper.py
+++ b/gmso/core/improper.py
@@ -49,6 +49,50 @@ class Improper(Connection):
         # ToDo: Deprecate this?
         return self.__dict__.get('improper_type_')
 
+    def equivalent_members(self):
+        """Get a set of the equivalent connection member tuples
+        Returns
+        _______
+        frozenset
+            A unique set of tuples of equivalent connection members
+        Notes
+        _____
+        For an improper:
+            i, j, k, l == i, k, j, l
+        where i, j, k, and l are the connection members.
+        """
+        equiv_members = [self.connection_members[0],
+                         self.connection_members[2],
+                         self.connection_members[1],
+                         self.connection_members[3]]
+
+        return frozenset([
+                tuple(self.connection_members),
+                tuple(equiv_members)
+                ])
+
+    def _equivalent_members_hash(self):
+        """Returns a unique hash representing the connection
+        Returns
+        _______
+        int
+            A unique hash to represent the connection members
+        Notes
+        _____
+        For an improper:
+            i, j, k, l == i, k, j, l
+        where i, j, k, and l are the connection members.
+        Here j and k are interchangeable and i and l are fixed.
+        """
+
+        return hash(tuple([
+            self.connection_members[0],
+            self.connection_members[3],
+            frozenset([self.connection_members[1],
+                       self.connection_members[2]])
+            ]))
+
+
     def __setattr__(self, key, value):
         if key == 'connection_type':
             super(Improper, self).__setattr__('improper_type', value)

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -166,6 +166,8 @@ class Topology(object):
             IMPROPER_TYPE_DICT: self._improper_types_idx
         }
 
+        self._unique_connections = {}
+
 
     @property
     def name(self):
@@ -386,11 +388,26 @@ class Topology(object):
         update_types : bool, default=True
             If True also add any Potential object associated with connection to the
             topology.
+
+        Returns
+        _______
+        gmso.Connection
+            The Connection object or equivalent Connection object that
+            is in the topology
         """
+        # Check if an equivalent connection is in the topology
+        equivalent_members = connection._equivalent_members_hash()
+        if equivalent_members in self._unique_connections:
+            warnings.warn('An equivalent connection already exists. '
+                        'Providing the existing equivalent Connection.')
+            connection = self._unique_connections[equivalent_members]
+
         for conn_member in connection.connection_members:
             if conn_member not in self.sites:
                 self.add_site(conn_member)
         self._connections.add(connection)
+        self._unique_connections.update(
+                {equivalent_members : connection})
         if isinstance(connection, Bond):
             self._bonds.add(connection)
         if isinstance(connection, Angle):
@@ -402,6 +419,7 @@ class Topology(object):
         if update_types:
             self.update_connection_types()
 
+        return connection
 
     def identify_connections(self):
         _identify_connections(self)

--- a/gmso/tests/test_angle.py
+++ b/gmso/tests/test_angle.py
@@ -2,6 +2,7 @@ import pytest
 
 from pydantic import ValidationError
 
+from gmso.core.topology import Topology
 from gmso.core.angle import Angle
 from gmso.core.angle_type import AngleType
 from gmso.core.atom_type import AtomType
@@ -79,3 +80,48 @@ class TestAngle(BaseTest):
 
         assert ref_angle != same_angle
         assert ref_angle != diff_angle
+
+    def test_add_equivalent_connections(self):
+        atom1 = Atom(name="AtomA")
+        atom2 = Atom(name="AtomB")
+        atom3 = Atom(name="AtomC")
+
+        angle = Angle(
+                connection_members=[atom1, atom2, atom3]
+                )
+        angle_eq = Angle(
+                connection_members=[atom3, atom2, atom1]
+                )
+        angle_not_eq = Angle(
+                connection_members=[atom1, atom3, atom2]
+                )
+
+        top = Topology()
+        top.add_connection(angle)
+        top.add_connection(angle_eq)
+        assert top.n_angles == 1
+
+        top.add_connection(angle_not_eq)
+        assert top.n_angles == 2
+
+    def test_equivalent_members_set(self):
+        atom1 = Atom(name="AtomA")
+        atom2 = Atom(name="AtomB")
+        atom3 = Atom(name="AtomC")
+
+        angle = Angle(
+                connection_members=[atom1, atom2, atom3]
+                )
+        angle_eq = Angle(
+                connection_members=[atom3, atom2, atom1]
+                )
+        angle_not_eq = Angle(
+                connection_members=[atom1, atom3, atom2]
+                )
+
+        assert (tuple(angle_eq.connection_members)
+                in angle.equivalent_members())
+        assert (tuple(angle.connection_members)
+                in angle_eq.equivalent_members())
+        assert not (tuple(angle.connection_members)
+                in angle_not_eq.equivalent_members())

--- a/gmso/tests/test_bond.py
+++ b/gmso/tests/test_bond.py
@@ -2,6 +2,7 @@ import pytest
 
 from pydantic import ValidationError
 
+from gmso.core.topology import Topology
 from gmso.core.bond import Bond
 from gmso.core.atom_type import AtomType
 from gmso.core.bond_type import BondType
@@ -71,3 +72,35 @@ class TestBond(BaseTest):
 
         assert ref_connection != same_connection
         assert ref_connection != diff_connection
+
+    def test_add_equivalent_connections(self):
+        atom1 = Atom(name="AtomA")
+        atom2 = Atom(name="AtomB")
+
+        bond = Bond(
+                connection_members=[atom1, atom2]
+                )
+        bond_eq = Bond(
+                connection_members=[atom2, atom1]
+                )
+
+        top = Topology()
+        top.add_connection(bond)
+        top.add_connection(bond_eq)
+        assert top.n_bonds == 1
+
+    def test_equivalent_members_set(self):
+        atom1 = Atom(name="AtomA")
+        atom2 = Atom(name="AtomB")
+
+        bond = Bond(
+                connection_members=[atom1, atom2]
+                )
+        bond_eq = Bond(
+                connection_members=[atom2, atom1]
+                )
+
+        assert (tuple(bond_eq.connection_members)
+                in bond.equivalent_members())
+        assert (tuple(bond.connection_members)
+                in bond_eq.equivalent_members())

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -419,32 +419,69 @@ class TestTopology(BaseTest):
         assert top.sites[10].atom_type.name == 'atom_type_changed'
         assert top.is_typed()
 
+    def test_add_duplicate_connected_atom(self):
+        top = Topology()
+        atom1 = Atom(name="AtomA")
+        atom2 = Atom(name="AtomB")
+        bond = Bond(
+                connection_members=[atom1, atom2]
+                )
+        bond_eq = Bond(
+                connection_members=[atom1, atom2]
+                )
+
+        top.add_connection(bond)
+        top.add_connection(bond_eq)
+        top.update_topology()
+        assert top.n_connections == 1
+
     def test_topology_get_index(self):
         top = Topology()
-        conn_members = [Atom(), Atom(), Atom(), Atom()]
-        for i in range(5):
-            top.add_site(Atom())
-            top.add_connection(Bond(
-                connection_members=[conn_members[0], conn_members[1]]))
-            top.add_connection(Angle(
-                connection_members=[conn_members[0], conn_members[1], conn_members[2]]))
-            top.add_connection(Dihedral(
-                connection_members=[conn_members[0], conn_members[1], conn_members[2], conn_members[3]]))
-            top.add_connection(Improper(
-                connection_members=[conn_members[0], conn_members[1], conn_members[2], conn_members[3]]))
-        a_bond = Bond(connection_members=[conn_members[0], conn_members[1]])
-        an_angle = Angle(connection_members=[conn_members[0], conn_members[1], conn_members[2]])
-        a_site = Atom()
-        a_dihedral = Dihedral(connection_members=[conn_members[0], conn_members[1], conn_members[2], conn_members[3]])
-        an_improper = Improper(connection_members=[conn_members[0], conn_members[1], conn_members[2], conn_members[3]])
+        conn_members = [Atom() for _ in range(10)]
+        for atom in conn_members:
+            top.add_site(atom)
 
-        top.add_site(a_site)
+        for i in range(5):
+            top.add_connection(Bond(
+                connection_members=[conn_members[i], conn_members[i+1]]))
+            top.add_connection(Angle(
+                connection_members=[conn_members[i],
+                                    conn_members[i+1],
+                                    conn_members[i+2]]))
+            top.add_connection(Dihedral(
+                connection_members=[conn_members[i],
+                                    conn_members[i+1],
+                                    conn_members[i+2],
+                                    conn_members[i+3]]))
+            top.add_connection(Improper(
+                connection_members=[conn_members[i],
+                                    conn_members[i+1],
+                                    conn_members[i+2],
+                                    conn_members[i+3]]))
+
+
+        a_atom = Atom()
+        a_bond = Bond(connection_members=[conn_members[6],
+                                          conn_members[7]])
+        an_angle = Angle(connection_members=[conn_members[6],
+                                             conn_members[7],
+                                             conn_members[8]])
+        a_dihedral = Dihedral(connection_members=[conn_members[6],
+                                                  conn_members[7],
+                                                  conn_members[8],
+                                                  conn_members[9]])
+        an_improper = Improper(connection_members=[conn_members[6],
+                                                   conn_members[7],
+                                                   conn_members[8],
+                                                   conn_members[9]])
+
+        top.add_site(a_atom)
         top.add_connection(a_bond)
         top.add_connection(an_angle)
         top.add_connection(a_dihedral)
         top.add_connection(an_improper)
 
-        assert top.get_index(a_site) == 9
+        assert top.get_index(a_atom) == 10
         assert top.get_index(a_bond) == 5
         assert top.get_index(an_angle) == 5
         assert top.get_index(a_dihedral) == 5


### PR DESCRIPTION
Same as PR #384. 

Makes sure that there is only one connection between any equivalent sets of connection members (e.g. you can't have a bond between atoms 1 and 2 and another one between atoms 2 and 1 since they are the same). This will be useful for applying layered potentials in future PRs. 