### PR TITLE
pin foyer and ffutils version

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -11,17 +11,16 @@ dependencies:
   - pydantic>1.8
   - networkx
   - pytest
-  - mbuild >= 0.11.0
-  - openbabel >= 3.0.0
-  - foyer >= 0.11.1
-  - gsd >= 2.0
-  - parmed >= 3.4.3
+  - mbuild>=0.11.0
+  - openbabel>=3.0.0
+  - foyer>=0.11.3
+  - forcefield-utilities>=0.2.1
+  - gsd>=2.0
+  - parmed>=3.4.3
   - pytest-cov
   - codecov
   - bump2version
   - matplotlib
   - ipywidgets
-  - ele >= 0.2.0
+  - ele>=0.2.0
   - pre-commit
-  - pip:
-        - "--editable=git+https://github.com/mosdef-hub/forcefield-utilities.git#egg=forcefield-utilities"

--- a/environment.yml
+++ b/environment.yml
@@ -10,5 +10,6 @@ dependencies:
   - lxml
   - pydantic>1.8
   - networkx
-  - ele >= 0.2.0
-  - forcefield-utilities
+  - ele>=0.2.0
+  - foyer>=0.11.3
+  - forcefield-utilities>=0.2.1

--- a/gmso/tests/test_forcefield.py
+++ b/gmso/tests/test_forcefield.py
@@ -10,6 +10,7 @@ from gmso.core.improper_type import ImproperType
 from gmso.exceptions import (
     ForceFieldError,
     ForceFieldParseError,
+    GMSOError,
     MissingAtomTypesError,
     MissingPotentialError,
 )
@@ -658,3 +659,15 @@ class TestForceField(BaseTest):
     def test_deprecated_gmso(self):
         with pytest.warns(DeprecationWarning):
             ForceField(get_path("ff-example0.xml"), backend="gmso")
+
+    def test_not_supoprted_backend(self, opls_ethane_foyer):
+        # Unsupported ff parser backend
+        with pytest.raises(GMSOError):
+            ForceField(get_path("ff-example0.xml"), backend="bogus")
+
+        # Unsupported ff writer backend
+        with pytest.raises(NotImplementedError):
+            opls_ethane_foyer.to_xml("test_xml_writer.xml", backend="ffutils")
+
+        with pytest.raises(GMSOError):
+            opls_ethane_foyer.to_xml("test_xml_writer.xml", backend="bogus")

--- a/gmso/utils/decorators.py
+++ b/gmso/utils/decorators.py
@@ -19,6 +19,7 @@ class register_pydantic_json(object):
 
 
 def deprecate_kwargs(deprecated_kwargs=None):
+    """Decorate functions with deprecated/deprecating kwargs."""
     if deprecated_kwargs is None:
         deprecated_kwargs = set()
 


### PR DESCRIPTION
I reran the all CI tests after `foyer v0.11.3` and `ffutls v0.2.1` were out but the CI somehow were still grabbing `foyer v0.11.2`. This PR tries to change the foyer/ffutils version in the env yml. 