### PR TITLE
Fix bug in MetadataMixin.add_tag overwrite

### DIFF
--- a/gmso/abc/metadata_mixin.py
+++ b/gmso/abc/metadata_mixin.py
@@ -19,7 +19,7 @@ class MetadataMixin(BaseModel):
 
     def add_tag(self, tag: str, value: Any, overwrite=True) -> None:
         """Add metadata for a particular tag"""
-        if self.tags.get(tag) is None and not overwrite:
+        if self.tags.get(tag) and not overwrite:
             raise ValueError(
                 f'Tag {tag} already exists. '
                 f'Please use overwrite=True to overwrite'

--- a/gmso/tests/test_metadata_mixin.py
+++ b/gmso/tests/test_metadata_mixin.py
@@ -18,6 +18,13 @@ class TestMetadataMixin(BaseTest):
         metadata_mixin.add_tag('int_tag', 1)
         assert len(metadata_mixin.tag_names) == 3
 
+    def test_metadata_mixin_add_tags_overwrite(self, metadata_mixin):
+        with pytest.raises(ValueError):
+            metadata_mixin.add_tag('tag2', 'new_value', overwrite=False)
+        metadata_mixin.add_tag('tag2', 'new_value', overwrite=True)
+        assert metadata_mixin.get_tag('tag2') == 'new_value'
+        assert len(metadata_mixin.tag_names) == 3
+
     def test_metadata_get_tags(self, metadata_mixin):
         assert metadata_mixin.get_tag('tag1').get('tag_name_1') == 'value_1'
         assert metadata_mixin.get_tag('int_tag') == 1


### PR DESCRIPTION
`MetadataMixin`, introduced in #501, had a bug when using `overwrite=False`, the `add_tag` method would fail when adding new tags with `overwrite=False`. This PR attempts to fix that. 