### PR TITLE
Remove mosdef channel from files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN conda update conda -yq && \
 	conda config --set always_yes yes --set changeps1 no && \
 	conda config --add channels omnia && \
 	conda config --add channels conda-forge && \
-	conda config --add channels mosdef && \
 	conda create -n gmso-docker python=$PY_VERSION && \
 	. /opt/conda/etc/profile.d/conda.sh && \
 	conda activate gmso-docker && \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,12 +32,18 @@ stages:
             Python37Ubuntu:
               imageName: 'ubuntu-latest'
               python.version: 3.7
+            Python38Ubuntu:
+              imageName: 'ubuntu-latest'
+              python.version: 3.8
             Python36macOS:
               imageName: 'macOS-latest'
               python.version: 3.6
             Python37macOS:
               imageName: 'macOS-latest'
               python.version: 3.7
+            Python38macOS:
+              imageName: 'macOS-latest'
+              python.version: 3.8
 
         pool:
           vmImage: $(imageName)
@@ -53,7 +59,6 @@ stages:
           - bash: |
               conda config --set always_yes yes --set changeps1 no
               conda config --add channels omnia
-              conda config --add channels mosdef
               conda config --add channels conda-forge
               conda update conda -yq
             displayName: Add relevant channels

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -18,14 +18,13 @@ Dependencies of ``GMSO`` are listed in the file ``requirements.txt``. They
 can be installed in one line:
 ::
 
-    $ conda install -c omnia -c mosdef -c conda-forge --file requirements.txt
+    $ conda install -c omnia -c conda-forge --file requirements.txt
 
 Alternatively you can add all the required channels to your ``.condarc`` file
 and then install dependencies.
 ::
 
     $ conda config --add channels omnia
-    $ conda config --add channels mosdef
     $ conda config --add channels conda-forge
     $ conda install --file requirements.txt
 


### PR DESCRIPTION
Test in GMSO is failing since Foyer is still being pulled from the `mosdef` channel. This PR removes the `mosdef` channel from the testing process and installation docs. Mirror https://github.com/mosdef-hub/mbuild/pull/823.