### PR TITLE
Support breaking changes from `pydantic>=v1.9`

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -7,7 +7,7 @@ dependencies:
   - unyt <= 2.8
   - boltons
   - lxml
-  - pydantic=1.8.2
+  - pydantic>1.8
   - networkx
   - pytest
   - mbuild >= 0.11.0

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
   - unyt <= 2.8
   - boltons
   - lxml
-  - pydantic=1.8.2
+  - pydantic>1.8
   - networkx
   - ele >= 0.2.0
   - forcefield-utilities

--- a/gmso/abc/gmso_base.py
+++ b/gmso/abc/gmso_base.py
@@ -2,7 +2,7 @@
 import json
 import warnings
 from abc import ABC
-from typing import Any, ClassVar, Optional, Type, Union
+from typing import Any, ClassVar, Type
 
 from pydantic import BaseModel
 from pydantic.validators import dict_validator

--- a/gmso/abc/gmso_base.py
+++ b/gmso/abc/gmso_base.py
@@ -2,7 +2,7 @@
 import json
 import warnings
 from abc import ABC
-from typing import Any, ClassVar, Type
+from typing import Any, ClassVar, Optional, Type, Union
 
 from pydantic import BaseModel
 from pydantic.validators import dict_validator
@@ -64,6 +64,10 @@ class GMSOBase(BaseModel, ABC):
 
     def dict(self, **kwargs) -> "DictStrAny":
         kwargs["by_alias"] = True
+        super_dict = super(GMSOBase, self).dict(**kwargs)
+        return super_dict
+
+    def _iter(self, **kwargs) -> "TupleGenerator":
         exclude = kwargs.get("exclude")
         include = kwargs.get("include")
         include_alias = set()
@@ -84,8 +88,8 @@ class GMSOBase(BaseModel, ABC):
                 else:
                     exclude_alias.add(excluded)
             kwargs["exclude"] = exclude_alias
-        super_dict = super(GMSOBase, self).dict(**kwargs)
-        return super_dict
+
+        yield from super()._iter(**kwargs)
 
     def json(self, **kwargs):
         kwargs["by_alias"] = True


### PR DESCRIPTION
This PR integrates support for breaking changes in `pydantic>=v1.9`. Mainly the `dict` method has changed in upstream to use `_iter`, which yields a tuple generator.