### PR TITLE
Prevent a nondeterministic AssertionError in unit tests

### DIFF
--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -472,7 +472,9 @@ class TestTopology(BaseTest):
 
     def test_topology_get_index_bond_type(self, typed_methylnitroaniline):
         assert typed_methylnitroaniline.get_index(typed_methylnitroaniline.bonds[0].connection_type) == 0
-        assert typed_methylnitroaniline.get_index(typed_methylnitroaniline.bonds[-1].connection_type)
+        assert isinstance(
+                typed_methylnitroaniline.get_index(typed_methylnitroaniline.bonds[-1].connection_type),
+                int)
 
     def test_topology_get_index_bond_type_after_change(self, typed_methylnitroaniline):
         typed_methylnitroaniline.bonds[0].connection_type.name = 'changed name'


### PR DESCRIPTION
Sometimes the `test_topology_get_index_bond_type` fail randomly. This _might_ be due to dictionaries/sets not being ordered (IDK if this is there reason) causing the index of the last BondType to be 0, which causes an assertion error. As of the first commit to this PR, the tests would no longer fail but the nondeterministic nature of indexing Atom/ConnectionTypes is not addressed. If anyone can figure this out, please push to this PR (or start a new one). 