### PR TITLE
Modified RB and Periodic torsions, and added new Mie n-6 potential

### DIFF
--- a/gmso/lib/jsons/MiePotential_n_6.json
+++ b/gmso/lib/jsons/MiePotential_n_6.json
@@ -1,0 +1,5 @@
+{
+  "name": "MiePotential_n_6",
+  "expression": "(n/(n-6)) * (n/6)**(6/(n-6)) * epsilon * ((sigma/r)**n - (sigma/r)**6)",
+  "independent_variables": "r"
+}

--- a/gmso/lib/jsons/PeriodicTorsionPotential.json
+++ b/gmso/lib/jsons/PeriodicTorsionPotential.json
@@ -1,5 +1,5 @@
 {
   "name": "PeriodicTorsionPotential",
-  "expression": "k * (1 + cos(n * phi - phi_eq))",
+  "expression": "k0 + k1 * (1 + cos(1 * phi - phi1_eq)) + k2 * (1 + cos(2 * phi - phi2_eq)) + k3 * (1 + cos(3 * phi - phi3_eq)) + k4 * (1 + cos(4 * phi - phi4_eq)) + k5 * (1 + cos(5 * phi - phi5_eq))",
   "independent_variables": "phi"
 }

--- a/gmso/lib/jsons/RyckaertBellemansTorsionPotential.json
+++ b/gmso/lib/jsons/RyckaertBellemansTorsionPotential.json
@@ -1,5 +1,5 @@
 {
   "name": "RyckaertBellemansTorsionPotential",
-  "expression": "c0 * cos(phi)**0 + c1 * cos(phi)**1 + c2 * cos(phi)**2 + c3 * cos(phi)**3 + c4 * cos(phi)**4 + c5 * cos(phi)**5",
+  "expression": "c0 + c1 * cos(phi)**1 + c2 * cos(phi)**2 + c3 * cos(phi)**3 + c4 * cos(phi)**4 + c5 * cos(phi)**5",
   "independent_variables": "phi"
 }


### PR DESCRIPTION
- The RB torsion should just use C0 and not C0 * cos(phi)**0

- The periodic torsion should just be similar to RB and go to the 5th power series (i.e., cos(5x) term)

- Added the n-6 Mie potential as it is the one GOMC supports.  Also, from my understanding changing both the power series ones can be counterproductive in the force field fitting, but I could be wrong.