### PR TITLE
Pin pydantic to versions less than 1.9

### DIFF
--- a/docs/docs-env.yml
+++ b/docs/docs-env.yml
@@ -9,7 +9,7 @@ dependencies:
     - unyt >= 2.4
     - boltons
     - lxml
-    - pydantic
+    - pydantic < 1.9.0
     - networkx
     - ele >= 0.2.0
     - numpydoc

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -7,7 +7,7 @@ dependencies:
   - unyt >= 2.4
   - boltons
   - lxml
-  - pydantic
+  - pydantic < 1.9.0
   - networkx
   - pytest
   - mbuild >= 0.11.0

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,6 @@ dependencies:
   - unyt >= 2.4
   - boltons
   - lxml
-  - pydantic
+  - pydantic < 1.9.0
   - networkx
   - ele >= 0.2.0


### PR DESCRIPTION
With the release of `pydantic` 1.9.X, there have been some nuanced
changes to how json handling is done.

This has led to breaking changes in the serialization of some of our
data structures.
This does not happen with `pydantic` 1.8.2 or less.

The current patch is to pin to versions less than 1.9 until we have a
fix.