### PR TITLE
Allow pre-commit to format prs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,12 @@
+ci:
+    autofix_commit_msg: |
+        [pre-commit.ci] auto fixes from pre-commit.com hooks
+        for more information, see https://pre-commit.ci
+    autofix_prs: true
+    autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    autoupdate_schedule: weekly
+    skip: []
+    submodules: false
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.0.1


### PR DESCRIPTION
Previously, when we introduced pre-commit, it required users to manually
run the pre-commit hook locally.

Now, these pre-commit features can be run in the cloud now, which can be
useful for users that might not want to install the required packages.
This introduces the yaml configuration necessary to autoformat PRs
according to our current configuration.