### PR TITLE
Add doi conversion from foyer XML

### DIFF
--- a/gmso/external/convert_foyer_xml.py
+++ b/gmso/external/convert_foyer_xml.py
@@ -278,6 +278,7 @@ def _write_nbforces(forcefield, ff_kwargs):
                 "mass": atom_type.get("mass", "0.0"),
                 "definition": atom_type.get("def", ""),
                 "description": atom_type.get("desc", ""),
+                "doi": atom_type.get("doi", "")
             },
         )
 


### PR DESCRIPTION
We are current not translating doi information when converting foyer XML to GMSO XML. This PR add that conversion. 