### PR TITLE
pin unyt to version that supports 3.7

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - numpy
   - sympy
-  - unyt >= 2.4
+  - unyt <= 2.8
   - boltons
   - lxml
   - pydantic < 1.9.0

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
   - numpy
   - sympy
-  - unyt >= 2.4
+  - unyt <= 2.8
   - boltons
   - lxml
   - pydantic < 1.9.0


### PR DESCRIPTION
It seems like unyt decided to drop support for python 3.6 and 3.7 (https://pypi.org/project/unyt/), so this PR will pin the unyt package to those that still support py3.7. We will need to make a decision soon about whether it's time to drop support for py3.7 too. 