### PR TITLE
 Proper exclude `kwarg` consolidation in `ParametricPotential.dict`

### DIFF
--- a/gmso/core/parametric_potential.py
+++ b/gmso/core/parametric_potential.py
@@ -157,7 +157,13 @@ class ParametricPotential(AbstractPotential):
         exclude_defaults: bool = False,
         exclude_none: bool = False,
     ) -> dict:
-        exclude = {"topology_", "set_ref_"}
+        if exclude is None:
+            exclude = set()
+        if isinstance(exclude, dict):
+            exclude = set(exclude)
+
+        exclude = exclude.union({"topology_", "set_ref_"})
+
         return super().dict(
             include=include,
             exclude=exclude,

--- a/gmso/tests/test_atom_type.py
+++ b/gmso/tests/test_atom_type.py
@@ -346,3 +346,9 @@ class TestAtomType(BaseTest):
         assert atomtype_metadata.pop_tag("non_existent_tag") is None
         atomtype_metadata.delete_tag("int_tag")
         assert len(atomtype_metadata.tag_names) == 2
+
+    def test_atom_type_dict(self):
+        atype = AtomType()
+        atype_dict = atype.dict(exclude={"potential_expression"})
+        assert "potential_expression" not in atype_dict
+        assert "charge" in atype_dict


### PR DESCRIPTION
# Close #595