### PR TITLE
Assign proper units when converting from Parmed

### DIFF
--- a/gmso/external/convert_parmed.py
+++ b/gmso/external/convert_parmed.py
@@ -546,8 +546,8 @@ def _improper_types_from_pmd(structure, improper_types_member_map=None):
 
     for impropertype in structure.improper_types:
         improper_params = {
-            "k": (impropertype.psi_k * u.Unit("kcal/mol")),
-            "phi_eq": (impropertype.psi_eq * u.Unit("kcal/mol")),
+            "k": (impropertype.psi_k * u.kcal / (u.mol * u.radian**2)),
+            "phi_eq": (impropertype.psi_eq * u.degree),
         }
         expr = lib["HarmonicImproperPotential"]
         member_types = improper_types_member_map.get(id(impropertype))


### PR DESCRIPTION
For ImproperTypes we were not using the correct units when converting from parmed. Thanks to #657, we are able to catch and fix it now.