### PR TITLE
Add mol2 to formarts __init__.py

### DIFF
--- a/gmso/formats/__init__.py
+++ b/gmso/formats/__init__.py
@@ -6,6 +6,7 @@ from .gro import read_gro, write_gro
 from .gsd import write_gsd
 from .json import save_json
 from .lammpsdata import write_lammpsdata
+from .mcf import write_mcf
 from .mol2 import from_mol2
 from .top import write_top
 from .xyz import read_xyz, write_xyz

--- a/gmso/formats/__init__.py
+++ b/gmso/formats/__init__.py
@@ -6,6 +6,7 @@ from .gro import read_gro, write_gro
 from .gsd import write_gsd
 from .json import save_json
 from .lammpsdata import write_lammpsdata
+from .mol2 import from_mol2
 from .top import write_top
 from .xyz import read_xyz, write_xyz
 


### PR DESCRIPTION
Add mol2 loader import to format's `__init__.py`. Missing the line doesn't cause any issue with GMSO tests, but it failed when I tried to use it for a different PR in mbuild (https://github.com/mosdef-hub/mbuild/pull/971)