### PR TITLE
Change the element repr to report the mass in amu

### DIFF
--- a/gmso/core/element.py
+++ b/gmso/core/element.py
@@ -26,11 +26,10 @@ class Element(GMSOBase):
     mass: u.unyt_quantity = Field(..., description='Mass of the element.')
 
     def __repr__(self):
-        mass_string = f"{self.mass.to(u.amu)}".split()[0] + " amu"
         return 'Element: {}, symbol: {}, atomic number: {}, mass: {}'.format(
                                                                       self.name, self.symbol,
                                                                       self.atomic_number,
-                                                                      mass_string)
+                                                                      self.mass.to("amu"))
 
     def __eq__(self, other):
         return hash(self) == hash(other)

--- a/gmso/core/element.py
+++ b/gmso/core/element.py
@@ -26,10 +26,11 @@ class Element(GMSOBase):
     mass: u.unyt_quantity = Field(..., description='Mass of the element.')
 
     def __repr__(self):
+        mass_string = f"{self.mass.to(u.amu)}".split()[0] + " amu"
         return 'Element: {}, symbol: {}, atomic number: {}, mass: {}'.format(
                                                                       self.name, self.symbol,
                                                                       self.atomic_number,
-                                                                      self.mass)
+                                                                      mass_string)
 
     def __eq__(self, other):
         return hash(self) == hash(other)


### PR DESCRIPTION
Very simple change so that the `element` `__repr__` reports the mass of the element in atomic mass units, instead of `kg`. Due to the way that `unyt` handles `amu` units, I had to do a little messing with the string to make it print pretty. 

**Before**:
```python
element=element_by_symbol("C")
element
```

```
Element: carbon, symbol: C, atomic number: 6, mass: 1.9944234818454697e-26 kg
```

**After**:
```python
element=element_by_symbol("C")
element
```

```
Element: carbon, symbol: C, atomic number: 6, mass: 12.0107 amu
```