### PR TITLE
Forcefield XML writers and Topology to ForceField Conversion 

### DIFF
--- a/gmso/core/atom_type.py
+++ b/gmso/core/atom_type.py
@@ -127,6 +127,12 @@ class AtomType(ParametricPotential):
         """Return the SMARTS string of the atom_type."""
         return self.__dict__.get("definition_")
 
+    def _etree_attrib(self):
+        attrib = super()._etree_attrib()
+        if self.overrides == set():
+            attrib.pop("overrides")
+        return attrib
+
     def __hash__(self):
         """Return the hash of the atom_type."""
         return hash(

--- a/gmso/core/forcefield.py
+++ b/gmso/core/forcefield.py
@@ -1,6 +1,7 @@
 """Module for working with GMSO forcefields."""
 import warnings
 from collections import ChainMap
+from pathlib import Path
 from typing import Iterable
 
 from lxml import etree
@@ -454,6 +455,125 @@ class ForceField(object):
     def __str__(self):
         """Return a string representation of the ForceField."""
         return f"<ForceField {self.name}, id: {id(self)}>"
+
+    def xml(self, filename, overwrite=False):
+        """Get an lxml ElementTree representation of this ForceField
+
+        Parameters
+        ----------
+        filename: Union[str, pathlib.Path], default=None
+            The filename to write the XML file to
+
+        overwrite: bool, default=False
+            If True, overwrite an existing file if it exists
+        """
+        ff_el = etree.Element(
+            "ForceField", attrib={"name": self.name, "version": self.version}
+        )
+
+        metadata = etree.SubElement(ff_el, "FFMetaData")
+        if self.scaling_factors.get("electrostatics14Scale"):
+            metadata.attrib["electrostatics14Scale"] = str(
+                self.scaling_factors.get("electrostatics14Scale")
+            )
+        if self.scaling_factors.get("nonBonded14Scale"):
+            metadata.attrib["nonBonded14Scale"] = str(
+                self.scaling_factors.get("nonBonded14Scale")
+            )
+
+        # ToDo: ParameterUnitsDefintions and DefaultUnits
+
+        etree.SubElement(
+            metadata,
+            "Units",
+            attrib={
+                "energy": "K*kb",
+                "distance": "nm",
+                "mass": "amu",
+                "charge": "coulomb",
+            },
+        )
+
+        at_groups = self.group_atom_types_by_expression()
+        for expr, atom_types in at_groups.items():
+            atypes = etree.SubElement(
+                ff_el, "AtomTypes", attrib={"expression": expr}
+            )
+            params_units_def = None
+            for atom_type in atom_types:
+                if params_units_def is None:
+                    params_units_def = {}
+                    for param, value in atom_type.parameters.items():
+                        params_units_def[param] = value.units
+                        etree.SubElement(
+                            atypes,
+                            "ParametersUnitDef",
+                            attrib={
+                                "parameter": param,
+                                "unit": str(value.units),
+                            },
+                        )
+
+                atypes.append(atom_type.etree(units=params_units_def))
+
+        bond_types_groups = self.group_bond_types_by_expression()
+        angle_types_groups = self.group_angle_types_by_expression()
+        dihedral_types_groups = self.group_dihedral_types_by_expression()
+        improper_types_groups = self.group_improper_types_by_expression()
+
+        for tag, potential_group in [
+            ("BondTypes", bond_types_groups),
+            ("AngleTypes", angle_types_groups),
+            ("DihedralTypes", dihedral_types_groups),
+            ("ImproperTypes", improper_types_groups),
+        ]:
+            for expr, potentials in potential_group.items():
+                potential_group = etree.SubElement(
+                    ff_el, tag, attrib={"expression": expr}
+                )
+                params_units_def = None
+                for potential in potentials:
+                    if params_units_def is None:
+                        params_units_def = {}
+                        for param, value in potential.parameters.items():
+                            params_units_def[param] = value.units
+                            etree.SubElement(
+                                potential_group,
+                                "ParametersUnitDef",
+                                attrib={
+                                    "parameter": param,
+                                    "unit": str(value.units),
+                                },
+                            )
+
+                    potential_group.append(potential.etree(params_units_def))
+
+        ff_etree = etree.ElementTree(element=ff_el)
+
+        if not isinstance(filename, Path):
+            filename = Path(filename)
+
+        if filename.suffix != ".xml":
+            from gmso.exceptions import ForceFieldError
+
+            raise ForceFieldError(
+                f"The filename {str(filename)} is not an XML file. "
+                f"Please provide filename with .xml extension"
+            )
+
+        if not overwrite and filename.exists():
+            raise FileExistsError(
+                f"File {filename} already exists. Consider "
+                f"using overwrite=True if you want to overwrite "
+                f"the existing file."
+            )
+
+        ff_etree.write(
+            str(filename),
+            pretty_print=True,
+            xml_declaration=True,
+            encoding="utf-8",
+        )
 
     @classmethod
     def from_xml(cls, xmls_or_etrees, strict=True, greedy=True):

--- a/gmso/core/parametric_potential.py
+++ b/gmso/core/parametric_potential.py
@@ -8,6 +8,7 @@ from gmso.abc.abstract_potential import AbstractPotential
 from gmso.exceptions import GMSOError
 from gmso.utils.decorators import confirm_dict_existence
 from gmso.utils.expression import PotentialExpression
+from gmso.utils.misc import get_xml_representation
 
 
 class ParametricPotential(AbstractPotential):

--- a/gmso/core/parametric_potential.py
+++ b/gmso/core/parametric_potential.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional, Union
 
 import unyt as u
+from lxml import etree
 from pydantic import Field, validator
 
 from gmso.abc.abstract_potential import AbstractPotential
@@ -205,6 +206,67 @@ class ParametricPotential(AbstractPotential):
             params = self.parameters
 
         return params
+
+    def _etree_attrib(self):
+        """Return the XML equivalent representation of this ParametricPotential"""
+        attrib = {
+            key: get_xml_representation(value)
+            for key, value in self.dict(
+                by_alias=True,
+                exclude_none=True,
+                exclude={
+                    "topology_",
+                    "set_ref_",
+                    "member_types_",
+                    "potential_expression_",
+                    "tags_",
+                },
+            ).items()
+            if value != ""
+        }
+
+        return attrib
+
+    def etree(self, units=None):
+        """Return an lxml.ElementTree for the parametric potential adhering to gmso XML schema"""
+
+        attrib = self._etree_attrib()
+
+        if hasattr(self, "member_types") and hasattr(self, "member_classes"):
+            if self.member_types:
+                iterating_attribute = self.member_types
+                prefix = "type"
+            elif self.member_classes:
+                iterating_attribute = self.member_classes
+                prefix = "class"
+            else:
+                raise GMSOError(
+                    f"Cannot convert {self.__class__.__name__} into an XML."
+                    f"Please specify member_classes or member_types attribute."
+                )
+            for idx, value in enumerate(iterating_attribute):
+                attrib[f"{prefix}{idx+1}"] = str(value)
+
+        xml_element = etree.Element(self.__class__.__name__, attrib=attrib)
+        params = etree.SubElement(xml_element, "Parameters")
+
+        for key, value in self.parameters.items():
+            value_unit = None
+            if units is not None:
+                value_unit = units[key]
+
+            etree.SubElement(
+                params,
+                "Parameter",
+                attrib={
+                    "name": key,
+                    "value": get_xml_representation(
+                        value.in_units(value_unit) if value_unit else value
+                    ),
+                },
+            )
+
+        return xml_element
 
     @classmethod
     def from_template(cls, potential_template, parameters, topology=None):

--- a/gmso/tests/test_forcefield.py
+++ b/gmso/tests/test_forcefield.py
@@ -6,6 +6,7 @@ from sympy import sympify
 
 from gmso.core.forcefield import ForceField
 from gmso.exceptions import (
+    ForceFieldError,
     ForceFieldParseError,
     MissingAtomTypesError,
     MissingPotentialError,
@@ -560,3 +561,23 @@ class TestForceField(BaseTest):
             opls_ethane_foyer._get_improper_type(
                 ["opls_359", "opls_600", "opls_700", "opls_800"], warn=True
             )
+
+    def test_write_xml(self, opls_ethane_foyer):
+        opls_ethane_foyer.xml("test_xml_writer.xml")
+        reloaded_xml = ForceField("test_xml_writer.xml")
+        get_names = lambda ff, param: [
+            typed for typed in getattr(ff, param).keys()
+        ]
+        for param in [
+            "atom_types",
+            "bond_types",
+            "angle_types",
+            "dihedral_types",
+        ]:
+            assert get_names(opls_ethane_foyer, param) == get_names(
+                reloaded_xml, param
+            )
+
+    def test_write_not_xml(self, opls_ethane_foyer):
+        with pytest.raises(ForceFieldError):
+            opls_ethane_foyer.xml("bad_path")

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -797,5 +797,3 @@ class TestTopology(BaseTest):
         top = Topology()
         with pytest.raises(GMSOError):
             top.get_forcefield()
-
-

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -789,3 +789,13 @@ class TestTopology(BaseTest):
     def test_iter_sites_by_residue_number(self, residue_top):
         sites = list(residue_top.iter_sites_by_residue_number(4))
         assert len(sites) == 5
+
+    def test_write_forcefield(self, typed_water_system):
+        forcefield = typed_water_system.get_forcefield()
+        assert "opls_111" in forcefield.atom_types
+        assert "opls_112" in forcefield.atom_types
+        top = Topology()
+        with pytest.raises(GMSOError):
+            top.get_forcefield()
+
+

--- a/gmso/utils/misc.py
+++ b/gmso/utils/misc.py
@@ -114,3 +114,13 @@ def mask_with(iterable, window_size=1, mask="*"):
 
         idx += 1
         yield to_yield
+
+
+def get_xml_representation(value):
+    """Given a value, get its XML representation."""
+    if isinstance(value, u.unyt_quantity):
+        return str(value.value)
+    elif isinstance(value, set):
+        return ",".join(value)
+    else:
+        return str(value)


### PR DESCRIPTION
## Discussion Points
- Should we use some standard default units while writing the files out? Since these files are meant to read in and out entirely within the mosdef-ecosystem, I think a standard use of default units makes sense.
- Some decent test systems are required for testing this PR.

## Example Usage
A simple example usage is available in the following [`gist`](https://gist.github.com/umesh-timalsina/0597128dc44561a2f1d667703107cfe5).

## Checklist:
- [x] Convert typed topology potentials to a forcefield.
- [x] add xml mehod to each parametric-potential class to write out the forcefield XML File.
- [ ] Tests 
 
