### PR TITLE
Replace `unyt.amu` with `Unit("amu")` to perserve mass values from mBuild

### DIFF
--- a/gmso/external/convert_mbuild.py
+++ b/gmso/external/convert_mbuild.py
@@ -4,6 +4,7 @@ from warnings import warn
 import mbuild as mb
 import numpy as np
 import unyt as u
+from unyt import Unit
 from boltons.setutils import IndexedSet
 
 from gmso.core.atom import Atom
@@ -271,7 +272,8 @@ def _parse_site(site_map, particle, search_method, infer_element=False):
         ele = search_method(particle.name) if infer_element else None
 
     charge = particle.charge * u.elementary_charge if particle.charge else None
-    mass = particle.mass * u.amu if particle.mass else None
+    #mass = particle.mass * u.amu if particle.mass else None
+    mass = particle.mass * Unit('amu') if particle.mass else None
 
     site = Atom(
         name=particle.name,

--- a/gmso/external/convert_mbuild.py
+++ b/gmso/external/convert_mbuild.py
@@ -4,8 +4,8 @@ from warnings import warn
 import mbuild as mb
 import numpy as np
 import unyt as u
-from unyt import Unit
 from boltons.setutils import IndexedSet
+from unyt import Unit
 
 from gmso.core.atom import Atom
 from gmso.core.bond import Bond
@@ -272,7 +272,7 @@ def _parse_site(site_map, particle, search_method, infer_element=False):
         ele = search_method(particle.name) if infer_element else None
 
     charge = particle.charge * u.elementary_charge if particle.charge else None
-    mass = particle.mass * Unit('amu') if particle.mass else None
+    mass = particle.mass * Unit("amu") if particle.mass else None
 
     site = Atom(
         name=particle.name,

--- a/gmso/external/convert_mbuild.py
+++ b/gmso/external/convert_mbuild.py
@@ -272,7 +272,6 @@ def _parse_site(site_map, particle, search_method, infer_element=False):
         ele = search_method(particle.name) if infer_element else None
 
     charge = particle.charge * u.elementary_charge if particle.charge else None
-    #mass = particle.mass * u.amu if particle.mass else None
     mass = particle.mass * Unit('amu') if particle.mass else None
 
     site = Atom(


### PR DESCRIPTION
This is a quick PR that changes how we use amu units from Unyt.  There is some inconsistent behavior with how Unyt handles amu specifically compared to other units. See the issue [here](https://github.com/yt-project/unyt/issues/440)

In `from_mbuild` I believe the goal is to copy over the particle mass as is, but to add on amu units since mBuild uses amu for mass. But, when we do this using `u.amu` we end up converting the mass to kg.  This happens because `u.amu` is already a `unyt_quantity` that is in kg.  In the issue, there is a suggestion to use `Unit('amu')` instead.

Example: You can see `u.amu` does not have the same behavior as `u.g` or `u.g/u.mol`, but `Unit("amu")` does.

```
>>> import unyt as u
>>> from unyt import Unit
>>> u.amu.units
kg
>>> u.amu
unyt_quantity(1.66053892e-27, 'kg')
>>> Unit("amu")
amu
>>> u.g
g
>>> u.g/u.mol
g/mol
```

Here is what the change would look like in gmso. IMO, keeping the mass values the same as they are in mBuild, and actually using units of amu instead of kg is preferable. 

Code snippet:
```
>>> import gmso
>>> import mbuild as mb
>>> from gmso.external import from_mbuild
>>> methane = mb.load("C", smiles=True)
>>> top = from_mbuild(methane)
```

Using `unyt.amu` (current behavior):
```
>>> for p in methane:
...     print(p.mass) 
12.011
1.008
1.008
1.008
1.008

>>> for site in top.sites:
...     print(site.mass)
... 
1.9944732980130996e-26 kg
1.673823232368e-27 kg
1.673823232368e-27 kg
1.673823232368e-27 kg
1.673823232368e-27 kg
```

Using `Unit("amu")`:

```
>>> for p in methane:
...     print(p.mass) 
12.011
1.008
1.008
1.008
1.008

>>> for site in top.sites:
...     print(site.mass)
... 
12.011 amu
1.008 amu
1.008 amu
1.008 amu
1.008 amu
>>> 
```