### PR TITLE
Update method to load in mol2 file

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,11 +65,11 @@ stages:
             displayName: Install mamba
 
           - bash: |
+              rm /usr/share/miniconda/pkgs/cache/*.json
               mamba update conda -yq
             displayName: Add relevant channels and update
 
           - bash: |
-              rm /usr/share/miniconda/pkgs/cache/*.json
               sed -i -E 's/python.*$/python='$(python.version)'/' environment-dev.yml
               mamba env create -f environment-dev.yml
               source activate gmso-dev

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,6 +69,7 @@ stages:
             displayName: Add relevant channels and update
 
           - bash: |
+              rm /usr/share/miniconda/pkgs/cache/*.json
               sed -i -E 's/python.*$/python='$(python.version)'/' environment-dev.yml
               mamba env create -f environment-dev.yml
               source activate gmso-dev

--- a/gmso/formats/mol2.py
+++ b/gmso/formats/mol2.py
@@ -33,6 +33,7 @@ def from_mol2(filename, site_type="atom"):
 
     Notes
     -----
+    The position of atom in the mol2 file is assumed to be in Angstrom.
     It may be common to want to create an mBuild compound from a mol2 file. This is possible
     by installing [mBuild](https://mbuild.mosdef.org/en/stable/index.html)
     and converting using the following python code:
@@ -49,52 +50,76 @@ def from_mol2(filename, site_type="atom"):
     # Initialize topology
     topology = Topology(name=mol2path.stem)
     # save the name from the filename
-    with open(mol2path, "r") as f:
-        line = f.readline()
-        with open(filename, "r") as f:
-            fcontents = f.readlines()
-        sections = dict()
-        key = "meta"
-        for line in fcontents:
-            if "@<TRIPOS>" in line:
-                section_key = line.strip("\n")
-                sections[section_key] = list()
-            else:
-                sections[section_key].append(line)
+    with open(filename, "r") as f:
+        fcontents = f.readlines()
+    sections = dict()
+    for line in fcontents:
+        if "@<TRIPOS>" in line:
+            section_key = line.strip("\n")
+            sections[section_key] = list()
+        else:
+            sections[section_key].append(line)
 
-        supported_rti = {
-            "@<TRIPOS>ATOM": _parse_atom,
-            "@<TRIPOS>BOND": _parse_bond,
-            "@<TRIPOS>CRYSIN": _parse_box,
-            "@<TRIPOS>FF_PBC": _parse_box,
-        }
-        for section in sections:
-            if section not in supported_rti:
-                warnings.warn(
-                    f"The record type indicator {section} is not supported."
-                )
-            else:
-                supported_rti[section](
-                    topology, sections[section], site_type="atom"
-                )
+    _parse_site = _parse_lj if site_type == "lj" else _parse_atom
+    supported_rti = {
+        "@<TRIPOS>ATOM": _parse_site,
+        "@<TRIPOS>BOND": _parse_bond,
+        "@<TRIPOS>CRYSIN": _parse_box,
+        "@<TRIPOS>FF_PBC": _parse_box,
+    }
+    for section in sections:
+        if section not in supported_rti:
+            warnings.warn(
+                f"The record type indicator {section} is not supported."
+            )
+        else:
+            supported_rti[section](
+                topology, sections[section], site_type="atom"
+            )
 
     topology.update_topology()
     # TODO: read in parameters to correct attribute as well. This can be saved in various rti sections.
     return topology
 
 
-def _parse_atom(top, section, site_type="atom"):
-    """Parse atom information from the mol2 file."""
-    parse_ele = {
-        "lj": lambda ele: None,
-        "atom": lambda ele: element_by_symbol(ele)
-        if element_by_symbol(ele)
-        else element_by_name(ele),
-    }
+def _parse_lj(top, section):
+    """Parse atom of lj style from mol2 file."""
     for line in section:
         cont = line.split()
         position = [float(x) for x in cont[2:5]] * u.Å
-        element = parse_ele[site_type](cont[5])
+
+        try:
+            charge = float(cont[8])
+        except IndexError:
+            warnings.warn(
+                f"No charge was detected for site {cont[1]} with index {cont[0]}"
+            )
+
+        atom = Atom(
+            name=cont[1],
+            position=position.to("nm"),
+            charge=charge,
+            residue_name=cont[7],
+            residue_number=int(cont[6]),
+        )
+        top.add_site(atom)
+
+
+def _parse_atom(top, section):
+    """Parse atom information from the mol2 file."""
+    parse_ele = (
+        lambda ele: element_by_symbol(ele)
+        if element_by_symbol(ele)
+        else element_by_name(ele),
+    )
+    for line in section:
+        cont = line.split()
+        position = [float(x) for x in cont[2:5]] * u.Å
+        element = parse_ele(cont[5])
+
+        if not element:
+            warnings.warn(f"Could not parse the element of {cont[5]}")
+
         try:
             charge = float(cont[8])
         except IndexError:
@@ -106,6 +131,7 @@ def _parse_atom(top, section, site_type="atom"):
             name=cont[1],
             position=position.to("nm"),
             element=element,
+            charge=charge,
             residue_name=cont[7],
             residue_number=int(cont[6]),
         )

--- a/gmso/formats/mol2.py
+++ b/gmso/formats/mol2.py
@@ -73,9 +73,7 @@ def from_mol2(filename, site_type="atom"):
                 f"The record type indicator {section} is not supported."
             )
         else:
-            supported_rti[section](
-                topology, sections[section], site_type="atom"
-            )
+            supported_rti[section](topology, sections[section])
 
     topology.update_topology()
     # TODO: read in parameters to correct attribute as well. This can be saved in various rti sections.
@@ -138,7 +136,7 @@ def _parse_atom(top, section):
         top.add_site(atom)
 
 
-def _parse_bond(top, section, **kwargs):
+def _parse_bond(top, section):
     """Parse bond information from the mol2 file."""
     for line in section:
         cont = line.split()
@@ -151,7 +149,7 @@ def _parse_bond(top, section, **kwargs):
         top.add_connection(bond)
 
 
-def _parse_box(top, section, **kwargs):
+def _parse_box(top, section):
     """Parse box information from the mol2 file."""
     if top.box:
         warnings.warn("Topology already has a box")

--- a/gmso/tests/test_mol2.py
+++ b/gmso/tests/test_mol2.py
@@ -56,14 +56,14 @@ class TestMol2(BaseTest):
 
         with pytest.warns(
             UserWarning,
-            match=r"No charges were detected for site C with index 1",
+            match=r"No charge was detected for site C with index 1",
         ):
             top = Topology.load(get_fn("ethane.mol2"))
         assert list(top.sites)[0].charge is None
 
         with pytest.warns(
             UserWarning,
-            match=r"No element detected for site C with index1\, consider manually adding the element to the topology",
+            match=r"No element detected for site C with index 1, consider manually adding the element to the topology",
         ):
             Topology.load(get_fn("benzene.mol2"))
 
@@ -114,7 +114,7 @@ class TestMol2(BaseTest):
     def test_broken_files(self):
         with pytest.warns(
             UserWarning,
-            match=r"The record type indicator @<TRIPOS>MOLECULE_extra_text\n is not supported. Skipping current section and moving to the next RTI header.",
+            match=r"The record type indicator @<TRIPOS>MOLECULE_extra_text is not supported. Skipping current section and moving to the next RTI header.",
         ):
             Topology.load(get_fn("broken.mol2"))
         with pytest.warns(


### PR DESCRIPTION
We encountered a flaky test over mbuild when reading in the [beta-cristabolite mol2](https://github.com/mosdef-hub/mbuild/blob/master/mbuild/lib/surfaces/beta-cristobalite-expanded.mol2). The issue happens when parsing the bond section, which sometime misses a bond, which we are suspecting due to some racing condition (?). I was able to reproduce this issue when reading the file in a loop `for i in range(100)`, and assert the number of bond. This PR update the method to read in the mol2 file to parse the whole file at the beginning to the list and parse each section accordingly. 