### PR TITLE
Update syntax with new `mb.Box`

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -10,7 +10,7 @@ dependencies:
   - pydantic
   - networkx
   - pytest
-  - mbuild >= 0.10.6
+  - mbuild >= 0.11.0
   - openbabel >= 3.0.0
   - foyer
   - gsd >= 2.0

--- a/gmso/external/convert_mbuild.py
+++ b/gmso/external/convert_mbuild.py
@@ -118,7 +118,7 @@ def from_mbuild(compound, box=None, search_method=element_by_symbol):
     # if compound.periodicity is None and not box:
     else:
         if np.allclose(compound.periodicity, np.zeros(3)):
-            box = from_mbuild_box(compound.boundingbox)
+            box = from_mbuild_box(compound.get_boundingbox())
             if box:
                 box.lengths += [0.5, 0.5, 0.5] * u.nm
             top.box = box

--- a/gmso/external/convert_mbuild.py
+++ b/gmso/external/convert_mbuild.py
@@ -117,13 +117,11 @@ def from_mbuild(compound, box=None, search_method=element_by_symbol):
     # Assumes 2-D systems are not supported in mBuild
     # if compound.periodicity is None and not box:
     else:
-        if np.allclose(compound.periodicity, np.zeros(3)):
-            box = from_mbuild_box(compound.get_boundingbox())
-            if box:
-                box.lengths += [0.5, 0.5, 0.5] * u.nm
-            top.box = box
+        if compound.box:
+            top.box = from_mbuild_box(compound.box)
         else:
-            top.box = Box(lengths=compound.periodicity)
+            top.box = from_mbuild_box(compound.get_boundingbox())
+    top.periodicity = compound.periodicity
 
     return top
 

--- a/gmso/tests/test_convert_mbuild.py
+++ b/gmso/tests/test_convert_mbuild.py
@@ -77,7 +77,7 @@ class TestConvertMBuild(BaseTest):
         top_cmpnd.add(mid_cmpnd)
         mid_cmpnd.add(bot_cmpnd)
 
-        top_cmpnd.periodicity = [1, 1, 1]
+        top_cmpnd.periodicity = [True, True, True]
 
         top = from_mbuild(top_cmpnd)
 
@@ -109,7 +109,7 @@ class TestConvertMBuild(BaseTest):
         l1_cmpnd.add(l2_cmpnd)
         l2_cmpnd.add(particle)
 
-        l0_cmpnd.periodicity = [1, 1, 1]
+        l0_cmpnd.periodicity = [True, True, True]
 
         top = from_mbuild(l0_cmpnd)
 
@@ -128,7 +128,7 @@ class TestConvertMBuild(BaseTest):
         top_cmpnd.add(particle1)
         mid_cmpnd.add(particle2)
 
-        top_cmpnd.periodicity = [1, 1, 1]
+        top_cmpnd.periodicity = [True, True, True]
 
         top = from_mbuild(top_cmpnd)
 
@@ -151,16 +151,11 @@ class TestConvertMBuild(BaseTest):
         with pytest.raises(ValueError):
             top = from_mbuild(mb_ethane, box=[3,3,3])
 
-    def test_pass_box_periodicity(self, mb_ethane):
-        mb_ethane.periodicity = [2,2,2]
-        top = from_mbuild(mb_ethane)
-        assert_allclose_units(top.box.lengths, [2,2,2]*u.nm, rtol=1e-5, atol=1e-8)
-
     def test_pass_box_bounding(self, mb_ethane):
-        mb_ethane.periodicity = [0,0,0]
+        mb_ethane.periodicity = [False, False, False]
         top = from_mbuild(mb_ethane)
         assert_allclose_units(top.box.lengths,
-                (mb_ethane.boundingbox.lengths + [0.5, 0.5, 0.5]) * u.nm, rtol=1e-5, atol=1e-8)
+                (mb_ethane.get_boundingbox().lengths) * u.nm, rtol=1e-5, atol=1e-8)
 
     def test_empty_compound_name(self):
         compound = mb.load("CCOC", smiles=True)


### PR DESCRIPTION
Update syntax that used `mb.Compound.boundingbox`. Will also pin `mbuild` version in a later commit (after it is released). 