### PR TITLE
Fix typo in Periodic Torsion

### DIFF
--- a/gmso/lib/jsons/PeriodicTorsionPotential.json
+++ b/gmso/lib/jsons/PeriodicTorsionPotential.json
@@ -1,5 +1,5 @@
 {
   "name": "PeriodicTorsionPotential",
-  "expression": "k * (1 + cos(n * phi - phi_eq))**2",
+  "expression": "k * (1 + cos(n * phi - phi_eq))",
   "independent_variables": "phi"
 }

--- a/gmso/tests/test_potential_templates.py
+++ b/gmso/tests/test_potential_templates.py
@@ -42,7 +42,7 @@ class TestPotentialTemplates(BaseTest):
     def test_periodic_torsion_potential(self, templates):
         periodic_torsion_potential = templates['PeriodicTorsionPotential']
         assert periodic_torsion_potential.name == 'PeriodicTorsionPotential'
-        assert periodic_torsion_potential.expression == sympy.sympify('k * (1 + cos(n * phi - phi_eq))**2')
+        assert periodic_torsion_potential.expression == sympy.sympify('k * (1 + cos(n * phi - phi_eq))')
         assert periodic_torsion_potential.independent_variables == {sympy.sympify('phi')}
 
     def test_ryckaert_bellemans_torsion_potential(self, templates):


### PR DESCRIPTION
I believe there is a typo in the `PotentialTemplate` for periodic torsions. The value is squared when it should not be. See reference [here](https://manual.gromacs.org/current/reference-manual/functions/bonded-interactions.html#proper-dihedrals-periodic-type).