### PR TITLE
Add periodic improper potential

### DIFF
--- a/gmso/lib/jsons/PeriodicImproperPotential.json
+++ b/gmso/lib/jsons/PeriodicImproperPotential.json
@@ -1,5 +1,5 @@
 {
-  "name": "PeriodicTorsionPotential",
+  "name": "PeriodicImproperPotential",
   "expression": "k * (1 + cos(n * phi - phi_eq))",
   "independent_variables": "phi"
 }

--- a/gmso/lib/jsons/PeriodicImproperPotential.json
+++ b/gmso/lib/jsons/PeriodicImproperPotential.json
@@ -1,0 +1,5 @@
+{
+  "name": "PeriodicTorsionPotential",
+  "expression": "k * (1 + cos(n * phi - phi_eq))",
+  "independent_variables": "phi"
+}

--- a/gmso/tests/test_potential_templates.py
+++ b/gmso/tests/test_potential_templates.py
@@ -65,6 +65,12 @@ class TestPotentialTemplates(BaseTest):
         assert harmonic_improper_potential.expression == sympy.sympify('0.5 * k * (phi - phi_eq)**2')
         assert harmonic_improper_potential.independent_variables == {sympy.sympify('phi')}
 
+    def test_periodic_improper_potential(self, templates):
+        periodic_torsion_potential = templates['PeriodicImproperPotential']
+        assert periodic_torsion_potential.name == 'PeriodicImproperPotential'
+        assert periodic_torsion_potential.expression == sympy.sympify('k * (1 + cos(n * phi - phi_eq))')
+        assert periodic_torsion_potential.independent_variables == {sympy.sympify('phi')}
+
     def test_harmonic_bond_potential(self, templates):
         harmonic_bond_potential = templates['HarmonicBondPotential']
         assert harmonic_bond_potential.name == 'HarmonicBondPotential'


### PR DESCRIPTION
Self explanatory. Adds a potential template for `PeriodicImproperPotential`. 

See [here for GROMACS](https://manual.gromacs.org/current/reference-manual/functions/bonded-interactions.html#improper-dihedrals-periodic-type) and [here for LAMMPS](https://lammps.sandia.gov/doc/dihedral_charmm.html).