### PR TITLE
Ignore `setup.cfg` in pre-commit's `Trailing Whitespace`.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,8 @@ repos:
   hooks:
     - id: check-yaml
     - id: end-of-file-fixer
-      exclude: 'setup.cfg'
     - id: trailing-whitespace
+      exclude: 'setup.cfg'
 - repo: https://github.com/psf/black
   rev: 21.9b0
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
   hooks:
     - id: check-yaml
     - id: end-of-file-fixer
+      exclude: 'setup.cfg'
     - id: trailing-whitespace
 - repo: https://github.com/psf/black
   rev: 21.9b0

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,15 +9,15 @@ tag_name = {new_version}
 omit = gmso/tests/*
 
 [coverage:report]
-exclude_lines = 
+exclude_lines =
 	pragma: no cover
-	
+
 	def __repr__
 	def __str__
 	except ImportError
 	if 0:
 	if __name__ == .__main__.:
-omit = 
+omit =
 	gmso/tests/*
 
 [bumpversion:file:gmso/__init__.py]


### PR DESCRIPTION
~As per https://github.com/c4urself/bump2version/issues/58, the EOF Fixer is not compatible with bump2version. This PR fixes that.~

UPDATE: This PR deals with trailing whitespace hook.