### PR TITLE
fix bug when convert position in to_mbuild

### DIFF
--- a/gmso/external/convert_mbuild.py
+++ b/gmso/external/convert_mbuild.py
@@ -164,7 +164,7 @@ def to_mbuild(topology):
         else:
             element = None
         particle = mb.Compound(
-            name=site.name, pos=site.position, element=element
+            name=site.name, pos=site.position.to(u.nm).value, element=element
         )
         particle_map[site] = particle
         compound.add(particle)


### PR DESCRIPTION
Found a bug in `to_mbuild` method when converting positions (did not do unit conversion + only end up with one of the x position). This PR will address that and add relevant tests.