### PR TITLE
Update foyer converter 

### DIFF
--- a/gmso/external/convert_foyer_xml.py
+++ b/gmso/external/convert_foyer_xml.py
@@ -278,7 +278,8 @@ def _write_nbforces(forcefield, ff_kwargs):
                 "mass": atom_type.get("mass", "0.0"),
                 "definition": atom_type.get("def", ""),
                 "description": atom_type.get("desc", ""),
-                "doi": atom_type.get("doi", "")
+                "doi": atom_type.get("doi", ""),
+                "overrides": atom_type.get("overrides", "")
             },
         )
 


### PR DESCRIPTION
I just realized that the foyer converter does not convert `overrides` fields of the XML. This PR addresses that issue. 