### PR TITLE
New labels system for abstract site

### DIFF
--- a/gmso/abc/abstract_site.py
+++ b/gmso/abc/abstract_site.py
@@ -1,6 +1,6 @@
 """Basic interaction site in GMSO that all other sites will derive from."""
 import warnings
-from typing import Any, ClassVar, Optional, Sequence, Tuple, TypeVar, Union
+from typing import Any, ClassVar, NamedTuple, Optional, Sequence, TypeVar, Union
 
 import numpy as np
 import unyt as u
@@ -11,7 +11,9 @@ from gmso.abc.gmso_base import GMSOBase
 from gmso.exceptions import GMSOError
 
 PositionType = Union[Sequence[float], np.ndarray, u.unyt_array]
-LabelType = Tuple[StrictStr, StrictInt]
+MoleculeType = NamedTuple("Molecule", name=StrictStr, number=StrictInt)
+ResidueType = NamedTuple("Residue", name=StrictStr, number=StrictInt)
+
 SiteT = TypeVar("SiteT", bound="Site")
 
 BASE_DOC_ATTR = "__base_doc__"
@@ -53,17 +55,16 @@ class Site(GMSOBase):
 
     label_: str = Field("", description="Label to be assigned to the site")
 
-    group_: Optional[LabelType] = Field(
-        None,
-        description="Molecule Group label for the site, format of (group_name, group_number)",
+    group_: Optional[StrictStr] = Field(
+        None, description="Flexible alternative label relative to site"
     )
 
-    molecule_: Optional[LabelType] = Field(
+    molecule_: Optional[MoleculeType] = Field(
         None,
         description="Molecule label for the site, format of (molecule_name, molecule_number)",
     )
 
-    residue_: Optional[LabelType] = Field(
+    residue_: Optional[ResidueType] = Field(
         None,
         description="Residue label for the site, format of (residue_name, residue_number)",
     )

--- a/gmso/abc/abstract_site.py
+++ b/gmso/abc/abstract_site.py
@@ -1,6 +1,6 @@
 """Basic interaction site in GMSO that all other sites will derive from."""
 import warnings
-from typing import Any, ClassVar, Optional, Sequence, TypeVar, Union
+from typing import Any, ClassVar, Optional, Sequence, Tuple, TypeVar, Union
 
 import numpy as np
 import unyt as u
@@ -11,6 +11,7 @@ from gmso.abc.gmso_base import GMSOBase
 from gmso.exceptions import GMSOError
 
 PositionType = Union[Sequence[float], np.ndarray, u.unyt_array]
+LabelType = Tuple[StrictStr, StrictInt]
 SiteT = TypeVar("SiteT", bound="Site")
 
 BASE_DOC_ATTR = "__base_doc__"
@@ -24,8 +25,9 @@ def default_position():
 class Site(GMSOBase):
     __iterable_attributes__: ClassVar[set] = {
         "label",
-        "residue_name",
-        "residue_number",
+        "group",
+        "molecule",
+        "residue",
     }
 
     __base_doc__: ClassVar[
@@ -51,12 +53,19 @@ class Site(GMSOBase):
 
     label_: str = Field("", description="Label to be assigned to the site")
 
-    residue_number_: Optional[StrictInt] = Field(
-        None, description="Residue number for the site"
+    group_: Optional[LabelType] = Field(
+        None,
+        description="Molecule Group label for the site, format of (group_name, group_number)",
     )
 
-    residue_name_: Optional[StrictStr] = Field(
-        None, description="Residue label for the site"
+    molecule_: Optional[LabelType] = Field(
+        None,
+        description="Molecule label for the site, format of (molecule_name, molecule_number)",
+    )
+
+    residue_: Optional[LabelType] = Field(
+        None,
+        description="Residue label for the site, format of (residue_name, residue_number)",
     )
 
     position_: PositionType = Field(
@@ -80,14 +89,19 @@ class Site(GMSOBase):
         return self.__dict__.get("label_")
 
     @property
-    def residue_name(self):
-        """Return the residue name assigned to the site."""
-        return self.__dict__.get("residue_name_")
+    def group(self) -> str:
+        """Return the group of the site."""
+        return self.__dict__.get("group_")
 
     @property
-    def residue_number(self):
-        """Return the reside number assigned to the site."""
-        return self.__dict__.get("residue_number_")
+    def molecule(self) -> tuple:
+        """Return the molecule of the site."""
+        return self.__dict__.get("molecule_")
+
+    @property
+    def residue(self):
+        """Return the residue assigned to the site."""
+        return self.__dict__.get("residue_")
 
     def __repr__(self):
         """Return the formatted representation of the site."""
@@ -155,16 +169,18 @@ class Site(GMSOBase):
             "name_": "name",
             "position_": "position",
             "label_": "label",
-            "residue_name_": "residue_name",
-            "residue_number_": "residue_number",
+            "group_": "group",
+            "molecule_": "molecule",
+            "residue_": "residue",
         }
 
         alias_to_fields = {
             "name": "name_",
             "position": "position_",
             "label": "label_",
-            "residue_name": "residue_name_",
-            "residue_number": "residue_number_",
+            "group": "group_",
+            "molecule": "molecule_",
+            "residue": "residue_",
         }
 
         validate_assignment = True

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -322,6 +322,19 @@ class Topology(object):
         """Return all impropers in the topology."""
         return self._impropers
 
+    def unique_site_labels(self, label_type="molecule", name_only=True):
+        """Return a list of all molecule/residue labels in the Topology."""
+        # Not super happy with this method name, open for suggestion.
+        unique_tags = IndexedSet()
+        if name_only:
+            for site in self.sites:
+                label = getattr(site, label_type)
+                unique_tags.add(label[0] if label else None)
+        else:
+            for site in self.sites:
+                unique_tags.add(getattr(site, label_type))
+        return unique_tags
+
     @property
     def atom_types(self):
         """Return all atom_types in the topology.
@@ -1134,25 +1147,39 @@ class Topology(object):
             if getattr(site, key) == value:
                 yield site
 
-    def iter_sites_by_residue_name(self, name):
-        """Iterate through this topology's sites which contain this specific residue `name`.
+    def iter_sites_by_residue(self, name):
+        """Iterate through this topology's sites which contain this specific residue name.
 
         See Also
         --------
         gmso.core.topology.Topology.iter_sites
             The method to iterate over Topology's sites
         """
-        return self.iter_sites("residue_name", name)
+        if name is None:
+            for site in self._sites:
+                if not site.residue:
+                    yield site
+        else:
+            for site in self._sites:
+                if site.residue and getattr(site, "residue")[0] == name:
+                    yield site
 
-    def iter_sites_by_residue_number(self, number):
-        """Iterate through this topology's sites which contain this specific residue `number`.
+    def iter_sites_by_molecule(self, name):
+        """Iterate through this topology's sites which contain this specific molecule name.
 
         See Also
         --------
         gmso.core.topology.Topology.iter_sites
             The method to iterate over Topology's sites
         """
-        return self.iter_sites("residue_number", number)
+        if name is None:
+            for site in self._sites:
+                if not site.molecule:
+                    yield site
+        else:
+            for site in self._sites:
+                if site.molecule and getattr(site, "molecule")[0] == name:
+                    yield site
 
     def save(self, filename, overwrite=False, **kwargs):
         """Save the topology to a file.

--- a/gmso/external/convert_parmed.py
+++ b/gmso/external/convert_parmed.py
@@ -109,8 +109,7 @@ def from_parmed(structure, refer_type=True):
                         [atom.xx, atom.xy, atom.xz] * u.angstrom
                     ).in_units(u.nm),
                     atom_type=pmd_top_atomtypes[atom.atom_type],
-                    residue_name=residue.name,
-                    residue_number=residue.idx,
+                    residue=(residue.name, residue.idx),
                     element=element,
                 )
             else:
@@ -121,8 +120,7 @@ def from_parmed(structure, refer_type=True):
                         [atom.xx, atom.xy, atom.xz] * u.angstrom
                     ).in_units(u.nm),
                     atom_type=None,
-                    residue_name=residue.name,
-                    residue_number=residue.idx,
+                    residue=(residue.name, residue.idx),
                     element=element,
                 )
             site_map[atom] = site
@@ -624,9 +622,9 @@ def to_parmed(top, refer_type=True):
         ).value
 
         # Add atom to structure
-        if site.residue_name:
+        if site.residue:
             structure.add_atom(
-                pmd_atom, resname=site.residue_name, resnum=site.residue_number
+                pmd_atom, resname=site.residue[0], resnum=site.residue[1]
             )
         else:
             structure.add_atom(pmd_atom, resname="RES", resnum=-1)

--- a/gmso/formats/mol2.py
+++ b/gmso/formats/mol2.py
@@ -103,8 +103,7 @@ def _parse_lj(top, section):
                 name=content[1],
                 position=position.to("nm"),
                 charge=charge,
-                residue_name=content[7],
-                residue_number=int(content[6]),
+                residue=(content[7], int(content[6])),
             )
             top.add_site(atom)
 
@@ -146,8 +145,7 @@ def _parse_atom(top, section):
                 position=position.to("nm"),
                 element=element,
                 charge=charge,
-                residue_name=content[7],
-                residue_number=int(content[6]),
+                residue=(content[7], int(content[6])),
             )
             top.add_site(atom)
 

--- a/gmso/tests/base_test.py
+++ b/gmso/tests/base_test.py
@@ -213,11 +213,9 @@ class BaseTest:
         molecule_tags = top.unique_site_labels(
             label_type="molecule", name_only=False
         )
-        for tag in molecule_tags:
+        for subtop in top.subtops:
             angle = Angle(
-                connection_members=[
-                    site for site in top.iter_sites("molecule", tag)
-                ],
+                connection_members=[site for site in subtop.sites],
                 name="opls_112~opls_111~opls_112",
                 angle_type=ff.angle_types["opls_112~opls_111~opls_112"],
             )

--- a/gmso/tests/base_test.py
+++ b/gmso/tests/base_test.py
@@ -210,9 +210,14 @@ class BaseTest:
         for bond in top.bonds:
             bond.bond_type = ff.bond_types["opls_111~opls_112"]
 
-        for subtop in top.subtops:
+        molecule_tags = top.unique_site_labels(
+            label_type="molecule", name_only=False
+        )
+        for tag in molecule_tags:
             angle = Angle(
-                connection_members=[site for site in subtop.sites],
+                connection_members=[
+                    site for site in top.iter_sites("molecule", tag)
+                ],
                 name="opls_112~opls_111~opls_112",
                 angle_type=ff.angle_types["opls_112~opls_111~opls_112"],
             )
@@ -494,8 +499,7 @@ class BaseTest:
         for i in range(1, 26):
             atom = Atom(
                 name=f"atom_{i + 1}",
-                residue_number=i % 5,
-                residue_name="MY_RES_EVEN" if i % 2 == 0 else f"MY_RES_ODD",
+                residue=("MY_RES_EVEN" if i % 2 == 0 else f"MY_RES_ODD", i % 5),
             )
             top.add_site(atom, update_types=False)
         top.update_topology()

--- a/gmso/tests/test_convert_parmed.py
+++ b/gmso/tests/test_convert_parmed.py
@@ -267,8 +267,8 @@ class TestConvertParmEd(BaseTest):
         assert len(top_from_struc.subtops) == len(struc.residues)
 
         for site in top_from_struc.sites:
-            assert site.residue_name == "HEX"
-            assert site.residue_number in list(range(6))
+            assert site.residue[0] == "HEX"
+            assert site.residue[1] in list(range(6))
 
         struc_from_top = to_parmed(top_from_struc)
         assert len(struc_from_top.residues) == len(struc.residues)
@@ -286,8 +286,7 @@ class TestConvertParmEd(BaseTest):
         assert len(top_from_struc.subtops) == len(struc.residues)
 
         for site in top_from_struc.sites:
-            site.residue_name = None
-            site.residue_number = None
+            site.residue = None
 
         struc_from_top = to_parmed(top_from_struc)
         assert len(struc_from_top.residues) == 1

--- a/gmso/tests/test_mol2.py
+++ b/gmso/tests/test_mol2.py
@@ -63,33 +63,27 @@ class TestMol2(BaseTest):
 
     def test_residue(self):
         top = Topology.load(get_fn("ethanol_aa.mol2"))
-        assert np.all([site.residue_name == "ETO" for site in top.sites])
-        assert np.all([site.residue_number == 1 for site in top.sites])
+        assert np.all([site.residue[0] == "ETO" for site in top.sites])
+        assert np.all([site.residue[1] == 1 for site in top.sites])
 
         top = Topology.load(get_fn("benzene_ua.mol2"), site_type="lj")
         assert np.all(
             [
-                site.residue_name == "BEN1"
-                for site in top.iter_sites("residue_name", "BEN1")
+                site.residue[0] == "BEN1"
+                for site in top.iter_sites_by_residue("BEN1")
             ]
         )
         assert np.all(
-            [
-                site.residue_number == 1
-                for site in top.iter_sites("residue_name", "BEN1")
-            ]
+            [site.residue[1] == 1 for site in top.iter_sites_by_residue("BEN1")]
         )
         assert np.all(
             [
-                site.residue_name == "BEN2"
-                for site in top.iter_sites("residue_name", "BEN2")
+                site.residue[0] == "BEN2"
+                for site in top.iter_sites_by_residue("BEN2")
             ]
         )
         assert np.all(
-            [
-                site.residue_number == 2
-                for site in top.iter_sites("residue_name", "BEN2")
-            ]
+            [site.residue[1] == 2 for site in top.iter_sites_by_residue("BEN2")]
         )
 
     def test_lj_system(self):

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -703,14 +703,11 @@ class TestTopology(BaseTest):
             clone.get_untyped(group="foo")
 
     def test_iter_sites(self, residue_top):
-        for site in residue_top.iter_sites("residue_name", "MY_RES_EVEN"):
-            assert site.residue_name == "MY_RES_EVEN"
+        for site in residue_top.iter_sites_by_residue("MY_RES_EVEN"):
+            assert site.residue[0] == "MY_RES_EVEN"
 
-        for site in residue_top.iter_sites("residue_name", "MY_RES_ODD"):
-            assert site.residue_name == "MY_RES_ODD"
-
-        sites = list(residue_top.iter_sites("residue_number", 4))
-        assert len(sites) == 5
+        for site in residue_top.iter_sites_by_residue("MY_RES_ODD"):
+            assert site.residue[0] == "MY_RES_ODD"
 
     def test_iter_sites_non_iterable_attribute(self, residue_top):
         with pytest.raises(ValueError):
@@ -719,15 +716,10 @@ class TestTopology(BaseTest):
 
     def test_iter_sites_none(self, residue_top):
         with pytest.raises(ValueError):
-            for site in residue_top.iter_sites("residue_name", None):
+            for site in residue_top.iter_sites("residue", None):
                 pass
 
     def test_iter_sites_by_residue_name(self, pairpotentialtype_top):
         assert (
-            len(list(pairpotentialtype_top.iter_sites_by_residue_name("AAA")))
-            == 0
+            len(list(pairpotentialtype_top.iter_sites_by_residue("AAA"))) == 0
         )
-
-    def test_iter_sites_by_residue_number(self, residue_top):
-        sites = list(residue_top.iter_sites_by_residue_number(4))
-        assert len(sites) == 5


### PR DESCRIPTION
The code of this PR is a part of #638, and is broken off to be it's own PR as suggested by @umesh-timalsina. This PR introduce the new labeling system in abstract Site, which will allow for subsequent removal of the SubTopology class. The labels are intended to present important information a Topology - group, molecule, and residue - without having a strict hierarchy structure in place.