### PR TITLE
Remove autodoc warning

### DIFF
--- a/gmso/abc/auto_doc.py
+++ b/gmso/abc/auto_doc.py
@@ -153,7 +153,7 @@ def _find_extra_params(cls, fields, init_params):
     extra_params = []
     aliases_set = set(field.alias for field in fields.values())
     for param in init_params:
-        if param not in aliases_set and param is not 'self':
+        if param not in aliases_set and param != 'self':
             if hasattr(cls, param) and isinstance(getattr(cls, param), property):
                 prop = getattr(cls, param)
                 [doc_main, doc_desc] = prop.__doc__.split('\n')


### PR DESCRIPTION
When importing `gmso` I get the following warning:

```
>>> import gmso
/Users/ryandefever/repos/mosdef/gmso/gmso/abc/auto_doc.py:156: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if param not in aliases_set and param is not 'self':
```

I switched `is not` for `!=` in the relevant file. I frankly don't know much about this, so someone @umesh-timalsina can you confirm that this is the correct fix.

