### PR TITLE
Fix default expression for `PairPotentialType`

### DIFF
--- a/gmso/core/pairpotential_type.py
+++ b/gmso/core/pairpotential_type.py
@@ -35,7 +35,7 @@ class PairPotentialType(ParametricPotential):
     def __init__(
         self,
         name="PairPotentialType",
-        expression="4 * eps * (sigma / r)**12 - (sigma / r)**6)",
+        expression="4 * eps * (sigma / r)**12 - (sigma / r)**6",
         parameters=None,
         independent_variables=None,
         member_types=None,

--- a/gmso/core/pairpotential_type.py
+++ b/gmso/core/pairpotential_type.py
@@ -35,7 +35,7 @@ class PairPotentialType(ParametricPotential):
     def __init__(
         self,
         name="PairPotentialType",
-        expression="4 * eps * (sigma / r)**12 - (sigma / r)**6",
+        expression="4 * eps * ((sigma / r)**12 - (sigma / r)**6)",
         parameters=None,
         independent_variables=None,
         member_types=None,


### PR DESCRIPTION
#484 introduced a bug where the default value of expression for `PairPotentialType` has one extra bracket. This PR attempts to fix it.