### PR TITLE
Migrate from conda to mamba during installs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,10 @@ RUN conda update conda -yq && \
 	conda config --set always_yes yes --set changeps1 no && \
 	. /opt/conda/etc/profile.d/conda.sh && \
 	sed -i -E "s/python.*$/python="$PY_VERSION"/" environment-dev.yml && \
-	conda env create nomkl -f environment-dev.yml && \
+  conda install -c conda-forge mamba && \
+	mamba env create nomkl -f environment-dev.yml && \
 	conda activate gmso-dev && \
-	conda install -c conda-forge nomkl jupyter && \
+	mamba install -c conda-forge nomkl jupyter && \
         python setup.py install && \
 	echo "source activate gmso-dev" >> \
 	/home/anaconda/.profile && \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,11 +57,14 @@ stages:
             displayName: Take ownership of conda installation
 
           - bash: |
-              conda install -c conda-forge mamba
+              conda config --set always_yes yes --set changeps1 no
+            displayName: Set conda configuration
+
+          - bash: |
+              conda install -y -c conda-forge mamba
             displayName: Install mamba
 
           - bash: |
-              conda config --set always_yes yes --set changeps1 no
               mamba update conda -yq
             displayName: Add relevant channels and update
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,7 +78,7 @@ stages:
           - bash: |
               source activate gmso-dev
               pip install pytest-azurepipelines
-              python -m pytest -v --cov=gmso --cov-report=html --pyargs gmso --no-coverage-upload
+              python -m pytest -v --cov=gmso --cov-report=html --color=yes --pyargs gmso --no-coverage-upload
             displayName: Run tests
 
           - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,13 +57,17 @@ stages:
             displayName: Take ownership of conda installation
 
           - bash: |
+              conda install -c conda-forge mamba
+            displayName: Install mamba
+
+          - bash: |
               conda config --set always_yes yes --set changeps1 no
-              conda update conda -yq
-            displayName: Add relevant channels
+              mamba update conda -yq
+            displayName: Add relevant channels and update
 
           - bash: |
               sed -i -E 's/python.*$/python='$(python.version)'/' environment-dev.yml
-              conda env create -f environment-dev.yml
+              mamba env create -f environment-dev.yml
               source activate gmso-dev
               pip install -e .
             displayName: Install requirements and testing branch


### PR DESCRIPTION
Previously, all conda environment creations use conda for the
dependency resolution, which is notoriously slower than mamba's
implementation.

This can have a noticeable impact on run times during CI as well as
building docker images. Mamba has replaced conda in our dockerfile as
well as our azurepipelines.yml file.