### PR TITLE
Fix bug in convert foyer XML 

### DIFF
--- a/gmso/external/convert_foyer_xml.py
+++ b/gmso/external/convert_foyer_xml.py
@@ -235,7 +235,7 @@ def _populate_class_or_type_attrib(root, type_):
                 "type{}".format(j + 1), "c{}".format(j + 1)
             )
         elif "class" in item[0]:
-            root.attrib["type{}".format(j + 1)] = type_.get(
+            root.attrib["class{}".format(j + 1)] = type_.get(
                 "class{}".format(j + 1), "c{}".format(j + 1)
             )
 

--- a/gmso/tests/test_convert_foyer_xml.py
+++ b/gmso/tests/test_convert_foyer_xml.py
@@ -102,7 +102,7 @@ class TestXMLConversion(BaseTest):
         assert foyer_fullerene.bond_types["C~C"].parameters[
             "k"
         ] == u.unyt_quantity(1000, u.kJ / u.mol / u.nm ** 2)
-        assert foyer_fullerene.bond_types["C~C"].member_types == ("C", "C")
+        assert foyer_fullerene.bond_types["C~C"].member_classes == ("C", "C")
 
     def test_foyer_angles(self, foyer_fullerene):
         assert len(foyer_fullerene.angle_types) == 1
@@ -118,7 +118,7 @@ class TestXMLConversion(BaseTest):
         assert foyer_fullerene.angle_types["C~C~C"].parameters[
             "theta_eq"
         ] == u.unyt_quantity(3.141592, u.rad)
-        assert foyer_fullerene.angle_types["C~C~C"].member_types == (
+        assert foyer_fullerene.angle_types["C~C~C"].member_classes == (
             "C",
             "C",
             "C",


### PR DESCRIPTION
Will fix #620. Found and fixed a bug in `convert_foyer_xml` where the atomclass of connection types is converted to `type` instead of `class`.