### PR TITLE
Include angle and dihedral information on conversion to networkx

### DIFF
--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -580,6 +580,14 @@ class Topology(object):
         self.update_connection_types()
         self.is_typed(updated=True)
 
+    def _get_bonds_for(self, site):
+        """return a list of the bonds that contain Site"""
+        bonds = []
+        for bond in self.bonds:
+            if site in bond.connection_members:
+                bonds.append(bond)
+        return bonds
+
     def _get_angles_for(self, site):
         """return a list of the angles that contain Site"""
         angles = []

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -580,6 +580,22 @@ class Topology(object):
         self.update_connection_types()
         self.is_typed(updated=True)
 
+    def _get_angles_for(self, site):
+        """return a list of the angles that contain Site"""
+        angles = []
+        for angle in self.angles:
+            if site in angle.connection_members:
+                angles.append(angle)
+        return angles
+
+    def _get_dihedrals_for(self, site):
+        """return a list of the dihedrals that contain Site"""
+        dihedrals = []
+        for dihedral in self.dihedrals:
+            if site in dihedral.connection_members:
+                dihedrals.append(dihedral)
+        return dihedrals
+
     def get_index(self, member):
         """Get index of a member in the topology
 

--- a/gmso/external/convert_networkx.py
+++ b/gmso/external/convert_networkx.py
@@ -1,3 +1,4 @@
+import warnings
 import networkx as nx
 
 from gmso.exceptions import GMSOError
@@ -39,6 +40,7 @@ def from_networkx(graph):
     top = Topology()
 
     node_mapping = dict()
+
     for node in graph.nodes:
         if not isinstance(node, Site):
             raise TypeError("Nodes must be instances of gmso.abc.Site")
@@ -55,6 +57,12 @@ def from_networkx(graph):
             conn = Bond(connection_members=edge)
             top.add_connection(conn)
 
+    warnings.simplefilter('once', UserWarning) 
+
+    for node in graph.nodes:
+        if graph.nodes[node]['angles'] or graph.nodes[node]['dihedrals']:
+            warnings.warn("Angle and Dihedral information is not converted.") 
+    
     return top
 
 def to_networkx(top):

--- a/gmso/external/convert_networkx.py
+++ b/gmso/external/convert_networkx.py
@@ -60,9 +60,12 @@ def from_networkx(graph):
     warnings.simplefilter('once', UserWarning) 
 
     for node in graph.nodes:
-        if graph.nodes[node]['angles'] or graph.nodes[node]['dihedrals']:
+        try:
+            graph.nodes[node]['angles'] or graph.nodes[node]['dihedrals']:
             warnings.warn("Angle and Dihedral information is not converted.") 
-    
+        except KeyError:
+            pass
+
     return top
 
 def to_networkx(top):

--- a/gmso/external/convert_networkx.py
+++ b/gmso/external/convert_networkx.py
@@ -88,4 +88,18 @@ def to_networkx(top):
     for b in top.bonds:
         graph.add_edge(b.connection_members[0], b.connection_members[1], connection=b)
 
+    for node in graph.nodes:
+        angles = []
+        for angle in list(top.angles):
+            if node in angle.connection_members:
+                angles.append(angle)
+        graph.nodes[node]['angles'] = angles
+
+    for node in graph.nodes:
+        dihedrals = []
+        for dihedral in list(top.dihedrals):
+            if node in dihedral.connection_members:
+                dihedrals.append(dihedral)
+        graph.nodes[node]['dihedrals'] = dihedrals
+
     return graph

--- a/gmso/external/convert_networkx.py
+++ b/gmso/external/convert_networkx.py
@@ -89,17 +89,9 @@ def to_networkx(top):
         graph.add_edge(b.connection_members[0], b.connection_members[1], connection=b)
 
     for node in graph.nodes:
-        angles = []
-        for angle in list(top.angles):
-            if node in angle.connection_members:
-                angles.append(angle)
-        graph.nodes[node]['angles'] = angles
+        graph.nodes[node]['angles'] = top._get_angles_for(node)
 
     for node in graph.nodes:
-        dihedrals = []
-        for dihedral in list(top.dihedrals):
-            if node in dihedral.connection_members:
-                dihedrals.append(dihedral)
-        graph.nodes[node]['dihedrals'] = dihedrals
+        graph.nodes[node]['dihedrals'] = top._get_dihedrals_for(node)
 
     return graph

--- a/gmso/external/convert_networkx.py
+++ b/gmso/external/convert_networkx.py
@@ -61,7 +61,7 @@ def from_networkx(graph):
 
     for node in graph.nodes:
         try:
-            graph.nodes[node]['angles'] or graph.nodes[node]['dihedrals']:
+            graph.nodes[node]['angles'] or graph.nodes[node]['dihedrals']
             warnings.warn("Angle and Dihedral information is not converted.") 
         except KeyError:
             pass

--- a/gmso/tests/test_convert_networkx.py
+++ b/gmso/tests/test_convert_networkx.py
@@ -16,7 +16,12 @@ class TestConvertNetworkX(BaseTest):
         assert ethane.n_sites == ethane_to_nx.number_of_nodes()
         assert ethane.n_bonds == ethane_to_nx.number_of_edges()
 
+
+        
         assert set(ethane.sites) == set(ethane_to_nx.nodes)
+        for site in ethane.sites:
+            assert set(ethane_to_nx.nodes[site]['angles']) == set(ethane._get_angles_for(site))
+            assert set(ethane_to_nx.nodes[site]['dihedrals']) == set(ethane._get_dihedrals_for(site))
 
     def test_from_networkx_ethane(self, ethane):
         ethane_to_nx = to_networkx(ethane)

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -536,3 +536,33 @@ class TestTopology(BaseTest):
         prev_idx = typed_methylnitroaniline.get_index(dihedral_type_to_test)
         typed_methylnitroaniline.dihedrals[0].connection_type.name = 'changed name'
         assert typed_methylnitroaniline.get_index(dihedral_type_to_test) != prev_idx
+
+    def test_topology_get_bonds_for(self, typed_methylnitroaniline):
+        site = list(typed_methylnitroaniline.sites)[0]
+        converted_bonds_list = typed_methylnitroaniline._get_bonds_for(site)
+        top_bonds_containing_site = []
+        for bond in typed_methylnitroaniline.bonds:
+            if site in bond.connection_members:
+                assert bond in converted_bonds_list
+                top_bonds_containing_site.append(bond)
+        assert len(top_bonds_containing_site) == len(converted_bonds_list)
+
+    def test_topology_get_angles_for(self, typed_methylnitroaniline):
+        site = list(typed_methylnitroaniline.sites)[0]
+        converted_angles_list = typed_methylnitroaniline._get_angles_for(site)
+        top_angles_containing_site = []
+        for angle in typed_methylnitroaniline.angles:
+            if site in angle.connection_members:
+                assert angle in converted_angles_list
+                top_angles_containing_site.append(angle)
+        assert len(top_angles_containing_site) == len(converted_angles_list)
+
+    def test_topology_get_dihedrals_for(self, typed_methylnitroaniline):
+        site = list(typed_methylnitroaniline.sites)[0]
+        converted_dihedrals_list = typed_methylnitroaniline._get_dihedrals_for(site)
+        top_dihedrals_containing_site = []
+        for dihedral in typed_methylnitroaniline.dihedrals:
+            if site in dihedral.connection_members:
+                assert dihedral in converted_dihedrals_list
+                top_dihedrals_containing_site.append(dihedral)
+        assert len(top_dihedrals_containing_site) == len(converted_dihedrals_list)


### PR DESCRIPTION
Include during the to_networkx conversion angle and dihedral information. This is stored as `angles` and `dihedrals` Networkx graph attributes for each node. The information stored there is accessible in the same way as we access this information stored within the topology objects (as the Angle class from gmso/core/angle.py and the Dihedrals class from gmso/core/dihedral.py. Therefore, any single node can be selected, and the dihedrals and angles it is an element of can be iterated through and printed. 

Once a graph object is returned through the command:
`Graph = gmso/external/to_networkx(topology)`

The information can be accessed with code such as:
`for node in Graph.nodes:`
    `print(Graph.nodes[node]['angles'])`

And likewise for dihedrals by replacing 'angles' with 'dihedrals'.
