### PR TITLE
fix typo when converting foyer XML

### DIFF
--- a/gmso/external/convert_foyer_xml.py
+++ b/gmso/external/convert_foyer_xml.py
@@ -146,9 +146,9 @@ def _write_gmso_xml(gmso_xml, **kwargs):
 
     ffMeta = _create_sub_element(forcefield, "FFMetaData")
     if kwargs.get("combining_rule"):
-        ffMeta.attrib["combining_rule"] = kwargs.get("combining_rule")
+        ffMeta.attrib["combiningRule"] = kwargs.get("combining_rule")
     else:
-        ffMeta.attrib["combining_rule"] = "geometric"
+        ffMeta.attrib["combiningRule"] = "geometric"
     if kwargs["coulomb14scale"]:
         ffMeta.attrib["electrostatics14Scale"] = kwargs["coulomb14scale"]
 

--- a/gmso/tests/files/foyer-trappe-ua.xml
+++ b/gmso/tests/files/foyer-trappe-ua.xml
@@ -1,0 +1,18 @@
+<ForceField name="Trappe-UA" version="0.0.2" combining_rule="lorentz">
+ <AtomTypes>
+  <Type name="O" class="O" element="O" mass="15.99940" def="OH" desc="Oxygen in hydroxyl" doi="10.1021/jp003882x"/>
+  <Type name="H" class="H" element="H" mass="1.00800" def="HO" desc="Hydrogen in hydroxyl" doi="10.1021/jp003882x"/>
+  <Type name="CH4" class="CH4" element="_CH4" mass="16.04300" def="_CH4" desc="CH4, united atom" doi="10.1021/jp972543+"/>
+ </AtomTypes>
+ <HarmonicBondForce>
+ </HarmonicBondForce>
+ <HarmonicAngleForce>
+ </HarmonicAngleForce>
+ <RBTorsionForce>
+ </RBTorsionForce>
+ <NonbondedForce coulomb14scale="0" lj14scale="0">
+  <Atom type="O" charge="-0.700" sigma="0.302" epsilon="0.773245"/>
+  <Atom type="H" charge="0.435" sigma="1.0" epsilon="0.0"/>
+  <Atom type="CH4" charge="0.0" sigma="0.373" epsilon="1.23054"/>
+ </NonbondedForce>
+</ForceField>

--- a/gmso/tests/test_convert_foyer_xml.py
+++ b/gmso/tests/test_convert_foyer_xml.py
@@ -4,6 +4,7 @@ import pytest
 import unyt as u
 from sympy import sympify
 
+from gmso.core.forcefield import ForceField
 from gmso.exceptions import ForceFieldParseError
 from gmso.external.convert_foyer_xml import from_foyer_xml
 from gmso.tests.base_test import BaseTest
@@ -53,6 +54,16 @@ class TestXMLConversion(BaseTest):
 
     def test_foyer_version(self, foyer_fullerene):
         assert foyer_fullerene.version == "0.0.1"
+
+    def test_foyer_combining_rule(self):
+        from_foyer_xml(get_path("foyer-trappe-ua.xml"))
+        loaded = ForceField("foyer-trappe-ua_gmso.xml")
+
+        assert loaded.name == "Trappe-UA"
+        assert loaded.version == "0.0.2"
+        assert loaded.combining_rule == "lorentz"
+        assert loaded.scaling_factors["electrostatics14Scale"] == 0
+        assert loaded.scaling_factors["nonBonded14Scale"] == 0
 
     def test_foyer_14scale(self, foyer_fullerene):
         assert foyer_fullerene.scaling_factors["electrostatics14Scale"] == 1.0


### PR DESCRIPTION
The naming mismatch (`combining_rule` vs `combiningRule`) causing issues converting combining rule information from foyer XML to gmso XML. This PR fix this by sticking to `combiningRule`. 