### PR TITLE
Fix nonbonded expression and charge unit

### DIFF
--- a/gmso/external/convert_foyer_xml.py
+++ b/gmso/external/convert_foyer_xml.py
@@ -154,7 +154,7 @@ def _write_gmso_xml(gmso_xml, **kwargs):
         attrib_dict={
             "energy": "kJ/mol",
             "mass": "amu",
-            "charge": "coulomb",
+            "charge": "elementary_charge",
             "distance": "nm",
         },
     )
@@ -248,14 +248,12 @@ def _write_nbforces(forcefield, ff_kwargs):
         forcefield,
         "AtomTypes",
         attrib_dict={
-            "expression": "ep * ((sigma/r)**12 - (sigma/r)**6) + q / (e0 * r)",
+            "expression": "ep * ((sigma/r)**12 - (sigma/r)**6)",
         },
     )
     parameters_units = {
         "ep": "kJ/mol",
-        "sigma": "nm",
-        "e0": "A**2*s**4/(kg*m**3)",
-        "q": "coulomb"
+        "sigma": "nm"
     }
 
     # NonBondedForces
@@ -288,11 +286,10 @@ def _write_nbforces(forcefield, ff_kwargs):
             './/AtomType[@name="{}"]'.format(atom_type.get("type"))
         )
         thisAtomType.attrib["name"] = atom_type.get("type", "AtomType")
+        thisAtomType.attrib["charge"] = atom_type.get("charge")
         parameters = {
             "ep": atom_type.get("epsilon"),
             "sigma": atom_type.get("sigma"),
-            "e0": "8.8542e-12",
-            "q": atom_type.get("charge")
         }
         _add_parameters(thisAtomType, parameters)
 

--- a/gmso/tests/test_convert_foyer_xml.py
+++ b/gmso/tests/test_convert_foyer_xml.py
@@ -82,7 +82,7 @@ class TestXMLConversion(BaseTest):
         assert foyer_fullerene.atom_types["C"].description == "carbon"
         assert foyer_fullerene.atom_types["C"].definition == "[C;r5;r6]"
         assert foyer_fullerene.atom_types["C"].expression == sympify(
-            "ep*(-sigma**6/r**6 + sigma**12/r**12) + q/(e0*r)"
+            "ep*(-sigma**6/r**6 + sigma**12/r**12)"
         )
 
     def test_foyer_bonds(self, foyer_fullerene):


### PR DESCRIPTION
Cal and I noticed that the nonbonded expression of atomtype when converted from a foyer xml has an extra component (it's has both LJ term and charge term). This PR will change the expression to only has the LJ term and assign the charge to `atom_type.charge` (also fix the charge unit to be `elementary_charge`). Relate to https://github.com/mosdef-hub/foyer/pull/358#issuecomment-842552924. 