### PR TITLE
Pin pydantic until conda install issue is fixed

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -7,7 +7,7 @@ dependencies:
   - unyt <= 2.8
   - boltons
   - lxml
-  - pydantic < 1.9.0
+  - pydantic=1.8.2
   - networkx
   - pytest
   - mbuild >= 0.11.0

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - unyt <= 2.8
   - boltons
   - lxml
-  - pydantic < 1.9.0
+  - pydantic=1.8.2
   - networkx
   - ele >= 0.2.0
   - forcefield-utilities


### PR DESCRIPTION
Relate to https://github.com/mosdef-hub/foyer/issues/511 and https://github.com/conda/conda/issues/11714. Summary, conda is grabbing the wrong version of `pydantic` and causing issue downstream. This PR will pin the version of pydantic to be 1.8.2, which will make conda install the correct version. 