### PR TITLE
Change scaling factors terminology in gmso.Topology

### DIFF
--- a/gmso/core/forcefield.py
+++ b/gmso/core/forcefield.py
@@ -211,7 +211,7 @@ class ForceField(object):
 
         Parameters
         ----------
-        group:  {'atom_types', 'bond_types', 'angle_types', 'dihedral_types', 'improper_types'}
+        group:  {'atom_type', 'bond_type', 'angle_type', 'dihedral_type', 'improper_type'}
             The potential group to perform this search on
         key: str or list of str
             The key to lookup for this potential group

--- a/gmso/core/forcefield.py
+++ b/gmso/core/forcefield.py
@@ -213,7 +213,7 @@ class ForceField(object):
         ----------
         group:  {'atom_type', 'bond_type', 'angle_type', 'dihedral_type', 'improper_type'}
             The potential group to perform this search on
-        key: str or list of str
+        key: str (for atom type) or list of str (for connection types)
             The key to lookup for this potential group
         warn: bool, default=False
             If true, raise a warning instead of Error if no match found

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -173,12 +173,12 @@ class Topology(object):
         self._pairpotential_types = {}
         self._pairpotential_types_idx = {}
         self._scaling_factors = {
-            "vdw_12": 0.0,
-            "vdw_13": 0.0,
-            "vdw_14": 0.5,
-            "coul_12": 0.0,
-            "coul_13": 0.0,
-            "coul_14": 0.5,
+            "nonBonded12Scale": 0.0,
+            "nonBonded13Scale": 0.0,
+            "nonBonded14Scale": 0.5,
+            "electrostatics12Scale": 0.0,
+            "electrostatics13Scale": 0.0,
+            "electrostatics14Scale": 0.5,
         }
         self._set_refs = {
             ATOM_TYPE_DICT: self._atom_types,
@@ -251,12 +251,12 @@ class Topology(object):
     def scaling_factors(self, scaling_factors):
         """Set the scaling factors for the topology."""
         expected_items = [
-            "vdw_12",
-            "vdw_13",
-            "vdw_14",
-            "coul_12",
-            "coul_13",
-            "coul_14",
+            "nonBonded12Scale",
+            "nonBonded13Scale",
+            "nonBonded14Scale",
+            "electrostatics12Scale",
+            "electrostatics13Scale",
+            "electrostatics14Scale",
         ]
         if not isinstance(scaling_factors, dict):
             raise GMSOError("Scaling factors should be a dictionary")

--- a/gmso/formats/lammpsdata.py
+++ b/gmso/formats/lammpsdata.py
@@ -375,7 +375,7 @@ def read_lammpsdata(
 
     # Validate 'unit_style'
     if unit_style not in ["real"]:
-        raiseValueError(
+        raise ValueError(
             'Unit Style "{}" is invalid or is not currently supported'.format(
                 unit_style
             )

--- a/gmso/formats/mcf.py
+++ b/gmso/formats/mcf.py
@@ -636,12 +636,16 @@ def _write_intrascaling_information(mcf, top):
     mcf.write(header)
     mcf.write(
         "{:.4f} {:.4f} {:.4f} 1.0000\n".format(
-            sf["vdw_12"], sf["vdw_13"], sf["vdw_14"]
+            sf["nonBonded12Scale"],
+            sf["nonBonded13Scale"],
+            sf["nonBonded14Scale"],
         )
     )
     mcf.write(
         "{:.4f} {:.4f} {:.4f} 1.0000\n".format(
-            sf["coul_12"], sf["coul_13"], sf["coul_14"]
+            sf["electrostatics12Scale"],
+            sf["electrostatics13Scale"],
+            sf["electrostatics14Scale"],
         )
     )
 

--- a/gmso/tests/test_mcf.py
+++ b/gmso/tests/test_mcf.py
@@ -135,12 +135,12 @@ class TestMCF(BaseTest):
         assert np.allclose(float(mcf_data[-4][3]), 1.0)
 
         top.scaling_factors = {
-            "vdw_12": 0.1,
-            "vdw_13": 0.2,
-            "vdw_14": 0.5,
-            "coul_12": 0.2,
-            "coul_13": 0.4,
-            "coul_14": 0.6,
+            "nonBonded12Scale": 0.1,
+            "nonBonded13Scale": 0.2,
+            "nonBonded14Scale": 0.5,
+            "electrostatics12Scale": 0.2,
+            "electrostatics13Scale": 0.4,
+            "electrostatics14Scale": 0.6,
         }
 
         top.save("ar.mcf", overwrite=True)

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -674,31 +674,31 @@ class TestTopology(BaseTest):
 
     def test_topology_scale_factors(self, typed_methylnitroaniline):
         sf = typed_methylnitroaniline.scaling_factors
-        assert np.allclose(sf["vdw_12"], 0.0)
-        assert np.allclose(sf["vdw_13"], 0.0)
-        assert np.allclose(sf["vdw_14"], 0.5)
-        assert np.allclose(sf["coul_12"], 0.0)
-        assert np.allclose(sf["coul_13"], 0.0)
-        assert np.allclose(sf["coul_14"], 0.5)
+        assert np.allclose(sf["nonBonded12Scale"], 0.0)
+        assert np.allclose(sf["nonBonded13Scale"], 0.0)
+        assert np.allclose(sf["nonBonded14Scale"], 0.5)
+        assert np.allclose(sf["electrostatics12Scale"], 0.0)
+        assert np.allclose(sf["electrostatics13Scale"], 0.0)
+        assert np.allclose(sf["electrostatics14Scale"], 0.5)
 
     def test_topology_change_scale_factors(self, typed_methylnitroaniline):
         typed_methylnitroaniline.scaling_factors = {
-            "vdw_12": 0.5,
-            "vdw_13": 0.5,
-            "vdw_14": 1.0,
-            "coul_12": 1.0,
-            "coul_13": 1.0,
-            "coul_14": 1.0,
+            "nonBonded12Scale": 0.5,
+            "nonBonded13Scale": 0.5,
+            "nonBonded14Scale": 1.0,
+            "electrostatics12Scale": 1.0,
+            "electrostatics13Scale": 1.0,
+            "electrostatics14Scale": 1.0,
         }
         sf = typed_methylnitroaniline.scaling_factors
-        assert np.allclose(sf["vdw_12"], 0.5)
-        assert np.allclose(sf["vdw_13"], 0.5)
-        assert np.allclose(sf["vdw_14"], 1.0)
-        assert np.allclose(sf["coul_12"], 1.0)
-        assert np.allclose(sf["coul_13"], 1.0)
-        assert np.allclose(sf["coul_14"], 1.0)
-        typed_methylnitroaniline.scaling_factors["vdw_12"] = 1.0
-        assert np.allclose(sf["vdw_12"], 1.0)
+        assert np.allclose(sf["nonBonded12Scale"], 0.5)
+        assert np.allclose(sf["nonBonded13Scale"], 0.5)
+        assert np.allclose(sf["nonBonded14Scale"], 1.0)
+        assert np.allclose(sf["electrostatics12Scale"], 1.0)
+        assert np.allclose(sf["electrostatics13Scale"], 1.0)
+        assert np.allclose(sf["electrostatics14Scale"], 1.0)
+        typed_methylnitroaniline.scaling_factors["nonBonded12Scale"] = 1.0
+        assert np.allclose(sf["nonBonded12Scale"], 1.0)
 
     def test_topology_invalid_scaling_factors(self, typed_methylnitroaniline):
         with pytest.raises(GMSOError):


### PR DESCRIPTION
Currently, the `gmso.Topology` scaling factors are using `vdw_14` and `coul_14` in `Topology.scaling_factors`. This PR change those terminology to be `nonBonded14Scale` and `electrostatics14Scale` to match with the terms used in Forcefield. 