### PR TITLE
Parameterized Parmed Conversions

### DIFF
--- a/gmso/tests/base_test.py
+++ b/gmso/tests/base_test.py
@@ -197,9 +197,6 @@ class BaseTest:
 
         mb_ethane = Ethane()
         oplsaa = foyer.Forcefield(name="oplsaa")
-        # At this point, we still need to go through
-        # parmed Structure, until foyer can perform
-        # atomtyping on gmso Topology
         pmd_ethane = oplsaa.apply(mb_ethane)
         top = from_parmed(pmd_ethane)
         top.name = "ethane"
@@ -674,3 +671,14 @@ class BaseTest:
         methane_ua_gomc = mb.Compound(name="_CH4")
 
         return methane_ua_gomc
+
+    @pytest.fixture
+    def parmed_benzene(self):
+        untyped_benzene = mb.load(get_fn("benzene.mol2"))
+        ff_improper = foyer.Forcefield(
+            forcefield_files=get_fn("improper_dihedral.xml")
+        )
+        benzene = ff_improper.apply(
+            untyped_benzene, assert_dihedral_params=False
+        )
+        return benzene

--- a/gmso/tests/test_top.py
+++ b/gmso/tests/test_top.py
@@ -51,9 +51,6 @@ class TestTop(BaseTest):
         top.save(f"{fname}.top", overwrite=True)
         with open(f"{fname}.top") as f:
             conts = f.readlines()
-        import os
-
-        print(os.getcwd())
         with open(get_path(f"{fname}_ref.top")) as f:
             ref_conts = f.readlines()
 

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -569,7 +569,7 @@ class TestTopology(BaseTest):
             typed_chloroethanol.get_index(
                 typed_chloroethanol.angles[5].connection_type
             )
-            == 1
+            == 4
         )
 
     def test_topology_get_index_dihedral_type(self, typed_chloroethanol):

--- a/gmso/utils/files/charmm36_cooh.xml
+++ b/gmso/utils/files/charmm36_cooh.xml
@@ -1,0 +1,51 @@
+<ForceField>
+  <AtomTypes>
+    <Type name="CTL2" class="CTL2" element="_CTL2" mass="12.011" def="[_CTL2]"/>
+    <Type name="OBL" class="OBL" element="_OBL" mass="15.994" def="[_OBL]"/>
+    <Type name="OHL" class="OHL" element="_OHL" mass="15.994" def="[_OHL]"/>
+    <Type name="CL" class="CL" element="_CL" mass="12.011" def="[_CL]"/>
+  </AtomTypes>
+  <HarmonicBondForce>
+    <Bond type1="CTL2" type2="CL" length="0.1522" k="167359.99999999994"/>
+    <Bond type1="OBL" type2="CL" length="0.122" k="627599.9999999998"/>
+    <Bond type1="OHL" type2="CL" length="0.14" k="192463.99999999994"/>
+    <Bond type1="CTL2" type2="CTL2" length="0.15300000000000002" k="186187.99999999994"/>
+    <Bond type1="OHL" type2="CTL2" length="0.142" k="358150.3999999999"/>
+  </HarmonicBondForce>
+  <HarmonicAngleForce>
+    <Angle type1="OBL" type2="CL" type3="CTL2" angle="2.181661564992912" k="585.76"/>
+    <Angle type1="CTL2" type2="CTL2" type3="CL" angle="1.8849555921538759" k="435.136"/>
+    <Angle type1="OHL" type2="CL" type3="OBL" angle="2.1467549799530254" k="418.4"/>
+    <Angle type1="OHL" type2="CL" type3="CTL2" angle="1.928588823453734" k="460.24"/>
+    <Angle type1="CTL2" type2="CTL2" type3="CTL2" angle="1.9826940302655582" k="488.2728"/>
+    <Angle type1="OHL" type2="CTL2" type3="CTL2" angle="1.9216075064457567" k="633.4576"/>
+  </HarmonicAngleForce>
+  <!-- Urey-Bradley terms -->
+  <AmoebaUreyBradleyForce>
+    <UreyBradley type1="OBL" type2="CL" type3="CTL2" d="0.24420000000000003" k="8368.0"/>
+    <UreyBradley type1="CTL2" type2="CL" type3="OBL" d="0.24420000000000003" k="8368.0"/>
+    <UreyBradley type1="OHL" type2="CL" type3="OBL" d="0.2262" k="87864.0"/>
+    <UreyBradley type1="OBL" type2="CL" type3="OHL" d="0.2262" k="87864.0"/>
+    <UreyBradley type1="CTL2" type2="CTL2" type3="CTL2" d="0.2561" k="4669.344999999999"/>
+  </AmoebaUreyBradleyForce>
+  <PeriodicTorsionForce>
+    <Proper type1="CTL2" type2="CTL2" type3="CTL2" type4="CL" periodicity1="5" phase1="3.141592653589793" k1="0.0" periodicity2="3" phase2="3.141592653589793" k2="1.3263279999999997" periodicity3="2" phase3="0.0" k3="2.330488" periodicity4="1" phase4="0.0" k4="3.150552"/>
+    <Proper type1="CTL2" type2="CTL2" type3="CTL2" type4="CTL2" periodicity1="2" phase1="0.0" k1="0.42258399999999996" periodicity2="3" phase2="3.141592653589793" k2="0.594128" periodicity3="4" phase3="0.0" k3="0.309616" periodicity4="5" phase4="0.0" k4="0.405848"/>
+    <Proper type1="" type2="CTL2" type3="OHL" type4="" periodicity1="3" phase1="0.0" k1="0.58576"/>
+    <Proper type1="" type2="CTL2" type3="CL" type4="" periodicity1="6" phase1="3.141592653589793" k1="0.2092"/>
+    <Proper type1="" type2="CL" type3="OHL" type4="" periodicity1="2" phase1="3.141592653589793" k1="8.5772"/>
+    <Proper type1="" type2="CTL2" type3="CTL2" type4="" periodicity1="3" phase1="0.0" k1="0.79496"/>
+  </PeriodicTorsionForce>
+  <CustomTorsionForce energy="k*(theta-theta0)^2">
+    <PerTorsionParameter name="k"/>
+    <PerTorsionParameter name="theta0"/>
+    <Improper type1="CL" type2="OBL" type3="" type4="" k="418.4" theta0="0.0"/>
+    <Improper type1="CL" type2="CTL2" type3="" type4="" k="401.66399999999993" theta0="0.0"/>
+  </CustomTorsionForce>
+  <NonbondedForce coulomb14scale="1.0" lj14scale="1.0">
+    <Atom type="CTL2" sigma="0.358141284692" epsilon="0.234304" charge="0.0"/>
+    <Atom type="OBL" sigma="0.3029055641680001" epsilon="0.50208" charge="0.0"/>
+    <Atom type="OHL" sigma="0.315378146222" epsilon="0.6363863999999999" charge="0.0"/>
+    <Atom type="CL" sigma="0.356359487256" epsilon="0.29288" charge="0.0"/>
+  </NonbondedForce>
+</ForceField>

--- a/gmso/utils/files/improper_dihedral.xml
+++ b/gmso/utils/files/improper_dihedral.xml
@@ -1,0 +1,23 @@
+<ForceField name="Test-Torsions" version="0.0.1" combining_rule="geometric">
+ <AtomTypes>
+  <Type name="CT" class="CT" element="C" mass="12.01100" def="C"/>
+  <Type name="HC" class="HC" element="H" mass="1.0081" def="H"/>
+ </AtomTypes>
+ <HarmonicBondForce>
+  <Bond class1="CT" class2="HC" length="0.163" k="251040.0"/>
+  <Bond class1="CT" class2="CT" length="0.163" k="251040.0"/>
+ </HarmonicBondForce>
+ <HarmonicAngleForce>
+  <Angle class1="CT" class2="CT" class3="HC" angle="2.7053" k="397.48"/>
+  <Angle class1="HC" class2="CT" class3="HC" angle="2.7053" k="397.48"/>
+  <Angle class1="CT" class2="CT" class3="CT" angle="1.9111" k="397.48"/>
+ </HarmonicAngleForce>
+ <PeriodicTorsionForce>
+   <Proper class1="CT" class2="CT" class3="CT" class4="HC" periodicity1="1" phase1="3.14" k1="3.1"/>
+   <Improper class1="CT" class2="CT" class3="CT" class4="HC" periodicity1="1" phase1="3.14" k1="3.1"/>
+ </PeriodicTorsionForce>
+  <NonbondedForce coulomb14scale="0" lj14scale="0">
+   <Atom type="CT" charge="-0.100" sigma="0.302" epsilon="0.773245"/>
+   <Atom type="HC" charge="0.100" sigma="0.302" epsilon="0.01"/>
+ </NonbondedForce>
+</ForceField>


### PR DESCRIPTION
This PR should fix minor issues #716 which didn't account for symmetries in conversions from parmed structures. This checks that the expected number of potentials are found, which were only being checked over simple molecules such as ethane, and as such missing that some connection types were repeated.

Additional tests were done to check for urey bradleys, harmonic and periodic impropers, and periodic propers.