### PR TITLE
Additional checks when generate pair lists 

### DIFF
--- a/gmso/external/convert_networkx.py
+++ b/gmso/external/convert_networkx.py
@@ -73,7 +73,7 @@ def from_networkx(graph):
     return top
 
 
-def to_networkx(top):
+def to_networkx(top, parse_angles=True, parse_dihedrals=True):
     """Convert a gmso.Topology to a networkX.Graph.
 
     Creates a graph from the topology where each node is a site and each
@@ -83,6 +83,10 @@ def to_networkx(top):
     ----------
     top : gmso.Topology
         topology.Topology instance that need to be converted
+    parse_angles : bool, optional, default=True
+        Populate angle field of all nodes
+    parse_dihedral : bool, optional default=True
+        Populate dihedral field of all nodes
 
     Returns
     -------
@@ -105,10 +109,12 @@ def to_networkx(top):
             b.connection_members[0], b.connection_members[1], connection=b
         )
 
-    for node in graph.nodes:
-        graph.nodes[node]["angles"] = top._get_angles_for(node)
+    if parse_angles:
+        for node in graph.nodes:
+            graph.nodes[node]["angles"] = top._get_angles_for(node)
 
-    for node in graph.nodes:
-        graph.nodes[node]["dihedrals"] = top._get_dihedrals_for(node)
+    if parse_dihedrals:
+        for node in graph.nodes:
+            graph.nodes[node]["dihedrals"] = top._get_dihedrals_for(node)
 
     return graph

--- a/gmso/formats/top.py
+++ b/gmso/formats/top.py
@@ -3,12 +3,14 @@ import datetime
 import warnings
 
 import unyt as u
+from networkx.algorithms import shortest_path_length
 
 from gmso.core.dihedral import Dihedral
 from gmso.core.element import element_by_atom_type
 from gmso.core.improper import Improper
 from gmso.core.views import PotentialFilters
 from gmso.exceptions import GMSOError
+from gmso.external import to_networkx
 from gmso.formats.formats_registry import saves_as
 from gmso.lib.potential_templates import PotentialTemplateLibrary
 from gmso.parameterization.molecule_utils import (
@@ -423,6 +425,8 @@ def _generate_pairs_list(top, molecule=None):
     """
 
     pairs_list = list()
+    graph = to_networkx(top, parse_angles=False, parse_dihedrals=False)
+
     dihedrals = molecule_dihedrals(top, molecule) if molecule else top.dihedrals
     for dihedral in dihedrals:
         pairs = (
@@ -430,6 +434,8 @@ def _generate_pairs_list(top, molecule=None):
             dihedral.connection_members[-1],
         )
         pairs = sorted(pairs, key=lambda site: top.get_index(site))
+        if shortest_path_length(graph, pairs[0], pairs[1]) < 3:
+            continue
         if pairs not in pairs_list:
             pairs_list.append(pairs)
 

--- a/gmso/tests/test_top.py
+++ b/gmso/tests/test_top.py
@@ -237,10 +237,19 @@ class TestTop(BaseTest):
         ethane_pairs = _generate_pairs_list(ethane_top)
         assert len(ethane_pairs) == len(ethane_top.dihedrals) == 9
 
-        # Cyclobutadiene with 16 dihedrals and 12 pairs (due to cyclic structure)
+        # Cyclobutadiene with 16 dihedrals and 8 pairs (due to cyclic structure)
         cyclobutadiene = mb.load("C1=CC=C1", smiles=True)
         cyclobutadiene_top = from_mbuild(cyclobutadiene)
         cyclobutadiene_top.identify_connections()
         cyclobutadiene_top_pairs = _generate_pairs_list(cyclobutadiene_top)
         assert len(cyclobutadiene_top.dihedrals) == 16
-        assert len(cyclobutadiene_top_pairs) == 12
+        assert len(cyclobutadiene_top_pairs) == 8
+
+        # Cyclopentane with 45 dihedrals and 40 pairs (due to cyclic structure)
+        cyclopentane = mb.load("C1CCCC1", smiles=True)
+        cyclopentane_top = from_mbuild(cyclopentane)
+        cyclopentane_top.identify_connections()
+        cyclopentane_top_pairs = _generate_pairs_list(cyclopentane_top)
+
+        assert len(cyclopentane_top.dihedrals) == 45
+        assert len(cyclopentane_top_pairs) == 40


### PR DESCRIPTION
Address #718. Added checks for `shortest_path_length` when generate pair lists from dihedral. Added unit test for the 4 and 5-ring member. Added options to create a lighter weight networkx graph (not populating angles and dihedrals for each node). 