### PR TITLE
Move generate_pairs_lists

### DIFF
--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -331,7 +331,7 @@ def _parse_pairs_information(
     pairs = list()
 
     scaled_pairs = list()
-    pairs_dict = generate_pairs_lists(top)
+    pairs_dict = generate_pairs_lists(top, refer_from_scaling_factor=True)
     for pair_type in pairs_dict:
         scaled_pairs.extend(pairs_dict[pair_type])
 

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -14,6 +14,7 @@ from unyt.array import allclose_units
 from gmso.core.views import PotentialFilters
 from gmso.exceptions import GMSOError, NotYetImplementedWarning
 from gmso.lib.potential_templates import PotentialTemplateLibrary
+from gmso.utils.connectivity import generate_pairs_lists
 from gmso.utils.conversions import (
     convert_opls_to_ryckaert,
     convert_ryckaert_to_opls,
@@ -330,8 +331,9 @@ def _parse_pairs_information(
     pairs = list()
 
     scaled_pairs = list()
-    for pair_type in _generate_pairs_list(top):
-        scaled_pairs.extend(pair_type)
+    pairs_dict = generate_pairs_lists(top)
+    for pair_type in pairs_dict:
+        scaled_pairs.extend(pairs_dict[pair_type])
 
     for pair in scaled_pairs:
         if pair[0].atom_type and pair[1].atom_type:
@@ -805,11 +807,12 @@ def _parse_coulombic(
     special_coulombic = hoomd.md.special_pair.Coulomb()
 
     # Use same method as to_hoomd_snapshot to generate pairs list
-    for i, pairs in enumerate(_generate_pairs_list(top)):
-        if scaling_factors[i] and pairs:
-            for pair in pairs:
+    pairs_dict = generate_pairs_lists(top)
+    for i, pair_type in enumerate(pairs_dict):
+        if scaling_factors[i] and pairs_dict[pair_type]:
+            for pair in pairs_dict[pair_type]:
                 pair_name = "-".join(
-                    [pair[0].atom_type.name, pair[1].atom_type.name]
+                    sorted([pair[0].atom_type.name, pair[1].atom_type.name])
                 )
                 special_coulombic.params[pair_name] = dict(
                     alpha=scaling_factors[i]
@@ -855,9 +858,10 @@ def _parse_lj(top, atypes, combining_rule, r_cut, nlist, scaling_factors):
     # and handle molecule scaling factors
     special_lj = hoomd.md.special_pair.LJ()
 
-    for i, pairs in enumerate(_generate_pairs_list(top)):
-        if scaling_factors[i] and pairs:
-            for pair in pairs:
+    pairs_dict = generate_pairs_lists(top)
+    for i, pair_type in enumerate(pairs_dict):
+        if scaling_factors[i] and pairs_dict[pair_type]:
+            for pair in pairs_dict[pair_type]:
                 if pair[0].atom_type in atypes and pair[1].atom_type in atypes:
                     adjscale = scaling_factors[i]
                     pair.sort(key=lambda site: site.atom_type.name)
@@ -1403,35 +1407,3 @@ def _convert_params_units(
         potential.parameters = converted_params
         converted_potentials.append(potential)
     return converted_potentials
-
-
-def _generate_pairs_list(top):
-    """Return a list of pairs that have non-zero scaling factor."""
-    nb_scalings, coulombic_scalings = top.scaling_factors
-
-    pairs12 = list()
-    if nb_scalings[0] or coulombic_scalings[0]:
-        for bond in top.bonds:
-            pairs12.append(sorted(bond.connection_members))
-
-    pairs13 = list()
-    if nb_scalings[1] or coulombic_scalings[1]:
-        for angle in top.angles:
-            pairs13.append(
-                sorted(
-                    [angle.connection_members[0], angle.connection_members[2]]
-                )
-            )
-
-    pairs14 = list()
-    if nb_scalings[2] or coulombic_scalings[2]:
-        for dihedral in top.dihedrals:
-            pairs14.append(
-                sorted(
-                    [
-                        dihedral.connection_members[0],
-                        dihedral.connection_members[-1],
-                    ]
-                )
-            )
-    return pairs12, pairs13, pairs14

--- a/gmso/formats/top.py
+++ b/gmso/formats/top.py
@@ -19,7 +19,7 @@ from gmso.parameterization.molecule_utils import (
     molecule_impropers,
 )
 from gmso.utils.compatibility import check_compatibility
-from gmso.utils.connectivity import generate_pairs_list
+from gmso.utils.connectivity import generate_pairs_lists
 
 
 @saves_as(".top")

--- a/gmso/formats/top.py
+++ b/gmso/formats/top.py
@@ -323,9 +323,9 @@ def _get_unique_molecules(top):
         unique_molecules[top.name] = dict()
         unique_molecules[top.name]["subtags"] = [top.name]
         unique_molecules[top.name]["sites"] = list(top.sites)
-        unique_molecules[top.name]["pairs"] = generate_pairs_lists(top)[
-            "pairs14"
-        ]
+        unique_molecules[top.name]["pairs"] = generate_pairs_lists(
+            top, refer_from_scaling_factor=True
+        )["pairs14"]
         unique_molecules[top.name]["bonds"] = list(top.bonds)
         unique_molecules[top.name]["bond_restraints"] = list(
             bond for bond in top.bonds if bond.restraint

--- a/gmso/formats/top.py
+++ b/gmso/formats/top.py
@@ -3,7 +3,6 @@ import datetime
 import warnings
 
 import unyt as u
-from networkx.algorithms import shortest_path_length
 
 from gmso.core.dihedral import Dihedral
 from gmso.core.element import element_by_atom_type
@@ -20,6 +19,7 @@ from gmso.parameterization.molecule_utils import (
     molecule_impropers,
 )
 from gmso.utils.compatibility import check_compatibility
+from gmso.utils.connectivity import generate_pairs_list
 
 
 @saves_as(".top")
@@ -323,7 +323,9 @@ def _get_unique_molecules(top):
         unique_molecules[top.name] = dict()
         unique_molecules[top.name]["subtags"] = [top.name]
         unique_molecules[top.name]["sites"] = list(top.sites)
-        unique_molecules[top.name]["pairs"] = _generate_pairs_list(top)
+        unique_molecules[top.name]["pairs"] = generate_pairs_lists(top)[
+            "pairs14"
+        ]
         unique_molecules[top.name]["bonds"] = list(top.bonds)
         unique_molecules[top.name]["bond_restraints"] = list(
             bond for bond in top.bonds if bond.restraint
@@ -344,7 +346,9 @@ def _get_unique_molecules(top):
             unique_molecules[tag]["sites"] = list(
                 top.iter_sites(key="molecule", value=molecule)
             )
-            unique_molecules[tag]["pairs"] = _generate_pairs_list(top, molecule)
+            unique_molecules[tag]["pairs"] = generate_pairs_lists(
+                top, molecule
+            )["pairs14"]
             unique_molecules[tag]["bonds"] = list(molecule_bonds(top, molecule))
             unique_molecules[tag]["bond_restraints"] = list(
                 bond for bond in molecule_bonds(top, molecule) if bond.restraint
@@ -387,63 +391,6 @@ def _lookup_element_symbol(atom_type):
         return element.symbol
     except GMSOError:
         return "X"
-
-
-def _generate_pairs_list(top, molecule=None):
-    """Worker function to generate all 1-4 pairs from the topology."""
-    # TODO: Need to make this to be independent from top.dihedrals
-    # https://github.com/ParmEd/ParmEd/blob/master/parmed/structure.py#L2730-L2785
-    # NOTE: This will only write out pairs corresponding to existing dihedrals
-    # depending on needs, a different routine (suggested here) may be used
-    # to get 1-4 pairs independent of top.dihedrals, however, this route may
-    # pose some issue with generate pairs list of molecule/subtopologys
-    # NOTE: This function could be moved out to gmso.utils at some point
-    """
-    if top.dihedrals:
-        # Grab dihedrals if it is available
-        dihedrals = top.dihedrals
-    else:
-        # Else, parse from graph
-        import networkx as nx
-        from gmso.utils.connectivity import _detect_connections
-
-        graph = nx.Graph()
-        for bond in top.bonds:
-            graph = graph.add_edge(b.connection_meners[0], b.connection_members[1])
-
-        line_graph = nx.line_graph(graph)
-
-        dihedral_matches = _detect_connections(line_graph, top, type_="dihedral")
-
-    pairs_list = list()
-    for dihedral in top.dihedrals:
-            pairs = sorted(
-                [dihedral.connection_members[0], dihedral.connection_members[-1]]
-            )
-        if pairs not in pairs_list:
-            pairs_list.append(pairs)
-    """
-
-    pairs_list = list()
-    graph = to_networkx(top, parse_angles=False, parse_dihedrals=False)
-
-    dihedrals = molecule_dihedrals(top, molecule) if molecule else top.dihedrals
-    for dihedral in dihedrals:
-        pairs = (
-            dihedral.connection_members[0],
-            dihedral.connection_members[-1],
-        )
-        pairs = sorted(pairs, key=lambda site: top.get_index(site))
-        if shortest_path_length(graph, pairs[0], pairs[1]) < 3:
-            continue
-        if pairs not in pairs_list:
-            pairs_list.append(pairs)
-
-    # TODO: Also write out special 1-4 pairs (topology.pairpotential_types)
-    return sorted(
-        pairs_list,
-        key=lambda pair: (top.get_index(pair[0]), top.get_index(pair[1])),
-    )
 
 
 def _write_pairs(top, pair, shifted_idx_map):

--- a/gmso/tests/files/restrained_benzene_ua.top
+++ b/gmso/tests/files/restrained_benzene_ua.top
@@ -1,4 +1,4 @@
-; File Topology written by GMSO at 2023-04-21 15:14:09.248301
+; File Topology written by GMSO at 2023-05-04 17:01:43.396827
 
 [ defaults ]
 ; nbfunc	comb-rule	gen-pairs	fudgeLJ		fudgeQQ

--- a/gmso/tests/test_connectivity.py
+++ b/gmso/tests/test_connectivity.py
@@ -1,10 +1,12 @@
+import mbuild as mb
 import pytest
 
 from gmso.core.atom import Atom
 from gmso.core.bond import Bond
 from gmso.core.topology import Topology
+from gmso.external import from_mbuild
 from gmso.tests.base_test import BaseTest
-from gmso.utils.connectivity import identify_connections
+from gmso.utils.connectivity import generate_pairs_lists, identify_connections
 
 
 class TestConnectivity(BaseTest):
@@ -167,3 +169,43 @@ class TestConnectivity(BaseTest):
                 idx_tuple[0] == members_tuple[0]
                 for members_tuple in indices["impropers"]
             )
+
+    def test_generate_pairs_list(self):
+        # Methane with no 1-4 pair
+        methane = mb.load("C", smiles=True)
+        methane_top = from_mbuild(methane)
+        methane_top.identify_connections()
+        methane_pairs = generate_pairs_lists(
+            methane_top, refer_from_scaling_factor=False
+        )
+        assert len(methane_pairs["pairs14"]) == len(methane_top.dihedrals) == 0
+
+        # Ethane with 9 1-4 pairs
+        ethane = mb.load("CC", smiles=True)
+        ethane_top = from_mbuild(ethane)
+        ethane_top.identify_connections()
+        ethane_pairs = generate_pairs_lists(
+            ethane_top, refer_from_scaling_factor=False
+        )
+        assert len(ethane_pairs["pairs14"]) == len(ethane_top.dihedrals) == 9
+
+        # Cyclobutadiene with 16 dihedrals and 8 pairs (due to cyclic structure)
+        cyclobutadiene = mb.load("C1=CC=C1", smiles=True)
+        cyclobutadiene_top = from_mbuild(cyclobutadiene)
+        cyclobutadiene_top.identify_connections()
+        cyclobutadiene_top_pairs = generate_pairs_lists(
+            cyclobutadiene_top, refer_from_scaling_factor=False
+        )
+        assert len(cyclobutadiene_top.dihedrals) == 16
+        assert len(cyclobutadiene_top_pairs["pairs14"]) == 8
+
+        # Cyclopentane with 45 dihedrals and 40 pairs (due to cyclic structure)
+        cyclopentane = mb.load("C1CCCC1", smiles=True)
+        cyclopentane_top = from_mbuild(cyclopentane)
+        cyclopentane_top.identify_connections()
+        cyclopentane_top_pairs = generate_pairs_lists(
+            cyclopentane_top, refer_from_scaling_factor=False
+        )
+
+        assert len(cyclopentane_top.dihedrals) == 45
+        assert len(cyclopentane_top_pairs["pairs14"]) == 40

--- a/gmso/tests/test_top.py
+++ b/gmso/tests/test_top.py
@@ -220,35 +220,3 @@ class TestTop(BaseTest):
 
             else:
                 assert sections[section] == ref_sections[ref_section]
-
-    # def test_generate_pairs_list(self):
-    #     # Methane with no 1-4 pair
-    #     methane = mb.load("C", smiles=True)
-    #     methane_top = from_mbuild(methane)
-    #     methane_top.identify_connections()
-    #     methane_pairs = _generate_pairs_list(methane_top)
-    #     assert len(methane_pairs) == len(methane_top.dihedrals) == 0
-
-    #     # Ethane with 9 1-4 pairs
-    #     ethane = mb.load("CC", smiles=True)
-    #     ethane_top = from_mbuild(ethane)
-    #     ethane_top.identify_connections()
-    #     ethane_pairs = _generate_pairs_list(ethane_top)
-    #     assert len(ethane_pairs) == len(ethane_top.dihedrals) == 9
-
-    #     # Cyclobutadiene with 16 dihedrals and 8 pairs (due to cyclic structure)
-    #     cyclobutadiene = mb.load("C1=CC=C1", smiles=True)
-    #     cyclobutadiene_top = from_mbuild(cyclobutadiene)
-    #     cyclobutadiene_top.identify_connections()
-    #     cyclobutadiene_top_pairs = _generate_pairs_list(cyclobutadiene_top)
-    #     assert len(cyclobutadiene_top.dihedrals) == 16
-    #     assert len(cyclobutadiene_top_pairs) == 8
-
-    #     # Cyclopentane with 45 dihedrals and 40 pairs (due to cyclic structure)
-    #     cyclopentane = mb.load("C1CCCC1", smiles=True)
-    #     cyclopentane_top = from_mbuild(cyclopentane)
-    #     cyclopentane_top.identify_connections()
-    #     cyclopentane_top_pairs = _generate_pairs_list(cyclopentane_top)
-
-    #     assert len(cyclopentane_top.dihedrals) == 45
-    #     assert len(cyclopentane_top_pairs) == 40

--- a/gmso/tests/test_top.py
+++ b/gmso/tests/test_top.py
@@ -6,7 +6,6 @@ import unyt as u
 import gmso
 from gmso.exceptions import EngineIncompatibilityError
 from gmso.external.convert_mbuild import from_mbuild
-from gmso.formats.top import write_top
 from gmso.parameterization import apply
 from gmso.tests.base_test import BaseTest
 from gmso.tests.utils import get_path

--- a/gmso/tests/test_top.py
+++ b/gmso/tests/test_top.py
@@ -202,7 +202,6 @@ class TestTop(BaseTest):
             if "dihedral" in section:
                 # Need to deal with these separatelt due to member's order issue
                 # Each dict will have the keys be members and values be their parameters
-                print(section)
                 members = dict()
                 ref_members = dict()
                 for line, ref in zip(

--- a/gmso/tests/test_top.py
+++ b/gmso/tests/test_top.py
@@ -6,7 +6,7 @@ import unyt as u
 import gmso
 from gmso.exceptions import EngineIncompatibilityError
 from gmso.external.convert_mbuild import from_mbuild
-from gmso.formats.top import _generate_pairs_list, write_top
+from gmso.formats.top import write_top
 from gmso.parameterization import apply
 from gmso.tests.base_test import BaseTest
 from gmso.tests.utils import get_path
@@ -222,34 +222,34 @@ class TestTop(BaseTest):
             else:
                 assert sections[section] == ref_sections[ref_section]
 
-    def test_generate_pairs_list(self):
-        # Methane with no 1-4 pair
-        methane = mb.load("C", smiles=True)
-        methane_top = from_mbuild(methane)
-        methane_top.identify_connections()
-        methane_pairs = _generate_pairs_list(methane_top)
-        assert len(methane_pairs) == len(methane_top.dihedrals) == 0
+    # def test_generate_pairs_list(self):
+    #     # Methane with no 1-4 pair
+    #     methane = mb.load("C", smiles=True)
+    #     methane_top = from_mbuild(methane)
+    #     methane_top.identify_connections()
+    #     methane_pairs = _generate_pairs_list(methane_top)
+    #     assert len(methane_pairs) == len(methane_top.dihedrals) == 0
 
-        # Ethane with 9 1-4 pairs
-        ethane = mb.load("CC", smiles=True)
-        ethane_top = from_mbuild(ethane)
-        ethane_top.identify_connections()
-        ethane_pairs = _generate_pairs_list(ethane_top)
-        assert len(ethane_pairs) == len(ethane_top.dihedrals) == 9
+    #     # Ethane with 9 1-4 pairs
+    #     ethane = mb.load("CC", smiles=True)
+    #     ethane_top = from_mbuild(ethane)
+    #     ethane_top.identify_connections()
+    #     ethane_pairs = _generate_pairs_list(ethane_top)
+    #     assert len(ethane_pairs) == len(ethane_top.dihedrals) == 9
 
-        # Cyclobutadiene with 16 dihedrals and 8 pairs (due to cyclic structure)
-        cyclobutadiene = mb.load("C1=CC=C1", smiles=True)
-        cyclobutadiene_top = from_mbuild(cyclobutadiene)
-        cyclobutadiene_top.identify_connections()
-        cyclobutadiene_top_pairs = _generate_pairs_list(cyclobutadiene_top)
-        assert len(cyclobutadiene_top.dihedrals) == 16
-        assert len(cyclobutadiene_top_pairs) == 8
+    #     # Cyclobutadiene with 16 dihedrals and 8 pairs (due to cyclic structure)
+    #     cyclobutadiene = mb.load("C1=CC=C1", smiles=True)
+    #     cyclobutadiene_top = from_mbuild(cyclobutadiene)
+    #     cyclobutadiene_top.identify_connections()
+    #     cyclobutadiene_top_pairs = _generate_pairs_list(cyclobutadiene_top)
+    #     assert len(cyclobutadiene_top.dihedrals) == 16
+    #     assert len(cyclobutadiene_top_pairs) == 8
 
-        # Cyclopentane with 45 dihedrals and 40 pairs (due to cyclic structure)
-        cyclopentane = mb.load("C1CCCC1", smiles=True)
-        cyclopentane_top = from_mbuild(cyclopentane)
-        cyclopentane_top.identify_connections()
-        cyclopentane_top_pairs = _generate_pairs_list(cyclopentane_top)
+    #     # Cyclopentane with 45 dihedrals and 40 pairs (due to cyclic structure)
+    #     cyclopentane = mb.load("C1CCCC1", smiles=True)
+    #     cyclopentane_top = from_mbuild(cyclopentane)
+    #     cyclopentane_top.identify_connections()
+    #     cyclopentane_top_pairs = _generate_pairs_list(cyclopentane_top)
 
-        assert len(cyclopentane_top.dihedrals) == 45
-        assert len(cyclopentane_top_pairs) == 40
+    #     assert len(cyclopentane_top.dihedrals) == 45
+    #     assert len(cyclopentane_top_pairs) == 40

--- a/gmso/utils/connectivity.py
+++ b/gmso/utils/connectivity.py
@@ -306,9 +306,9 @@ def generate_pairs_lists(
         {"pairs12": pairs12, "pairs13": pairs13, "pairs14": pairs14}
 
     NOTE: This method assume that the topology has already been loaded with
-    angles and dihedrals (through top.identify_connections). In addition,
-    this method will only generate pairs when the corresponding sclaing
-    factor is not 0.
+    angles and dihedrals (through top.identify_connections()). In addition,
+    if the refer_from_scaling_factor is True, this method will only generate
+    pairs when the corresponding scaling factor is not 0.
     """
     from gmso.external import to_networkx
     from gmso.parameterization.molecule_utils import (


### PR DESCRIPTION
Current, there are two `generate_pairs_lists` (used to generate 1-2, 1-3, 1-4 pairs) in 2 separate places (`hoomd` converter and `top` writer) doing the same job. This PR combine the two and move it to `utils/connectivity.py` to reduce code redundancy and make testing easier. 