### PR TITLE
Fix error in mbuild conversion when compound.name is empty

### DIFF
--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -124,11 +124,8 @@ class Topology(object):
         A topology within a topology
     """
     def __init__(self, name="Topology", box=None):
-        if name is not None:
-            self._name = name
-        else:
-            self._name = "Topology"
 
+        self.name = name
         self._box = box
         self._sites = IndexedSet()
         self._typed = False
@@ -175,7 +172,7 @@ class Topology(object):
 
     @name.setter
     def name(self, name):
-        self._name = str(name) if name else None
+        self._name = str(name) if name else 'Topology'
 
     @property
     def box(self):

--- a/gmso/external/convert_mbuild.py
+++ b/gmso/external/convert_mbuild.py
@@ -72,9 +72,7 @@ def from_mbuild(compound, box=None, search_method=element_by_symbol):
     top.typed = False
 
     # Keep the name if it is not the default mBuild Compound name
-    if ( compound.name != mb.Compound().name and
-         compound.name != '' and
-         compound.name != None):
+    if compound.name != mb.Compound().name:
         top.name = compound.name
 
     site_map = dict()

--- a/gmso/external/convert_mbuild.py
+++ b/gmso/external/convert_mbuild.py
@@ -149,7 +149,7 @@ def to_mbuild(topology):
     assert isinstance(topology, Topology), msg
 
     compound = mb.Compound()
-    if topology.name is None:
+    if topology.name is Topology().name:
         compound.name = 'Compound'
     else:
         compound.name = topology.name

--- a/gmso/external/convert_mbuild.py
+++ b/gmso/external/convert_mbuild.py
@@ -72,7 +72,9 @@ def from_mbuild(compound, box=None, search_method=element_by_symbol):
     top.typed = False
 
     # Keep the name if it is not the default mBuild Compound name
-    if compound.name != mb.Compound().name:
+    if ( compound.name != mb.Compound().name and
+         compound.name != '' and
+         compound.name != None):
         top.name = compound.name
 
     site_map = dict()

--- a/gmso/tests/test_convert_mbuild.py
+++ b/gmso/tests/test_convert_mbuild.py
@@ -165,5 +165,5 @@ class TestConvertMBuild(BaseTest):
     def test_empty_compound_name(self):
         compound = mb.load("CCOC", smiles=True)
         top = from_mbuild(compound)
-        print(top)
+        assert top.name is not None
 

--- a/gmso/tests/test_convert_mbuild.py
+++ b/gmso/tests/test_convert_mbuild.py
@@ -161,3 +161,9 @@ class TestConvertMBuild(BaseTest):
         top = from_mbuild(mb_ethane)
         assert_allclose_units(top.box.lengths,
                 (mb_ethane.boundingbox.lengths + [0.5, 0.5, 0.5]) * u.nm, rtol=1e-5, atol=1e-8)
+
+    def test_empty_compound_name(self):
+        compound = mb.load("CCOC", smiles=True)
+        top = from_mbuild(compound)
+        print(top)
+

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -35,6 +35,10 @@ class TestTopology(BaseTest):
         top = Topology(name='mytop')
         assert top.name == 'mytop'
 
+    def test_empty_name(self):
+        top = Topology(name='')
+        assert top.name == 'Topology'
+
     def test_change_comb_rule(self):
         top = Topology()
         assert top.combining_rule == 'lorentz'


### PR DESCRIPTION
Closes #503 

The error arose because of the condition that accepted the `compound.name` if it was not the default value. I guess when creating a molecule from SMILES, the `compound.name` ends up being empty, i.e., `compound.name = ''`. 

I made a change to the `name.setter` in `gmso.Topology` so that if the string is empty or `None`, then the default name, `"Topology"` is used. 

