### PR TITLE
Fix geometric mean error in HOOMD forcefield

### DIFF
--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -4,7 +4,6 @@ from __future__ import division
 import itertools
 import json
 import re
-import statistics
 import warnings
 
 import numpy as np
@@ -834,17 +833,13 @@ def _parse_lj(top, atypes, combining_rule, r_cut, nlist, scaling_factors):
         pairs = list(pairs)
         pairs.sort(key=lambda atype: atype.name)
         type_name = (pairs[0].name, pairs[1].name)
-        comb_epsilon = statistics.geometric_mean(
-            [pairs[0].parameters["epsilon"], pairs[1].parameters["epsilon"]]
-        )
+        comb_epsilon = np.sqrt(pairs[0].parameters["epsilon"].value * pairs[1].parameters["epsilon"].value)
         if top.combining_rule == "lorentz":
             comb_sigma = np.mean(
                 [pairs[0].parameters["sigma"], pairs[1].parameters["sigma"]]
             )
         elif top.combining_rule == "geometric":
-            comb_sigma = statistics.geometric_mean(
-                [pairs[0].parameters["sigma"], pairs[1].parameters["sigma"]]
-            )
+            comb_sigma = np.sqrt(pairs[0].parameters["sigma"].value * pairs[1].parameters["sigma"].value)
         else:
             raise ValueError(
                 f"Invalid combining rule provided ({combining_rule})"

--- a/gmso/tests/files/ethane_zero_parameter.xml
+++ b/gmso/tests/files/ethane_zero_parameter.xml
@@ -1,0 +1,24 @@
+<ForceField name="Forcefield" version="0.0.1" combining_rule="geometric">
+    <AtomTypes>
+        <Type name="opls_135" class="CT" element="C" mass="12.01078" def="[C;X4](C)(H)(H)H" desc="alkane CH3"
+              doi="10.1021/ja9621760" overrides=""/>
+        <Type name="opls_140" class="HC" element="H" mass="1.007947" def="H[C;X4]" desc="alkane H"
+              doi="10.1021/ja9621760" overrides=""/>
+    </AtomTypes>
+    <NonbondedForce coulomb14scale="0.5" lj14scale="0.5">
+        <Atom type="opls_135" charge="-0.18" sigma="0.0" epsilon="0.0"/>
+        <Atom type="opls_140" charge="0.06" sigma="0.25" epsilon="0.12552"/>
+    </NonbondedForce>
+    <HarmonicBondForce>
+        <Bond class1="CT" class2="CT" length="0.1529" k="224262.4"/>
+        <Bond class1="CT" class2="HC" length="0.109" k="284512.0"/>
+    </HarmonicBondForce>
+    <HarmonicAngleForce>
+        <Angle class1="CT" class2="CT" class3="HC" angle="1.932079482" k="313.8"/>
+        <Angle class1="HC" class2="CT" class3="HC" angle="1.8814649337" k="276.144"/>
+    </HarmonicAngleForce>
+    <RBTorsionForce>
+        <Proper class1="HC" class2="CT" class3="CT" class4="HC" c0="0.6276" c1="1.8828" c2="0.0" c3="-2.5104" c4="0.0"
+                c5="0.0"/>
+    </RBTorsionForce>
+</ForceField>

--- a/gmso/tests/test_hoomd.py
+++ b/gmso/tests/test_hoomd.py
@@ -12,7 +12,6 @@ from gmso.tests.base_test import BaseTest
 from gmso.tests.utils import get_path
 from gmso.utils.io import has_hoomd, has_mbuild, import_
 
-
 if has_hoomd:
     hoomd = import_("hoomd")
 if has_mbuild:

--- a/gmso/tests/test_hoomd.py
+++ b/gmso/tests/test_hoomd.py
@@ -9,7 +9,9 @@ from gmso.external import from_mbuild
 from gmso.external.convert_hoomd import to_hoomd_forcefield, to_hoomd_snapshot
 from gmso.parameterization import apply
 from gmso.tests.base_test import BaseTest
+from gmso.tests.utils import get_path
 from gmso.utils.io import has_hoomd, has_mbuild, import_
+
 
 if has_hoomd:
     hoomd = import_("hoomd")
@@ -245,3 +247,34 @@ class TestGsd(BaseTest):
             r_cut=1.4,
             pppm_kwargs={"resolution": (64, 64, 64), "order": 7},
         )
+
+    def test_ff_zero_parameter(self):
+        ethane = mb.lib.molecules.Ethane()
+        top = from_mbuild(ethane)
+        top.identify_connections()
+        ff_zero_param = ffutils.FoyerFFs().load(get_path("ethane_zero_parameter.xml")).to_gmso_ff()
+        top = apply(top, ff_zero_param, remove_untyped=True)
+        base_units = {
+            "mass": u.g / u.mol,
+            "length": u.nm,
+            "energy": u.kJ / u.mol,
+        }
+        gmso_forces, forces_base_units = to_hoomd_forcefield(
+            top,
+            r_cut=1.4,
+            base_units=base_units,
+            pppm_kwargs={"resolution": (64, 64, 64), "order": 7},
+        )
+        integrator_forces = list()
+        for cat in gmso_forces:
+            for force in gmso_forces[cat]:
+                integrator_forces.append(force)
+        for force in integrator_forces:
+            if isinstance(force, hoomd.md.pair.LJ):
+                keys = force.params.param_dict.keys()
+                for key in keys:
+                    if 'opls_135' in list(key):
+                        params = force.params.param_dict[key]
+                        variables = params.keys()
+                        for var in variables:
+                            assert params[var] == 0.0


### PR DESCRIPTION
This PR fixes the error raised by `statistics.geometric_mean()` when sigma or epsilon parameters are zero. Statistics package uses the [logscale](https://en.wikipedia.org/wiki/Geometric_mean) equation to calculate geometric mean but that only works for non-zero positive values, because ln(0) is undefined. 
This PR uses the non logarithmic equation for calculating the geometric mean. 