### PR TITLE
added Kelvin to standard energy converter via unit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     - id: trailing-whitespace
       exclude: 'setup.cfg'
 - repo: https://github.com/psf/black
-  rev: 22.1.0
+  rev: 22.3.0
   hooks:
     - id: black
       args: [--line-length=80]

--- a/gmso/tests/test_conversions.py
+++ b/gmso/tests/test_conversions.py
@@ -6,13 +6,13 @@ import unyt as u
 from mbuild.tests.base_test import BaseTest
 from unyt.testing import assert_allclose_units
 
-from gmso.utils.conversions import check_convert_kelvin_to_energy_units
+from gmso.utils.conversions import convert_kelvin_to_energy_units
 
 
 class TestKelvinToEnergy(BaseTest):
     def test_K_to_kcal(self):
         input_value = 1 * u.Kelvin / u.nm**2
-        new_value = check_convert_kelvin_to_energy_units(
+        new_value = convert_kelvin_to_energy_units(
             input_value,
             "kcal/mol",
         )
@@ -23,7 +23,7 @@ class TestKelvinToEnergy(BaseTest):
 
     def test_kcal_per_mol_to_kJ_per_mol(self):
         input_value = 2 * u.kcal / u.mol * u.gram**2
-        new_value = check_convert_kelvin_to_energy_units(
+        new_value = convert_kelvin_to_energy_units(
             input_value,
             "kJ/mol",
         )
@@ -37,7 +37,7 @@ class TestKelvinToEnergy(BaseTest):
             r"not a <class 'unyt.unit_object.Unit'>.",
         ):
             input_value = 2.0
-            check_convert_kelvin_to_energy_units(
+            convert_kelvin_to_energy_units(
                 input_value,
                 "kJ/mol",
             )
@@ -49,7 +49,7 @@ class TestKelvinToEnergy(BaseTest):
             r"not a <class 'str'>.",
         ):
             input_value = 2 * u.kcal / u.mol * u.gram**2
-            check_convert_kelvin_to_energy_units(
+            convert_kelvin_to_energy_units(
                 input_value,
                 1.0,
             )
@@ -60,7 +60,7 @@ class TestKelvinToEnergy(BaseTest):
             match=r"ERROR: The entered energy_output_unyt_units_str can not be in K energy units.",
         ):
             input_value = 2 * u.kcal / u.mol * u.gram**2
-            check_convert_kelvin_to_energy_units(
+            convert_kelvin_to_energy_units(
                 input_value,
                 "K",
             )
@@ -72,7 +72,7 @@ class TestKelvinToEnergy(BaseTest):
             r"\(length\)\**2\*\(mass\)/\(time\)\**2, but not in K energy units.",
         ):
             input_value = 2 * u.kcal / u.mol * u.gram**2
-            check_convert_kelvin_to_energy_units(
+            convert_kelvin_to_energy_units(
                 input_value,
                 "m",
             )

--- a/gmso/tests/test_conversions.py
+++ b/gmso/tests/test_conversions.py
@@ -1,0 +1,74 @@
+import pytest
+import sympy
+import unyt as u
+from unyt.testing import assert_allclose_units
+from copy import deepcopy
+from mbuild.tests.base_test import BaseTest
+from gmso.utils.conversions import check_convert_kelvin_to_energy_units
+
+
+class TestKelvinToEnergy(BaseTest):
+    def test_K_to_kcal(self):
+        input_value = 1 * u.Kelvin / u.nm ** 2
+        new_value = check_convert_kelvin_to_energy_units(
+            input_value,
+            'kcal/mol',
+        )
+
+        assert new_value == u.unyt_quantity(0.0019872041457050975, "kcal/(mol*nm**2)")
+
+    def test_kcal_per_mol_to_kJ_per_mol(self):
+        input_value = 2 * u.kcal / u.mol * u.gram**2
+        new_value = check_convert_kelvin_to_energy_units(
+            input_value,
+            'kJ/mol',
+        )
+
+        assert new_value == u.unyt_quantity(2, "kcal/mol*g**2")
+
+    def test_input_not_unyt_units(self):
+        with pytest.raises(
+            ValueError,
+            match=r"ERROR: The entered energy_input_unyt value is a <class 'float'>, "
+                  r"not a <class 'unyt.unit_object.Unit'>."
+        ):
+            input_value = 2.0
+            check_convert_kelvin_to_energy_units(
+                input_value,
+                'kJ/mol',
+            )
+
+    def test_kcal_per_mol_to_float_output(self):
+        with pytest.raises(
+            ValueError,
+            match=r"ERROR: The entered energy_output_unyt_units_str value is a <class 'float'>, "
+                  r"not a <class 'str'>."
+        ):
+            input_value = 2 * u.kcal / u.mol * u.gram ** 2
+            check_convert_kelvin_to_energy_units(
+                input_value,
+                1.0,
+            )
+
+    def test_output_units_in_K(self):
+        with pytest.raises(
+            ValueError,
+            match=r"ERROR: The entered energy_output_unyt_units_str can not be in K energy units."
+        ):
+            input_value = 2 * u.kcal / u.mol * u.gram ** 2
+            check_convert_kelvin_to_energy_units(
+                input_value,
+                'K',
+            )
+
+    def test_kcal_per_mol_to_string_m(self):
+        with pytest.raises(
+            ValueError,
+            match=r"ERROR: The entered energy_output_unyt_units_str value must be in units of energy/mol, "
+                  r"\(length\)\**2\*\(mass\)/\(time\)\**2, but not in K energy units."
+        ):
+            input_value = 2 * u.kcal / u.mol * u.gram ** 2
+            check_convert_kelvin_to_energy_units(
+                input_value,
+                'm',
+            )

--- a/gmso/utils/conversions.py
+++ b/gmso/utils/conversions.py
@@ -172,10 +172,12 @@ def convert_kelvin_to_energy_units(
 
     """
     # check for input errors
-    #if not isinstance(energy_input_unyt, type(u.unyt_quantity(1, "K"))):
+    # if not isinstance(energy_input_unyt, type(u.unyt_quantity(1, "K"))):
     if not isinstance(energy_input_unyt, u.unyt_quantity):
-        print_error_message = f"ERROR: The entered energy_input_unyt value is a {type(energy_input_unyt)}, " \
-                              f"not a {type(u.Kelvin)}."
+        print_error_message = (
+            f"ERROR: The entered energy_input_unyt value is a {type(energy_input_unyt)}, "
+            f"not a {type(u.Kelvin)}."
+        )
         raise ValueError(print_error_message)
 
     if not isinstance(energy_output_unyt_units_str, str):

--- a/gmso/utils/conversions.py
+++ b/gmso/utils/conversions.py
@@ -148,7 +148,9 @@ def check_convert_kelvin_to_energy_units(
         energy_input_unyt,
         energy_output_unyt_units_str,
 ):
-    """Checks to see if the unyt energy value is in Kelvin (K) and converts it to
+    """Converts the Kelvin (K) energy unit to a standard energy unit.
+
+    Check to see if the unyt energy value is in Kelvin (K) and converts it to
     another energy unit (Ex: kcal/mol, kJ/mol, etc.).  Otherwise, it passes thru the
     existing unyt values.
 

--- a/gmso/utils/conversions.py
+++ b/gmso/utils/conversions.py
@@ -140,7 +140,7 @@ def convert_ryckaert_to_opls(ryckaert_connection_type):
     return opls_connection_type
 
 
-def check_convert_kelvin_to_energy_units(
+def convert_kelvin_to_energy_units(
     energy_input_unyt,
     energy_output_unyt_units_str,
 ):
@@ -159,6 +159,9 @@ def check_convert_kelvin_to_energy_units(
         (Example - 'kcal/mol', 'kJ/mol', or any '(length)**2*(mass)/(time)**2' , but not 'K')
         The energy units which a Kelvin (K) energy is converted into.
         It does not convert any energy unit if the the energy_input_unyt is not in Kelvin (K).
+        NOTE and WARNING: the energy units of kcal, kJ will be accepted due to the way the
+        Unyt module does not accept mol as a recorded unit; however, this will result in
+        incorrect results from the intended function.
 
 
     Returns
@@ -169,8 +172,10 @@ def check_convert_kelvin_to_energy_units(
 
     """
     # check for input errors
-    if not isinstance(energy_input_unyt, type(u.unyt_quantity(1, "K"))):
-        print_error_message = f"ERROR: The entered energy_input_unyt value is a {type(energy_input_unyt)}, not a {type(u.Kelvin)}."
+    #if not isinstance(energy_input_unyt, type(u.unyt_quantity(1, "K"))):
+    if not isinstance(energy_input_unyt, u.unyt_quantity):
+        print_error_message = f"ERROR: The entered energy_input_unyt value is a {type(energy_input_unyt)}, " \
+                              f"not a {type(u.Kelvin)}."
         raise ValueError(print_error_message)
 
     if not isinstance(energy_output_unyt_units_str, str):

--- a/gmso/utils/conversions.py
+++ b/gmso/utils/conversions.py
@@ -144,7 +144,7 @@ def check_convert_kelvin_to_energy_units(
     energy_input_unyt,
     energy_output_unyt_units_str,
 ):
-    """Converts the Kelvin (K) energy unit to a standard energy unit.
+    """Convert the Kelvin (K) energy unit to a standard energy unit.
 
     Check to see if the unyt energy value is in Kelvin (K) and converts it to
     another energy unit (Ex: kcal/mol, kJ/mol, etc.).  Otherwise, it passes thru the

--- a/gmso/utils/conversions.py
+++ b/gmso/utils/conversions.py
@@ -1,6 +1,11 @@
 """Module for standard conversions needed in molecular simulations."""
 import sympy
 import unyt as u
+from unyt.dimensions import (
+    length,
+    mass,
+    time
+)
 
 import gmso
 from gmso.exceptions import GMSOError
@@ -137,3 +142,72 @@ def convert_ryckaert_to_opls(ryckaert_connection_type):
     )
 
     return opls_connection_type
+
+
+def check_convert_kelvin_to_energy_units(
+        energy_input_unyt,
+        energy_output_unyt_units_str,
+):
+    """Checks to see if the unyt energy value is in Kelvin (K) and converts it to
+    another energy unit (Ex: kcal/mol, kJ/mol, etc.).  Otherwise, it passes thru the
+    existing unyt values.
+
+    Parameters
+    ----------
+    energy_input_unyt : unyt.unyt_quantity
+        The energy in units of 'energy / other_units' Example: 'energy/mol/angstroms**2' or 'K/angstroms**2'.
+        NOTE: The only valid temperature unit for thermal energy is Kelvin (K).
+    energy_output_unyt_units_str : str (unyt valid energy units only)
+        (Example - 'kcal/mol', 'kJ/mol', or any '(length)**2*(mass)/(time)**2' , but not 'K')
+        The energy units which a Kelvin (K) energy is converted into.
+        It does not convert any energy unit if the the energy_input_unyt is not in Kelvin (K).
+
+
+    Returns
+    -------
+    energy_output_unyt : unyt.unyt_quantity
+        If the energy_input_unyt is in Kelvin (K), it converted to the specified energy_output_unyt_units_str.
+        Otherwise, it passes through the existing unyt values.
+
+    """
+    # check for input errors
+    if not isinstance(energy_input_unyt, type(u.unyt_quantity(1, 'K'))):
+        print_error_message = (
+            f"ERROR: The entered energy_input_unyt value is a {type(energy_input_unyt)}, not a {type(u.Kelvin)}.")
+        raise ValueError(print_error_message)
+
+    if not isinstance(energy_output_unyt_units_str, str):
+        print_error_message = (
+            f"ERROR: The entered energy_output_unyt_units_str value is a {type(energy_output_unyt_units_str)}, "
+            f"not a {type('string')}."
+        )
+        raise ValueError(print_error_message)
+
+    # check for K energy units and convert them to normal energy units;
+    # otherwise, just pass thru the original unyt units
+    if energy_output_unyt_units_str in ["K"]:
+        print_error_message = (
+            f"ERROR: The entered energy_output_unyt_units_str can not be in K energy units."
+        )
+        raise ValueError(print_error_message)
+
+    elif (length)**2*(mass)/(time)**2 != u.unyt_quantity(1, energy_output_unyt_units_str).units.dimensions:
+        print_error_message = (
+            f"ERROR: The entered energy_output_unyt_units_str value must be in units of energy/mol, "
+            f"(length)**2*(mass)/(time)**2, but not in K energy units."
+        )
+        raise ValueError(print_error_message)
+
+    if ('K') in str(energy_input_unyt.units) and 'temperature' in str(energy_input_unyt.units.dimensions):
+        K_to_energy_conversion_constant = u.unyt_quantity(1, 'K').to_value(
+            energy_output_unyt_units_str,
+            equivalence='thermal'
+        )
+        energy_output_unyt = energy_input_unyt / u.Kelvin * \
+                                     u.unyt_quantity(K_to_energy_conversion_constant,
+                                                     energy_output_unyt_units_str
+                                                     )
+    else:
+        energy_output_unyt  = energy_input_unyt
+
+    return energy_output_unyt


### PR DESCRIPTION
- Added a Kelvin ('K') energy units to standard energy values ('kcal/mol', 'kJ/mol', etc.) converter for when 'K' is with other unyt units.  This was needed as unyt only allows K to standard energy units when 'K' is the only unyt unit!

- If no 'K' energy units are in the unyt units, it just passes thru the original units.