### PR TITLE
Fix mass type in convert_parmed 

### DIFF
--- a/gmso/external/convert_parmed.py
+++ b/gmso/external/convert_parmed.py
@@ -568,15 +568,14 @@ def _atom_types_from_gmso(top, structure, atom_map):
         atype_charge = float(atom_type.charge.to("Coulomb").value) / (
             1.6 * 10 ** (-19)
         )
-        atype_mass = float(atom_type.mass.to("amu"))
         atype_sigma = float(atom_type.parameters["sigma"].to("angstrom").value)
         atype_epsilon = float(
             atom_type.parameters["epsilon"].to("kcal/mol").value
         )
         if atom_type.mass:
-            atype_mass = atom_type.mass.to("amu").value
+            atype_mass = float(atom_type.mass.to("amu").value)
         else:
-            atype_mass = element_by_symbol(atom_type.name).mass.to("amu").value
+            atype_mass = float(element_by_symbol(atom_type.name).mass.to("amu").value)
         atype_atomic_number = getattr(
             element_by_symbol(atom_type.name), "atomic_number", None
         )

--- a/gmso/external/convert_parmed.py
+++ b/gmso/external/convert_parmed.py
@@ -575,7 +575,9 @@ def _atom_types_from_gmso(top, structure, atom_map):
         if atom_type.mass:
             atype_mass = float(atom_type.mass.to("amu").value)
         else:
-            atype_mass = float(element_by_symbol(atom_type.name).mass.to("amu").value)
+            atype_mass = float(
+                element_by_symbol(atom_type.name).mass.to("amu").value
+            )
         atype_atomic_number = getattr(
             element_by_symbol(atom_type.name), "atomic_number", None
         )

--- a/gmso/tests/test_convert_parmed.py
+++ b/gmso/tests/test_convert_parmed.py
@@ -726,3 +726,19 @@ class TestConvertParmEd(BaseTest):
         assert top.n_angles == top_from_struc.n_angles
         assert top.n_dihedrals == top_from_struc.n_dihedrals
         assert len(top.atom_types) == len(top_from_struc.atom_types)
+
+    def test_to_and_from_parmed_with_impropers_dihedrals(
+        self, typed_methylnitroaniline
+    ):
+        top = typed_methylnitroaniline
+        struc = to_parmed(top)
+        top_from_struc = from_parmed(struc)
+        assert top.n_sites == top_from_struc.n_sites
+        assert top.n_bonds == top_from_struc.n_bonds
+        assert top.n_angles == top_from_struc.n_angles
+        assert top.n_dihedrals == top_from_struc.n_dihedrals
+        assert top.n_impropers == top_from_struc.n_impropers
+        assert len(top.atom_types) == len(top_from_struc.atom_types)
+        assert len(top.dihedral_types(filter_by=pfilter)) == len(
+            top_from_struc.dihedral_types(filter_by=pfilter)
+        )

--- a/gmso/tests/test_convert_parmed.py
+++ b/gmso/tests/test_convert_parmed.py
@@ -716,3 +716,13 @@ class TestConvertParmEd(BaseTest):
                 for t in dihedrals_list
             )
         )
+
+    def test_to_and_from_parmed_with_topology(self, typed_ethane):
+        top = typed_ethane
+        struc = to_parmed(top)
+        top_from_struc = from_parmed(struc)
+        assert top.n_sites == top_from_struc.n_sites
+        assert top.n_bonds == top_from_struc.n_bonds
+        assert top.n_angles == top_from_struc.n_angles
+        assert top.n_dihedrals == top_from_struc.n_dihedrals
+        assert len(top.atom_types) == len(top_from_struc.atom_types)


### PR DESCRIPTION
I found the following error in a test script where a GMSO topology is first converted to a Parmed structure using `to_parmed` and then the same structure is converted back to GMSO topology using `from_parmed`.

Here's the test script:

```python
import forcefield_utilities as ffutils
import gmso
from gmso.external import to_parmed, from_parmed, from_mbuild
from gmso.parameterization import apply
import mbuild as mb

methane_box = mb.fill_box(compound=[mb.load("C", smiles=True)], n_compounds=5, box=[2,2,2])
gmso_top = from_mbuild(methane_box)
oplsaa = ffutils.FoyerFFs().load('oplsaa').to_gmso_ff()
apply(top=gmso_top, forcefields=oplsaa, identify_connections=True)
pmd_struc = to_parmed(gmso_top)
back_to_gmso = from_parmed(pmd_struc)
```

error:

```
  File "/gmso/gmso/external/convert_parmed.py", line 61, in from_parmed
    pmd_top_atomtypes = _atom_types_from_pmd(structure)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/gmso/gmso/external/convert_parmed.py", line 314, in _atom_types_from_pmd
    pmd_top_atomtypes[atom_type] = top_atomtype
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/anaconda3/envs/gmso-dev/lib/python3.11/site-packages/parmed/topologyobjects.py", line 5312, in __hash__
    return hash((self.name, self._round_trunc(self.mass), self.atomic_number, self.bond_type,
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/anaconda3/envs/gmso-dev/lib/python3.11/site-packages/parmed/topologyobjects.py", line 5319, in _round_trunc
    return round(value, _TINY_DIGITS) if value is not None else None
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: type numpy.ndarray doesn't define __round__ method
```

The source of error is the incorrect type of `atype_mass` in `_atom_types_from_gmso` method, which should be float rather than numpy array.