### PR TITLE
Expanded search for improper_types

### DIFF
--- a/gmso/core/forcefield.py
+++ b/gmso/core/forcefield.py
@@ -1,4 +1,5 @@
 """Module for working with GMSO forcefields."""
+import itertools
 import warnings
 from collections import ChainMap
 from typing import Iterable
@@ -409,14 +410,18 @@ class ForceField(object):
             )
 
         forward = FF_TOKENS_SEPARATOR.join(atom_types)
-        reverse = FF_TOKENS_SEPARATOR.join(
-            [atom_types[0], atom_types[2], atom_types[1], atom_types[3]]
-        )
+        equivalent = [
+            FF_TOKENS_SEPARATOR.join(
+                [atom_types[0], atom_types[i], atom_types[j], atom_types[k]]
+            )
+            for (i, j, k) in itertools.permutations((1, 2, 3), 3)
+        ]
 
         if forward in self.improper_types:
             return self.improper_types[forward]
-        if reverse in self.improper_types:
-            return self.improper_types[reverse]
+        for eq in equivalent:
+            if eq in self.improper_types:
+                return self.improper_types[eq]
 
         match = None
         for i in range(1, 5):

--- a/gmso/tests/test_forcefield.py
+++ b/gmso/tests/test_forcefield.py
@@ -5,6 +5,7 @@ from lxml.etree import DocumentInvalid
 from sympy import sympify
 
 from gmso.core.forcefield import ForceField
+from gmso.core.improper_type import ImproperType
 from gmso.exceptions import (
     ForceFieldParseError,
     MissingAtomTypesError,
@@ -596,3 +597,19 @@ class TestForceField(BaseTest):
             ).definition
             == "[_CH2;X2]([_CH3,_CH2])[_CH3,_CH2]"
         )
+
+    def test_forcefield_get_impropers_combinations(self):
+        ff_with_impropers = ForceField()
+        ff_with_impropers.name = "imp_ff"
+        ff_with_impropers.improper_types = {
+            "CT~CT~HC~HC": ImproperType(name="imp1"),
+            "CT~HC~HC~HC": ImproperType(name="imp2"),
+        }
+        imp1 = ff_with_impropers.get_potential(
+            "improper_type", ["CT", "HC", "HC", "CT"]
+        )
+        imp2 = ff_with_impropers.get_potential(
+            "improper_type", ["CT", "HC", "CT", "HC"]
+        )
+        assert imp1.name == imp2.name
+        assert imp1 is imp2


### PR DESCRIPTION
For an improper, if we are to consider atom1 as the central atom, then the order of atom2/atom3/atom3 really doesn't matter when it comes to finding a matching type from the forcefield. In #644, when testing on a system with impropers, I found that we were only trying to find a potential match using two possibilities, while there should have been 6. This PR is an attempt to fix that. 

Previously, the following code would error out:
```py
>>> ff_with_impropers = ForceField()
>>> ff_with_impropers.name = "imp_ff"
>>> ff_with_impropers.improper_types = {
    "CT~CT~HC~HC": ImproperType(name="imp1"),
    "CT~HC~HC~HC": ImproperType(name="imp2"),
 }
>>> ff_with_impropers.get_potential("improper_type", ["CT", "HC", "HC", "CT"])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/umesh/krow/mosdef/gmso/gmso/core/forcefield.py", line 270, in get_potential
    return potential_extractors[group](key, warn=warn)
  File "/home/umesh/krow/mosdef/gmso/gmso/core/forcefield.py", line 455, in _get_improper_type
    raise MissingPotentialError(msg)
```

With this branch, we are able to find the correct parameters for improper based on the central atom regardless of how the rest of the atoms are ordered. 