### PR TITLE
Add member_classes attribute to parametric potentials. 

### DIFF
--- a/gmso/core/angle_type.py
+++ b/gmso/core/angle_type.py
@@ -26,7 +26,13 @@ class AngleType(ParametricPotential):
 
     member_types_: Optional[Tuple[str, str, str]] = Field(
         None,
-        description="List-like of gmso.AtomType.name or gmso.AtomType.atomclass "
+        description="List-like of gmso.AtomType.name "
+        "defining the members of this angle type",
+    )
+
+    member_classes_: Optional[Tuple[str, str, str]] = Field(
+        None,
+        description="List-like of gmso.AtomType.atomclass "
         "defining the members of this angle type",
     )
 
@@ -37,6 +43,7 @@ class AngleType(ParametricPotential):
         parameters=None,
         independent_variables=None,
         member_types=None,
+        member_classes=None,
         topology=None,
         tags=None,
     ):
@@ -55,6 +62,7 @@ class AngleType(ParametricPotential):
             independent_variables=independent_variables,
             topology=topology,
             member_types=member_types,
+            member_classes=member_classes,
             set_ref=ANGLE_TYPE_DICT,
             tags=tags,
         )
@@ -64,6 +72,12 @@ class AngleType(ParametricPotential):
         return self.__dict__.get("member_types_")
 
     class Config:
-        fields = {"member_types_": "member_types"}
+        fields = {
+            "member_types_": "member_types",
+            "member_classes_": "member_classes",
+        }
 
-        alias_to_fields = {"member_types": "member_types_"}
+        alias_to_fields = {
+            "member_types": "member_types_",
+            "member_classes_": "member_classes",
+        }

--- a/gmso/core/bond_type.py
+++ b/gmso/core/bond_type.py
@@ -27,7 +27,13 @@ class BondType(ParametricPotential):
 
     member_types_: Optional[Tuple[str, str]] = Field(
         None,
-        description="List-like of of gmso.AtomType.name or gmso.AtomType.atomclass "
+        description="List-like of of gmso.AtomType.name "
+        "defining the members of this bond type",
+    )
+
+    member_classes_: Optional[Tuple[str, str]] = Field(
+        None,
+        description="List-like of of gmso.AtomType.atomclass "
         "defining the members of this bond type",
     )
 
@@ -38,6 +44,7 @@ class BondType(ParametricPotential):
         parameters=None,
         independent_variables=None,
         member_types=None,
+        member_classes=None,
         topology=None,
         tags=None,
     ):
@@ -56,6 +63,7 @@ class BondType(ParametricPotential):
             independent_variables=independent_variables,
             topology=topology,
             member_types=member_types,
+            member_classes=member_classes,
             set_ref=BOND_TYPE_DICT,
             tags=tags,
         )
@@ -68,6 +76,12 @@ class BondType(ParametricPotential):
     class Config:
         """Pydantic configuration for class attributes."""
 
-        fields = {"member_types_": "member_types"}
+        fields = {
+            "member_types_": "member_types",
+            "member_classes_": "member_classes",
+        }
 
-        alias_to_fields = {"member_types": "member_types_"}
+        alias_to_fields = {
+            "member_types": "member_types_",
+            "member_classes": "member_classes_",
+        }

--- a/gmso/core/dihedral_type.py
+++ b/gmso/core/dihedral_type.py
@@ -32,8 +32,14 @@ class DihedralType(ParametricPotential):
 
     member_types_: Optional[Tuple[str, str, str, str]] = Field(
         None,
-        description="List-like of of gmso.AtomType.name or gmso.AtomType.atomclass "
+        description="List-like of of gmso.AtomType.name "
         "defining the members of this dihedral type",
+    )
+
+    member_classes_: Optional[Tuple[str, str, str, str]] = Field(
+        None,
+        description="List-like of of gmso.AtomType.atomclass defining the "
+        "members of this dihedral type",
     )
 
     def __init__(
@@ -43,6 +49,7 @@ class DihedralType(ParametricPotential):
         parameters=None,
         independent_variables=None,
         member_types=None,
+        member_classes=None,
         topology=None,
         tags=None,
     ):
@@ -62,6 +69,7 @@ class DihedralType(ParametricPotential):
             independent_variables=independent_variables,
             topology=topology,
             member_types=member_types,
+            member_classes=member_classes,
             set_ref=DIHEDRAL_TYPE_DICT,
             tags=tags,
         )
@@ -71,6 +79,12 @@ class DihedralType(ParametricPotential):
         return self.__dict__.get("member_types_")
 
     class Config:
-        fields = {"member_types_": "member_types"}
+        fields = {
+            "member_types_": "member_types",
+            "member_classes_": "member_classes",
+        }
 
-        alias_to_fields = {"member_types": "member_types_"}
+        alias_to_fields = {
+            "member_types": "member_types_",
+            "member_classes": "member_classes_",
+        }

--- a/gmso/core/improper_type.py
+++ b/gmso/core/improper_type.py
@@ -38,7 +38,13 @@ class ImproperType(ParametricPotential):
 
     member_types_: Optional[Tuple[str, str, str, str]] = Field(
         None,
-        description="List-like of of gmso.AtomType.name or gmso.AtomType.atomclass "
+        description="List-like of gmso.AtomType.name "
+        "defining the members of this improper type",
+    )
+
+    member_classes_: Optional[Tuple[str, str, str, str]] = Field(
+        None,
+        description="List-like of gmso.AtomType.atomclass "
         "defining the members of this improper type",
     )
 
@@ -49,6 +55,7 @@ class ImproperType(ParametricPotential):
         parameters=None,
         independent_variables=None,
         member_types=None,
+        member_classes=None,
         topology=None,
         tags=None,
     ):
@@ -67,6 +74,7 @@ class ImproperType(ParametricPotential):
             independent_variables=independent_variables,
             topology=topology,
             member_types=member_types,
+            member_classes=member_classes,
             set_ref=IMPROPER_TYPE_DICT,
             tags=tags,
         )
@@ -79,6 +87,12 @@ class ImproperType(ParametricPotential):
     class Config:
         """Pydantic configuration for attributes."""
 
-        fields = {"member_types_": "member_types"}
+        fields = {
+            "member_types_": "member_types",
+            "member_classes_": "member_classes",
+        }
 
-        alias_to_fields = {"member_types": "member_types_"}
+        alias_to_fields = {
+            "member_types": "member_types_",
+            "member_classes_": "member_classes",
+        }

--- a/gmso/exceptions.py
+++ b/gmso/exceptions.py
@@ -26,5 +26,9 @@ class MissingAtomTypesError(ForceFieldParseError):
     """Error for missing AtomTypes when creating a ForceField from an XML file."""
 
 
+class MixedClassAndTypesError(ForceFieldParseError):
+    """Error for missing AtomTypes when creating a ForceField from an XML file."""
+
+
 class MissingPotentialError(ForceFieldError):
     """Error for missing Potential when searching for Potentials in a ForceField."""

--- a/gmso/tests/files/ff-example0.xml
+++ b/gmso/tests/files/ff-example0.xml
@@ -37,7 +37,7 @@
                 <Parameter name='k' value="10000"/>
             </Parameters>
         </BondType>
-        <BondType name="BondType2" type1='Xe' class2="Xe">
+        <BondType name="BondType2" type1='Xe' type2="Xe">
             <Parameters>
                 <Parameter name='r_eq' value="10"/>
                 <Parameter name='k' value="20000"/>
@@ -65,7 +65,7 @@
     <DihedralTypes expression="0.5 * z * (r-r_eq)**2">
         <ParametersUnitDef parameter="r_eq" unit="nm"/>
         <ParametersUnitDef parameter="z" unit="kJ/mol"/>
-        <DihedralType name="DihedralType1" class1='Ar' class2='Ar' type3="Ar" type4="Ar">
+        <DihedralType name="DihedralType1" class1='Ar' class2='Ar' class3="Ar" class4="Ar">
             <Parameters>
                 <Parameter name='r_eq' value="10.0"/>
                 <Parameter name='z' value="100"/>


### PR DESCRIPTION
Closes #548.

This PR add support for member_classes attribute for parametric potentials:

- [x] Add Attribute to potential classes
- [x] Don't allow criss-crossing between `type` and `class` 
- [ ] Tests
- [ ] ForceField creation changes 