### PR TITLE
Small fix to mass in convert_parmed

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -15,7 +15,7 @@ dependencies:
   - openbabel>=3.0.0
   - foyer>=0.11.3
   - forcefield-utilities>=0.2.1
-  - gsd>=2.0
+  - gsd>2.0,<3.0
   - parmed>=3.4.3
   - pytest-cov
   - codecov

--- a/gmso/external/convert_parmed.py
+++ b/gmso/external/convert_parmed.py
@@ -556,6 +556,7 @@ def _atom_types_from_gmso(top, structure, atom_map):
         atype_charge = float(atom_type.charge.to("Coulomb").value) / (
             1.6 * 10 ** (-19)
         )
+        atype_mass = float(atom_type.mass.to("amu"))
         atype_sigma = float(atom_type.parameters["sigma"].to("angstrom").value)
         atype_epsilon = float(
             atom_type.parameters["epsilon"].to("kcal/mol").value
@@ -566,7 +567,7 @@ def _atom_types_from_gmso(top, structure, atom_map):
         atype = pmd.AtomType(
             atype_name,
             None,
-            atype_element.mass,
+            atype_mass,
             atype_element.atomic_number,
             atype_charge,
         )


### PR DESCRIPTION
I ran into an error when using `to_parmed` and `from_parmed` on a typed gmso topology.  I think there was just a small over-sight on preparing the `site.mass` value by converting it to amu units and type `float` which is what was already being done for sigma, charge, etc..

Here is the snippet that gives an error. It results from calling `round` on a unyt quantity with value and units

```
import forcefield_utilities as ffutils
import gmso
from gmso.external import to_parmed, from_parmed, from_mbuild
from gmso.parameterization import apply
import mbuild as mb

methane_box = mb.fill_box(compound=[mb.load("C", smiles=True)], n_compounds=5, box=[2,2,2])
gmso_top = from_mbuild(methane_box)
oplsaa = ffutils.FoyerFFs().load('oplsaa').to_gmso_ff()
apply(top=gmso_top, forcefields=oplsaa, identify_connections=True)
pmd_struc = to_parmed(gmso_top)
back_to_gmso = from_parmed(pmd_struc)
```

Error:
```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[18], line 12
     10 apply(top=gmso_top, forcefields=oplsaa, identify_connections=True)
     11 pmd_struc = to_parmed(gmso_top)
---> 12 back_to_gmso = from_parmed(pmd_struc)

File ~/gmso/gmso/external/convert_parmed.py:60, in from_parmed(structure, refer_type)
     58 # Consolidate parmed atomtypes and relate topology atomtypes
     59 if refer_type:
---> 60     pmd_top_atomtypes = _atom_types_from_pmd(structure)
     62 ind_res = _check_independent_residues(structure)
     63 for residue in structure.residues:

File ~/gmso/gmso/external/convert_parmed.py:287, in _atom_types_from_pmd(structure)
    285 for atom in structure.atoms:
    286     if isinstance(atom.atom_type, pmd.AtomType):
--> 287         unique_atom_types.add(atom.atom_type)
    288 unique_atom_types = list(unique_atom_types)
    289 pmd_top_atomtypes = {}

File ~/mambaforge/envs/hoomd-polymers/lib/python3.9/site-packages/parmed/topologyobjects.py:5312, in AtomType.__hash__(self)
   5311 def __hash__(self):
-> 5312     return hash((self.name, self._round_trunc(self.mass), self.atomic_number, self.bond_type,
   5313                  self._round_trunc(self.charge), self._round_trunc(self.epsilon),
   5314                  self._round_trunc(self.rmin), self._round_trunc(self.epsilon_14),
   5315                  self._round_trunc(self.rmin_14), tuple(self.nbfix.items())))

File ~/mambaforge/envs/hoomd-polymers/lib/python3.9/site-packages/parmed/topologyobjects.py:5319, in AtomType._round_trunc(cls, value)
   5317 @classmethod
   5318 def _round_trunc(cls, value):
-> 5319     return round(value, _TINY_DIGITS) if value is not None else None

TypeError: __round__() takes 1 positional argument but 2 were given
```