### PR TITLE
Initial addition of scaling factors to topology

### DIFF
--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -46,6 +46,9 @@ class Topology(object):
     combining_rule : str, ['lorentz', 'geometric']
         The combining rule for the topology, can be either 'lorentz' or 'geometric'
 
+    scaling_factors : dict
+        A collection of scaling factors used in the forcefield
+
     n_sites : int
         Number of sites in the topology
 
@@ -147,6 +150,14 @@ class Topology(object):
         self._improper_types = {}
         self._improper_types_idx = {}
         self._combining_rule = 'lorentz'
+        self._scaling_factors = {
+            "vdw_12": 0.0,
+            "vdw_13": 0.0,
+            "vdw_14": 0.5,
+            "coul_12": 0.0,
+            "coul_13": 0.0,
+            "coul_14": 0.5,
+        }
         self._set_refs = {
             ATOM_TYPE_DICT: self._atom_types,
             BOND_TYPE_DICT: self._bond_types,
@@ -199,6 +210,24 @@ class Topology(object):
         if rule not in ['lorentz', 'geometric']:
             raise GMSOError('Combining rule must be `lorentz` or `geometric`')
         self._combining_rule = rule
+
+    @property
+    def scaling_factors(self):
+        return self._scaling_factors
+
+    @scaling_factors.setter
+    def scaling_factors(self, scaling_factors):
+        expected_items = ["vdw_12", "vdw_13", "vdw_14", "coul_12", "coul_13", "coul_14"]
+        if not isinstance(scaling_factors, dict):
+            raise GMSOError("Scaling factors should be a dictionary")
+        for item in expected_items:
+            if item not in scaling_factors.keys():
+                raise GMSOError(f"Expected {expected_items} as keys in the scaling factors")
+        for val in scaling_factors.values():
+            if val < 0.0 or val > 1.0:
+                raise GMSOError("Scaling factors should be between 0.0 and 1.0")
+
+        self._scaling_factors = scaling_factors
 
     @property
     def positions(self):

--- a/gmso/tests/test_mcf.py
+++ b/gmso/tests/test_mcf.py
@@ -111,3 +111,42 @@ class TestMCF(BaseTest):
         top.atom_types[0].set_expression(alternate_lj)
 
         write_mcf(top, "ar.mcf")
+
+    def test_scaling_factors(self, n_typed_ar_system):
+        top = n_typed_ar_system()
+        write_mcf(top, "ar.mcf")
+        mcf_data = []
+        with open("ar.mcf") as f:
+            for line in f:
+                mcf_data.append(line.strip().split())
+        assert np.allclose(float(mcf_data[-5][0]), 0.0)
+        assert np.allclose(float(mcf_data[-5][1]), 0.0)
+        assert np.allclose(float(mcf_data[-5][2]), 0.5)
+        assert np.allclose(float(mcf_data[-5][3]), 1.0)
+        assert np.allclose(float(mcf_data[-4][0]), 0.0)
+        assert np.allclose(float(mcf_data[-4][1]), 0.0)
+        assert np.allclose(float(mcf_data[-4][2]), 0.5)
+        assert np.allclose(float(mcf_data[-4][3]), 1.0)
+
+        top.scaling_factors = {
+            "vdw_12": 0.1,
+            "vdw_13": 0.2,
+            "vdw_14": 0.5,
+            "coul_12": 0.2,
+            "coul_13": 0.4,
+            "coul_14": 0.6,
+        }
+
+        write_mcf(top, "ar.mcf")
+        mcf_data = []
+        with open("ar.mcf") as f:
+            for line in f:
+                mcf_data.append(line.strip().split())
+        assert np.allclose(float(mcf_data[-5][0]), 0.1)
+        assert np.allclose(float(mcf_data[-5][1]), 0.2)
+        assert np.allclose(float(mcf_data[-5][2]), 0.5)
+        assert np.allclose(float(mcf_data[-5][3]), 1.0)
+        assert np.allclose(float(mcf_data[-4][0]), 0.2)
+        assert np.allclose(float(mcf_data[-4][1]), 0.4)
+        assert np.allclose(float(mcf_data[-4][2]), 0.6)
+        assert np.allclose(float(mcf_data[-4][3]), 1.0)

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -570,3 +570,39 @@ class TestTopology(BaseTest):
                 assert dihedral in converted_dihedrals_list
                 top_dihedrals_containing_site.append(dihedral)
         assert len(top_dihedrals_containing_site) == len(converted_dihedrals_list)
+
+    def test_topology_scale_factors(self, typed_methylnitroaniline):
+        sf = typed_methylnitroaniline.scaling_factors
+        assert np.allclose(sf["vdw_12"], 0.0)
+        assert np.allclose(sf["vdw_13"], 0.0)
+        assert np.allclose(sf["vdw_14"], 0.5)
+        assert np.allclose(sf["coul_12"], 0.0)
+        assert np.allclose(sf["coul_13"], 0.0)
+        assert np.allclose(sf["coul_14"], 0.5)
+
+    def test_topology_change_scale_factors(self, typed_methylnitroaniline):
+        typed_methylnitroaniline.scaling_factors = {
+            "vdw_12": 0.5,
+            "vdw_13": 0.5,
+            "vdw_14": 1.0,
+            "coul_12": 1.0,
+            "coul_13": 1.0,
+            "coul_14": 1.0,
+        }
+        sf = typed_methylnitroaniline.scaling_factors
+        assert np.allclose(sf["vdw_12"], 0.5)
+        assert np.allclose(sf["vdw_13"], 0.5)
+        assert np.allclose(sf["vdw_14"], 1.0)
+        assert np.allclose(sf["coul_12"], 1.0)
+        assert np.allclose(sf["coul_13"], 1.0)
+        assert np.allclose(sf["coul_14"], 1.0)
+        typed_methylnitroaniline.scaling_factors["vdw_12"] = 1.0
+        assert np.allclose(sf["vdw_12"], 1.0)
+
+    def test_topology_invalid_scaling_factors(self, typed_methylnitroaniline):
+        with pytest.raises(GMSOError):
+            typed_methylnitroaniline.scaling_factors = (0.5, 1.0)
+        with pytest.raises(GMSOError):
+            typed_methylnitroaniline.scaling_factors = {
+                "lj_12": 0.0
+            }


### PR DESCRIPTION
Initial changes to add scaling factors to `Topology`. Closes #363. 

If someone who is familiar with `parmed` and `openmm`, it would be nice to support translation of the scaling factors from `gmso` <--> `parmed` and `gmso` <--> `openmm`.

Note I included the `1-2` and `1-3` factors in addition to `1-4`. Though the `1-2` and `1-3` factors are often zero, this is more general than just specify the 1-4, and supported by [lammps](https://lammps.sandia.gov/doc/special_bonds.html) and [cassandra](https://cassandra-mc.readthedocs.io/en/latest/guides/input_files.html#intramolecular-scaling). I also used a more general term `vdw` rather than `lj`.

There is nothing preventing a user from adding additional scaling factors to the dictionary, though they might not be supported by the writers. 