### PR TITLE
Fix return statement in `_parse_coulombic`

### DIFF
--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -800,7 +800,8 @@ def _parse_coulombic(
     )
     if not charge_groups:
         print("No charged group detected, skipping electrostatics.")
-        return None
+        #return None
+        return []
     else:
         coulombic = hoomd.md.long_range.pppm.make_pppm_coulomb_forces(
             nlist=nlist, resolution=resolution, order=order, r_cut=r_cut

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -800,7 +800,6 @@ def _parse_coulombic(
     )
     if not charge_groups:
         print("No charged group detected, skipping electrostatics.")
-        #return None
         return []
     else:
         coulombic = hoomd.md.long_range.pppm.make_pppm_coulomb_forces(

--- a/gmso/tests/test_hoomd.py
+++ b/gmso/tests/test_hoomd.py
@@ -429,7 +429,8 @@ class TestGsd(BaseTest):
 
         gmso_snapshot, snapshot_base_units = to_hoomd_snapshot(top)
         gmso_forces, forces_base_units = to_hoomd_forcefield(
-                top=top, r_cut=1.4,
+            top=top,
+            r_cut=1.4,
         )
         for cat in gmso_forces:
             for force in gmso_forces[cat]:

--- a/gmso/tests/test_hoomd.py
+++ b/gmso/tests/test_hoomd.py
@@ -410,3 +410,29 @@ class TestGsd(BaseTest):
                         variables = params.keys()
                         for var in variables:
                             assert params[var] == 0.0
+
+    def test_zero_charges(self):
+        compound = mb.load("CC", smiles=True)
+        com_box = mb.packing.fill_box(compound, box=[5, 5, 5], n_compounds=100)
+        base_units = {
+            "mass": u.amu,
+            "length": u.nm,
+            "energy": u.kJ / u.mol,
+        }
+
+        top = from_mbuild(com_box)
+        top.identify_connections()
+        oplsaa = ffutils.FoyerFFs().load("oplsaa").to_gmso_ff()
+        top = apply(top, oplsaa, remove_untyped=True)
+        for site in top.sites:
+            site.charge = 0
+
+        gmso_snapshot, snapshot_base_units = to_hoomd_snapshot(top)
+        gmso_forces, forces_base_units = to_hoomd_forcefield(
+                top=top, r_cut=1.4,
+        )
+        for cat in gmso_forces:
+            for force in gmso_forces[cat]:
+                assert not isinstance(force, hoomd.md.pair.pair.Ewald)
+                assert not isinstance(force, hoomd.md.long_range.pppm.Coulomb)
+                assert not isinstance(force, hoomd.md.special_pair.Coulomb)

--- a/gmso/tests/test_hoomd.py
+++ b/gmso/tests/test_hoomd.py
@@ -413,7 +413,7 @@ class TestGsd(BaseTest):
 
     def test_zero_charges(self):
         compound = mb.load("CC", smiles=True)
-        com_box = mb.packing.fill_box(compound, box=[5, 5, 5], n_compounds=100)
+        com_box = mb.packing.fill_box(compound, box=[5, 5, 5], n_compounds=20)
         base_units = {
             "mass": u.amu,
             "length": u.nm,
@@ -427,7 +427,6 @@ class TestGsd(BaseTest):
         for site in top.sites:
             site.charge = 0
 
-        gmso_snapshot, snapshot_base_units = to_hoomd_snapshot(top)
         gmso_forces, forces_base_units = to_hoomd_forcefield(
             top=top,
             r_cut=1.4,


### PR DESCRIPTION
This is a quick fix I noticed when using `convert_hoomd.py` on a topology with no charges.

`_parse_coulombic()` returns `None` if none of the sites have a charge value. This causes an error since the function is called inside of an `extend` method:

```
 763     nbonded_forces = list()
 764     nbonded_forces.extend(
 765         _parse_coulombic(
 766             top=top,
 767             nlist=nlist,
 768             scaling_factors=coulombic_scalings,
 769             resolution=pppm_kwargs["resolution"],
 770             order=pppm_kwargs["order"],
 771             r_cut=r_cut,
 772         )
```

With lists, passing `None` to `extend()` gives `TypeError: 'NoneType' object is not iterable`

Returning an empty list instead of `None` seems like the simplest fix.  I added a unit test that should have caught this as well.