### PR TITLE
Add MetadataMixin for tags in Potentials

### DIFF
--- a/gmso/abc/abstract_potential.py
+++ b/gmso/abc/abstract_potential.py
@@ -49,7 +49,7 @@ class AbstractPotential(GMSOBase, MetadataMixin):
                 parameters=None
             )
 
-        MetadataMixin.__init__(self, tags=kwargs.pop('tags', {}))
+        MetadataMixin.__init__(self, tags=kwargs.get('tags'))
 
         GMSOBase.__init__(
             self,

--- a/gmso/abc/abstract_potential.py
+++ b/gmso/abc/abstract_potential.py
@@ -4,10 +4,11 @@ from abc import abstractmethod
 from pydantic import Field
 
 from gmso.abc.gmso_base import GMSOBase
+from gmso.abc.metadata import MetadataMixin
 from gmso.utils.expression import _PotentialExpression
 
 
-class AbstractPotential(GMSOBase):
+class AbstractPotential(GMSOBase, MetadataMixin):
     __base_doc__ = """An abstract potential class.
 
     AbstractPotential stores a general interaction between components of a chemical
@@ -48,7 +49,10 @@ class AbstractPotential(GMSOBase):
                 parameters=None
             )
 
-        super().__init__(
+        MetadataMixin.__init__(self, tags=kwargs.pop('tags', {}))
+
+        GMSOBase.__init__(
+            self,
             name=name,
             potential_expression=potential_expression,
             **kwargs

--- a/gmso/abc/abstract_potential.py
+++ b/gmso/abc/abstract_potential.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from pydantic import Field
 
 from gmso.abc.gmso_base import GMSOBase
-from gmso.abc.metadata import MetadataMixin
+from gmso.abc.metadata_mixin import MetadataMixin
 from gmso.utils.expression import _PotentialExpression
 
 

--- a/gmso/abc/gmso_base.py
+++ b/gmso/abc/gmso_base.py
@@ -23,7 +23,7 @@ class GMSOBase(BaseModel, ABC):
     def __setattr__(self, name: Any, value: Any) -> None:
         if name in self.__config__.alias_to_fields:
             name = self.__config__.alias_to_fields[name]
-        else:
+        elif name in self.__config__.alias_to_fields.values():
             warnings.warn(
                 'Use of internal fields is discouraged. '
                 'Please use external fields to set attributes.'

--- a/gmso/abc/metadata.py
+++ b/gmso/abc/metadata.py
@@ -5,7 +5,7 @@ from pydantic import Field, BaseModel, validator
 
 class MetadataMixin(BaseModel):
     tags: Dict[str, Any] = Field(
-        {},
+        default={},
         description='Tags associated with the metadata'
     )
 

--- a/gmso/abc/metadata.py
+++ b/gmso/abc/metadata.py
@@ -1,0 +1,42 @@
+from typing import Dict, Any, List, Iterator
+
+from pydantic import Field, BaseModel, validator
+
+
+class MetadataMixin(BaseModel):
+    tags: Dict[str, Any] = Field(
+        {},
+        description='Tags associated with the metadata'
+    )
+
+    @property
+    def tag_names(self) -> List[str]:
+        return list(self.__dict__.get('tags'))
+
+    @property
+    def tag_names_iter(self) -> Iterator[str]:
+        return iter(self.__dict__.get('tags'))
+
+    def add_tag(self, tag: str, value: Any, overwrite=True) -> None:
+        """Add metadata for a particular tag"""
+        if self.tags.get(tag) is None and not overwrite:
+            raise ValueError(
+                f'Tag {tag} already exists. '
+                f'Please use overwrite=True to overwrite'
+            )
+        self.tags[tag] = value
+
+    def delete_tag(self, tag: str) -> None:
+        del self.tags[tag]
+
+    def pop_tag(self, tag: str) -> Any:
+        return self.tags.pop(tag)
+
+    @validator('tags', pre=True)
+    def validate_tags(cls, value):
+        if value is None:
+            value = dict()
+        return value
+
+    class Config:
+        validate_assignment = True

--- a/gmso/abc/metadata_mixin.py
+++ b/gmso/abc/metadata_mixin.py
@@ -26,11 +26,18 @@ class MetadataMixin(BaseModel):
             )
         self.tags[tag] = value
 
+    def get_tag(self, tag: str, throw=False) -> Any:
+        """Get value of a particular tag"""
+        if throw:
+            return self.tags[tag]
+        else:
+            return self.tags.get(tag)
+
     def delete_tag(self, tag: str) -> None:
         del self.tags[tag]
 
     def pop_tag(self, tag: str) -> Any:
-        return self.tags.pop(tag)
+        return self.tags.pop(tag, None)
 
     @validator('tags', pre=True)
     def validate_tags(cls, value):

--- a/gmso/core/angle_type.py
+++ b/gmso/core/angle_type.py
@@ -36,7 +36,8 @@ class AngleType(ParametricPotential):
                  parameters=None,
                  independent_variables=None,
                  member_types=None,
-                 topology=None):
+                 topology=None,
+                 tags=None):
         if parameters is None:
             parameters = {
                 'k': 1000 * u.Unit('kJ / (deg**2)'),
@@ -52,7 +53,8 @@ class AngleType(ParametricPotential):
             independent_variables=independent_variables,
             topology=topology,
             member_types=member_types,
-            set_ref=ANGLE_TYPE_DICT
+            set_ref=ANGLE_TYPE_DICT,
+            tags=tags
         )
 
     @property

--- a/gmso/core/atom_type.py
+++ b/gmso/core/atom_type.py
@@ -66,6 +66,7 @@ class AtomType(ParametricPotential):
                  independent_variables=None,
                  atomclass='', doi='', overrides=None, definition='',
                  description='',
+                 tags=None,
                  topology=None):
         if parameters is None:
             parameters = {'sigma': 0.3 * u.nm,
@@ -89,7 +90,8 @@ class AtomType(ParametricPotential):
             overrides=overrides,
             description=description,
             definition=definition,
-            set_ref=ATOM_TYPE_DICT
+            set_ref=ATOM_TYPE_DICT,
+            tags=tags
         )
 
     @property

--- a/gmso/core/bond_type.py
+++ b/gmso/core/bond_type.py
@@ -36,7 +36,8 @@ class BondType(ParametricPotential):
                  parameters=None,
                  independent_variables=None,
                  member_types=None,
-                 topology=None):
+                 topology=None,
+                 tags=None):
         if parameters is None:
             parameters = {
                 'k': 1000 * u.Unit('kJ / (nm**2)'),
@@ -52,7 +53,8 @@ class BondType(ParametricPotential):
             independent_variables=independent_variables,
             topology=topology,
             member_types=member_types,
-            set_ref=BOND_TYPE_DICT
+            set_ref=BOND_TYPE_DICT,
+            tags=tags
         )
 
     @property

--- a/gmso/core/dihedral_type.py
+++ b/gmso/core/dihedral_type.py
@@ -42,7 +42,8 @@ class DihedralType(ParametricPotential):
                  parameters=None,
                  independent_variables=None,
                  member_types=None,
-                 topology=None):
+                 topology=None,
+                 tags=None):
         if parameters is None:
             parameters = {
                 'k': 1000 * u.Unit('kJ / (deg**2)'),
@@ -59,7 +60,8 @@ class DihedralType(ParametricPotential):
             independent_variables=independent_variables,
             topology=topology,
             member_types=member_types,
-            set_ref=DIHEDRAL_TYPE_DICT
+            set_ref=DIHEDRAL_TYPE_DICT,
+            tags=tags
         )
 
     @property

--- a/gmso/core/improper_type.py
+++ b/gmso/core/improper_type.py
@@ -46,7 +46,8 @@ class ImproperType(ParametricPotential):
                  parameters=None,
                  independent_variables=None,
                  member_types=None,
-                 topology=None):
+                 topology=None,
+                 tags=None):
         if parameters is None:
             parameters = {
                 'k': 1000 * u.Unit('kJ / (deg**2)'),
@@ -62,7 +63,8 @@ class ImproperType(ParametricPotential):
             independent_variables=independent_variables,
             topology=topology,
             member_types=member_types,
-            set_ref=IMPROPER_TYPE_DICT
+            set_ref=IMPROPER_TYPE_DICT,
+            tags=tags
         )
 
     @property

--- a/gmso/tests/test_metadata_mixin.py
+++ b/gmso/tests/test_metadata_mixin.py
@@ -1,0 +1,36 @@
+import pytest
+from gmso.abc.metadata_mixin import MetadataMixin
+from gmso.tests.base_test import BaseTest
+
+
+class TestMetadataMixin(BaseTest):
+    @pytest.fixture(scope='session')
+    def metadata_mixin(self):
+        return MetadataMixin()
+
+    def test_metadata_empty_tags(self, metadata_mixin):
+        assert metadata_mixin.tag_names == []
+        assert list(metadata_mixin.tag_names_iter) == []
+
+    def test_metadata_add_tags(self, metadata_mixin):
+        metadata_mixin.add_tag('tag1', dict([('tag_name_1', 'value_1')]))
+        metadata_mixin.add_tag('tag2', dict([('tag_name_2', 'value_2')]))
+        metadata_mixin.add_tag('int_tag', 1)
+        assert len(metadata_mixin.tag_names) == 3
+
+    def test_metadata_get_tags(self, metadata_mixin):
+        assert metadata_mixin.get_tag('tag1').get('tag_name_1') == 'value_1'
+        assert metadata_mixin.get_tag('int_tag') == 1
+        assert metadata_mixin.get_tag('non_existent_tag') is None
+        with pytest.raises(KeyError):
+            metadata_mixin.get_tag('non_existent_tag', throw=True)
+
+    def test_metadata_mixin_all_tags(self, metadata_mixin):
+        assert 'int_tag' in metadata_mixin.tags
+
+    def test_metadata_mixin_delete_tags(self, metadata_mixin):
+        with pytest.raises(KeyError):
+            metadata_mixin.delete_tag('non_existent_tag')
+        assert metadata_mixin.pop_tag('non_existent_tag') is None
+        metadata_mixin.delete_tag('int_tag')
+        assert len(metadata_mixin.tag_names) == 2

--- a/gmso/utils/ff_utils.py
+++ b/gmso/utils/ff_utils.py
@@ -257,7 +257,8 @@ def parse_ff_atomtypes(atomtypes_el, ff_meta):
             'overrides': '',
             'definition': '',
             'description': '',
-            'topology': None
+            'topology': None,
+            'element': ''
         }
 
         if atom_types_expression:
@@ -265,6 +266,15 @@ def parse_ff_atomtypes(atomtypes_el, ff_meta):
 
         for kwarg in ctor_kwargs.keys():
             ctor_kwargs[kwarg] = atom_type.attrib.get(kwarg, ctor_kwargs[kwarg])
+
+        tags = {
+            'tags': {
+                'element': ctor_kwargs.pop('element', '')
+            }
+        }
+
+        ctor_kwargs.update(tags)
+
         if isinstance(ctor_kwargs['mass'], str):
             ctor_kwargs['mass'] = u.unyt_quantity(float(ctor_kwargs['mass']), units_dict['mass'])
         if isinstance(ctor_kwargs['overrides'], str):


### PR DESCRIPTION
This PR adds a Mixin class for addition of tagged data to Potentials. Few methods will be available for every `Potential` created in `gmso` after this. Closes #446 in a round about way :green_circle: .
Example:
```py
>>> from gmso import ForceField
>>> from gmso.tests.utils import get_path
>>> ff = ForceField(get_path('carbon.xml'))
>>> ff.atom_types
{'C': <AtomType C, id 139889433050704>}
>>> ff.atom_types['C']
<AtomType C, id 139889433050704>
>>> ff.atom_types['C'].tags
{'element': 'C'}
>>> ff.atom_types['C'].tag_names
['element']
>>> ff.atom_types['C'].add_tag('scaling_factor', 1.4) 
>>> ff.atom_types['C'].tags
{'element': 'C', 'scaling_factor': 1.4}
>>> 
 
```