### PR TITLE
Support GSD 3

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -15,7 +15,7 @@ dependencies:
   - openbabel>=3.0.0
   - foyer>=0.11.3
   - forcefield-utilities>=0.2.1
-  - gsd>=2.0
+  - gsd>=2.9
   - parmed>=3.4.3
   - pytest-cov
   - codecov

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.8
-  - numpy
+  - numpy=1.24.2
   - sympy
   - unyt<=2.9.2
   - boltons

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.8
-  - numpy
+  - numpy=1.24.2
   - sympy
   - unyt<=2.9.2
   - boltons

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -201,7 +201,6 @@ def to_hoomd_snapshot(
     read force field parameters from a Foyer XML file.
     """
     base_units = _validate_base_units(base_units, top, auto_scale)
-    
     hoomd_snapshot = hoomd.Snapshot()
 
     # Write box information

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -305,7 +305,7 @@ def _parse_particle_information(
         4.0 * np.pi * e0 * base_units["length"] * base_units["energy"]
     ) ** 0.5
 
-    if isinstance(snapshot, snap_from_hoomd):
+    if isinstance(snapshot, hoomd.Snapshot):
         snapshot.particles.N = top.n_sites
         snapshot.particles.types = unique_types
         snapshot.particles.position[0:] = xyz
@@ -354,7 +354,7 @@ def _parse_pairs_information(
         pair_typeids.append(pair_types.index(pair_type))
         pairs.append((top.get_index(pair[0]), top.get_index(pair[1])))
 
-    if isinstance(snapshot, snap_from_hoomd):
+    if isinstance(snapshot, hoomd.Snapshot):
         snapshot.pairs.N = len(pairs)
         snapshot.pairs.group[:] = np.reshape(pairs, (-1, 2))
         snapshot.pairs.types = pair_types
@@ -401,7 +401,7 @@ def _parse_bond_information(snapshot, top):
     unique_bond_types = list(set(bond_types))
     bond_typeids = [unique_bond_types.index(i) for i in bond_types]
 
-    if isinstance(snapshot, snap_from_hoomd):
+    if isinstance(snapshot, hoomd.Snapshot):
         snapshot.bonds.types = unique_bond_types
         snapshot.bonds.typeid[0:] = bond_typeids
         snapshot.bonds.group[0:] = bond_groups
@@ -448,7 +448,7 @@ def _parse_angle_information(snapshot, top):
     unique_angle_types = list(set(angle_types))
     angle_typeids = [unique_angle_types.index(i) for i in angle_types]
 
-    if isinstance(snapshot, snap_from_hoomd):
+    if isinstance(snapshot, hoomd.Snapshot):
         snapshot.angles.types = unique_angle_types
         snapshot.angles.typeid[0:] = angle_typeids
         snapshot.angles.group[0:] = np.reshape(angle_groups, (-1, 3))
@@ -494,7 +494,7 @@ def _parse_dihedral_information(snapshot, top):
     unique_dihedral_types = list(set(dihedral_types))
     dihedral_typeids = [unique_dihedral_types.index(i) for i in dihedral_types]
 
-    if isinstance(snapshot, snap_from_hoomd):
+    if isinstance(snapshot, hoomd.Snapshot):
         snapshot.dihedrals.types = unique_dihedral_types
         snapshot.dihedrals.typeid[0:] = dihedral_typeids
         snapshot.dihedrals.group[0:] = np.reshape(dihedral_groups, (-1, 4))
@@ -542,7 +542,7 @@ def _parse_improper_information(snapshot, top):
     unique_improper_types = list(set(improper_types))
     improper_typeids = [unique_improper_types.index(i) for i in improper_types]
 
-    if isinstance(snapshot, snap_from_hoomd):
+    if isinstance(snapshot, hoomd.Snapshot):
         snapshot.impropers.types = unique_improper_types
         snapshot.impropers.typeid[0:] = improper_typeids
         snapshot.impropers.group[0:] = np.reshape(improper_groups, (-1, 4))

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -90,7 +90,7 @@ def to_gsd_snapshot(
 
     Return
     ------
-    gsd_snapshot : gsd.hoomd.Snapshot
+    gsd_snapshot : gsd.hoomd.Frame
         Converted hoomd Snapshot.
     base_units : dict
         Based units dictionary utilized during the conversion.
@@ -103,7 +103,7 @@ def to_gsd_snapshot(
     """
     base_units = _validate_base_units(base_units, top, auto_scale)
 
-    gsd_snapshot = gsd.hoomd.Snapshot()
+    gsd_snapshot = gsd.hoomd.Frame()
 
     gsd_snapshot.configuration.step = 0
     gsd_snapshot.configuration.dimensions = 3
@@ -257,7 +257,7 @@ def _parse_particle_information(
 
     Parameters
     ----------
-    snapshot : gsd.hoomd.Snapshot or hoomd.Snapshot
+    snapshot : gsd.hoomd.Frame or hoomd.Snapshot
         The target Snapshot object.
     top : gmso.Topology
         Topology object holding system information.
@@ -313,7 +313,7 @@ def _parse_particle_information(
         snapshot.particles.typeid[0:] = typeids
         snapshot.particles.mass[0:] = masses
         snapshot.particles.charge[0:] = charges / charge_factor
-    elif isinstance(snapshot, gsd.hoomd.Snapshot):
+    elif isinstance(snapshot, gsd.hoomd.Frame):
         snapshot.particles.N = top.n_sites
         snapshot.particles.types = unique_types
         snapshot.particles.position = xyz
@@ -360,7 +360,7 @@ def _parse_pairs_information(
         snapshot.pairs.group[:] = np.reshape(pairs, (-1, 2))
         snapshot.pairs.types = pair_types
         snapshot.pairs.typeid[:] = pair_typeids
-    elif isinstance(snapshot, gsd.hoomd.Snapshot):
+    elif isinstance(snapshot, gsd.hoomd.Frame):
         snapshot.pairs.N = len(pairs)
         snapshot.pairs.group = np.reshape(pairs, (-1, 2))
         snapshot.pairs.types = pair_types
@@ -372,7 +372,7 @@ def _parse_bond_information(snapshot, top):
 
     Parameters
     ----------
-    snapshot : gsd.hoomd.Snapshot or hoomd.Snapshot
+    snapshot : gsd.hoomd.Frame or hoomd.Snapshot
         The target Snapshot object.
     top : gmso.Topology
         Topology object holding system information
@@ -406,7 +406,7 @@ def _parse_bond_information(snapshot, top):
         snapshot.bonds.types = unique_bond_types
         snapshot.bonds.typeid[0:] = bond_typeids
         snapshot.bonds.group[0:] = bond_groups
-    elif isinstance(snapshot, gsd.hoomd.Snapshot):
+    elif isinstance(snapshot, gsd.hoomd.Frame):
         snapshot.bonds.types = unique_bond_types
         snapshot.bonds.typeid = bond_typeids
         snapshot.bonds.group = bond_groups
@@ -419,7 +419,7 @@ def _parse_angle_information(snapshot, top):
 
     Parameters
     ----------
-    snapshot : gsd.hoomd.Snapshot or hoomd.Snapshot
+    snapshot : gsd.hoomd.Frame or hoomd.Snapshot
         The target Snapshot object.
     top : gmso.Topology
         Topology object holding system information
@@ -453,7 +453,7 @@ def _parse_angle_information(snapshot, top):
         snapshot.angles.types = unique_angle_types
         snapshot.angles.typeid[0:] = angle_typeids
         snapshot.angles.group[0:] = np.reshape(angle_groups, (-1, 3))
-    elif isinstance(snapshot, gsd.hoomd.Snapshot):
+    elif isinstance(snapshot, gsd.hoomd.Frame):
         snapshot.angles.types = unique_angle_types
         snapshot.angles.typeid = angle_typeids
         snapshot.angles.group = np.reshape(angle_groups, (-1, 3))
@@ -467,7 +467,7 @@ def _parse_dihedral_information(snapshot, top):
 
     Parameters
     ----------
-    snapshot : gsd.hoomd.Snapshot or hoomd.Snapshot
+    snapshot : gsd.hoomd.Frame or hoomd.Snapshot
         The target Snapshot object.
     top : gmso.Topology
         Topology object holding system information
@@ -499,7 +499,7 @@ def _parse_dihedral_information(snapshot, top):
         snapshot.dihedrals.types = unique_dihedral_types
         snapshot.dihedrals.typeid[0:] = dihedral_typeids
         snapshot.dihedrals.group[0:] = np.reshape(dihedral_groups, (-1, 4))
-    elif isinstance(snapshot, gsd.hoomd.Snapshot):
+    elif isinstance(snapshot, gsd.hoomd.Frame):
         snapshot.dihedrals.types = unique_dihedral_types
         snapshot.dihedrals.typeid = dihedral_typeids
         snapshot.dihedrals.group = np.reshape(dihedral_groups, (-1, 4))
@@ -547,7 +547,7 @@ def _parse_improper_information(snapshot, top):
         snapshot.impropers.types = unique_improper_types
         snapshot.impropers.typeid[0:] = improper_typeids
         snapshot.impropers.group[0:] = np.reshape(improper_groups, (-1, 4))
-    elif isinstance(snapshot, gsd.hoomd.Snapshot):
+    elif isinstance(snapshot, gsd.hoomd.Frame):
         snapshot.impropers.types = unique_improper_types
         snapshot.impropers.typeid = improper_typeids
         snapshot.impropers.group = np.reshape(improper_groups, (-1, 4))

--- a/gmso/formats/gsd.py
+++ b/gmso/formats/gsd.py
@@ -57,5 +57,5 @@ def write_gsd(
         shift_coords=shift_coords,
         parse_special_pairs=write_special_pairs,
     )[0]
-    with gsd.hoomd.open(filename, mode="wb") as gsd_file:
+    with gsd.hoomd.open(filename, mode="w") as gsd_file:
         gsd_file.append(gsd_snapshot)

--- a/gmso/utils/io.py
+++ b/gmso/utils/io.py
@@ -140,7 +140,6 @@ try:
     del gsd
 except ImportError:
     has_gsd = False
-    gsd_major = None
 
 try:
     import hoomd


### PR DESCRIPTION
This PR makes a few changes that supports using GSD 3.0 (#738 ).  I pinned the version to `gsd>=2.9` since the new API was introduced then. 

A couple of things to note:

- hoomd's internal snapshot functionality still uses `Snapshot`
- I decided to keep `snapshot` in most of the variable names we use. If it makes more sense to update these names to use frame as well I can. 

