### PR TITLE
Import networkx conversion functions in gmso.external

### DIFF
--- a/gmso/external/__init__.py
+++ b/gmso/external/__init__.py
@@ -1,3 +1,4 @@
 from .convert_mbuild import from_mbuild, to_mbuild, from_mbuild_box
 from .convert_parmed import from_parmed, to_parmed
 from .convert_openmm import to_openmm
+from .convert_networkx import from_networkx, to_networkx


### PR DESCRIPTION
Pointed out by @CalCraven, fixes networkx functions import issues and adheres to the import conventions of `gmso.external`.