### PR TITLE
Strip white space when parsing atomtype overrides

### DIFF
--- a/gmso/utils/ff_utils.py
+++ b/gmso/utils/ff_utils.py
@@ -318,10 +318,8 @@ def parse_ff_atomtypes(atomtypes_el, ff_meta):
             )
         if isinstance(ctor_kwargs["overrides"], str):
             ctor_kwargs["overrides"] = set(
-                [
-                    override.strip()
-                    for override in ctor_kwargs["overrides"].split(",")
-                ]
+                override.strip()
+                for override in ctor_kwargs["overrides"].split(",")
             )
         if isinstance(ctor_kwargs["charge"], str):
             ctor_kwargs["charge"] = u.unyt_quantity(

--- a/gmso/utils/ff_utils.py
+++ b/gmso/utils/ff_utils.py
@@ -317,7 +317,12 @@ def parse_ff_atomtypes(atomtypes_el, ff_meta):
                 float(ctor_kwargs["mass"]), units_dict["mass"]
             )
         if isinstance(ctor_kwargs["overrides"], str):
-            ctor_kwargs["overrides"] = set(ctor_kwargs["overrides"].split(","))
+            ctor_kwargs["overrides"] = set(
+                [
+                    override.strip()
+                    for override in ctor_kwargs["overrides"].split(",")
+                ]
+            )
         if isinstance(ctor_kwargs["charge"], str):
             ctor_kwargs["charge"] = u.unyt_quantity(
                 float(ctor_kwargs["charge"]), units_dict["charge"]


### PR DESCRIPTION
Strip white space when parsing atom_type overrides from XML. Fix bug mentioned in #551. 