### PR TITLE
Add functionality to remove sites and connections from a topology

### DIFF
--- a/gmso/abc/abstract_site.py
+++ b/gmso/abc/abstract_site.py
@@ -34,6 +34,7 @@ class Site(GMSOBase):
         "group",
         "molecule",
         "residue",
+        "connections",
     }
 
     __base_doc__: ClassVar[
@@ -51,6 +52,11 @@ class Site(GMSOBase):
     such that a label for a site can then be used to group sites together. The rules for defining a site label
     and their meaning the responsibility of the container where the sites will reside.
     """
+
+    connections_: set = Field(
+        set(),
+        description="Set of connections this site belongs to",
+    )
 
     name_: str = Field(
         "",
@@ -77,6 +83,10 @@ class Site(GMSOBase):
         default_factory=default_position,
         description="The 3D Cartesian coordinates of the position of the site",
     )
+
+    @property
+    def connections(self) -> set:
+        return self.__dict__.get("connections_")
 
     @property
     def name(self) -> str:
@@ -178,6 +188,7 @@ class Site(GMSOBase):
             "group_": "group",
             "molecule_": "molecule",
             "residue_": "residue",
+            "connections_": "connections",
         }
 
         alias_to_fields = {

--- a/gmso/abc/abstract_site.py
+++ b/gmso/abc/abstract_site.py
@@ -34,7 +34,6 @@ class Site(GMSOBase):
         "group",
         "molecule",
         "residue",
-        "connections",
     }
 
     __base_doc__: ClassVar[
@@ -52,11 +51,6 @@ class Site(GMSOBase):
     such that a label for a site can then be used to group sites together. The rules for defining a site label
     and their meaning the responsibility of the container where the sites will reside.
     """
-
-    connections_: set = Field(
-        set(),
-        description="Set of connections this site belongs to",
-    )
 
     name_: str = Field(
         "",
@@ -83,10 +77,6 @@ class Site(GMSOBase):
         default_factory=default_position,
         description="The 3D Cartesian coordinates of the position of the site",
     )
-
-    @property
-    def connections(self) -> set:
-        return self.__dict__.get("connections_")
 
     @property
     def name(self) -> str:
@@ -188,7 +178,6 @@ class Site(GMSOBase):
             "group_": "group",
             "molecule_": "molecule",
             "residue_": "residue",
-            "connections_": "connections",
         }
 
         alias_to_fields = {

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -1433,6 +1433,12 @@ class Topology(object):
             connections = ["bonds", "angles", "dihedrals", "impropers"]
         else:
             connections = set([option.lower() for option in connections])
+            for option in connections:
+                if option not in ["bonds", "angles", "dihedrals", "impropers"]:
+                    raise ValueError(
+                        "Valid connection types are limited to: "
+                        '"bonds", "angles", "dihedrals", "impropers"'
+                    )
         for conn_str in connections:
             for conn in getattr(self, conn_str):
                 if site in conn.connection_members:

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -672,6 +672,11 @@ class Topology(object):
     def remove_connection(self, connection):
         """Remove a connection from the topology.
 
+        Parameters
+        ----------
+        connection : gmso.abc.abstract_conneciton.Connection
+            The connection to be removed from the topology
+
         Notes
         -----
         The sites that belong to this connection are

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -630,18 +630,6 @@ class Topology(object):
             set([ptype.expression for ptype in self._pairpotential_types])
         )
 
-    def get_connections_by_site(self, site, connections=None):
-        """ """
-        if connections is None:
-            connections = ["bonds", "angles", "dihedrals", "impropers"]
-        connection_dict = dict()
-        for conn_str in connections:
-            connection_dict[conn_str] = []
-            for conn in getattr(self, conn_str):
-                if site in conn.connection_members:
-                    connection_dict[conn_str].append(conn)
-        return connection_dict
-
     def get_lj_scale(self, *, molecule_id=None, interaction=None):
         """Return the selected lj_scales defined for this topology."""
         return self._get_scaling_factor(molecule_id, interaction, "lj_scale", 0)
@@ -661,6 +649,8 @@ class Topology(object):
 
     def remove_site(self, site):
         """"""
+        for connection in self.iter_connections_by_site(site):
+            self.remove_connection(connection)
         self._sites.remove(site)
 
     def remove_connection(self, connection):
@@ -1392,6 +1382,15 @@ class Topology(object):
                     yield site
         else:
             return self.iter_sites("molecule", molecule_tag)
+
+    def iter_connections_by_site(self, site, connections=None):
+        """"""
+        if connections is None:
+            connections = ["bonds", "angles", "dihedrals", "impropers"]
+        for conn_str in connections:
+            for conn in getattr(self, conn_str):
+                if site in conn.connection_members:
+                    yield conn
 
     def create_subtop(self, label_type, label):
         """Create a new Topology object from a molecule or graup of the current Topology.

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -665,6 +665,10 @@ class Topology(object):
         gmso.core.topology.Topology.iter_connections_by_site
             The method that shows all connections belonging to a specific site
         """
+        if site not in self._sites:
+            raise ValueError(
+                f"Site {site} is not currently part of this topology."
+            )
         for connection in self.iter_connections_by_site(site):
             self.remove_connection(connection)
         self._sites.remove(site)
@@ -682,6 +686,10 @@ class Topology(object):
         The sites that belong to this connection are
         not removed from the topology.
         """
+        if connection not in self.connections:
+            raise ValueError(
+                f"Connection {connection} is not currently part of this topology."
+            )
         if isinstance(connection, gmso.core.bond.Bond):
             self._bonds.remove(connection)
         elif isinstance(connection, gmso.core.angle.Angle):

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -1412,7 +1412,7 @@ class Topology(object):
         Parameters
         ----------
         site : gmso.core.Site
-            Site to limit connections search to. 
+            Site to limit connections search to.
         connections : set or list or tuple, optional, default=None
             The connection types to include in the search.
             If None, iterates through all of a site's connections.

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -647,6 +647,26 @@ class Topology(object):
             ]
         )
 
+    def remove_site(self, site):
+        """"""
+        for connection in site.connections:
+            try:
+                self.remove_connection(connection)
+            except KeyError:
+                pass
+        self._sites.remove(site)
+
+    def remove_connection(self, connection):
+        """"""
+        if isinstance(connection, gmso.core.bond.Bond):
+            self._bonds.remove(connection)
+        elif isinstance(connection, gmso.core.angle.Angle):
+            self._angles.remove(connection)
+        elif isinstance(connection, gmso.core.dihedral.Dihedral):
+            self._dihedrals.remove(connection)
+        elif isinstance(connection, gmso.core.improper.Improper):
+            self._impropers.remove(connection)
+
     def set_scaling_factors(self, lj, electrostatics, *, molecule_id=None):
         """Set both lj and electrostatics scaling factors."""
         self.set_lj_scale(

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -1437,6 +1437,10 @@ class Topology(object):
             Connection where site is in Connection.connection_members
 
         """
+        if site not in self._sites:
+            raise ValueError(
+                f"Site {site} is not currently part of this topology."
+            )
         if connections is None:
             connections = ["bonds", "angles", "dihedrals", "impropers"]
         else:

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -648,13 +648,35 @@ class Topology(object):
         )
 
     def remove_site(self, site):
-        """"""
+        """Remove a site from the topology.
+
+        Parameters
+        ----------
+        site : gmso.core.Site
+            The site to be removed.
+
+        Notes
+        -----
+        When a site is removed, any connections that site belonged
+        to are also removed.
+
+        See Also
+        --------
+        gmso.core.topology.Topology.iter_connections_by_site
+            The method that shows all connections belonging to a specific site
+        """
         for connection in self.iter_connections_by_site(site):
             self.remove_connection(connection)
         self._sites.remove(site)
 
     def remove_connection(self, connection):
-        """"""
+        """Remove a connection from the topology.
+
+        Notes
+        -----
+        The sites that belong to this connection are
+        not removed from the topology.
+        """
         if isinstance(connection, gmso.core.bond.Bond):
             self._bonds.remove(connection)
         elif isinstance(connection, gmso.core.angle.Angle):
@@ -1384,9 +1406,28 @@ class Topology(object):
             return self.iter_sites("molecule", molecule_tag)
 
     def iter_connections_by_site(self, site, connections=None):
-        """"""
+        """Iterate through this topology's connections which contain
+        this specific site.
+
+        Parameters
+        ----------
+        site : gmso.core.Site
+            Site to limit connections search to. 
+        connections : set or list or tuple, optional, default=None
+            The connection types to include in the search.
+            If None, iterates through all of a site's connections.
+            Options include "bonds", "angles", "dihedrals", "impropers"
+
+        Yields
+        ------
+        gmso.abc.abstract_conneciton.Connection
+            Connection where site is in Connection.connection_members
+
+        """
         if connections is None:
             connections = ["bonds", "angles", "dihedrals", "impropers"]
+        else:
+            connections = set([option.lower() for option in connections])
         for conn_str in connections:
             for conn in getattr(self, conn_str):
                 if site in conn.connection_members:

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -630,6 +630,18 @@ class Topology(object):
             set([ptype.expression for ptype in self._pairpotential_types])
         )
 
+    def get_connections_by_site(self, site, connections=None):
+        """ """
+        if connections is None:
+            connections = ["bonds", "angles", "dihedrals", "impropers"]
+        connection_dict = dict()
+        for conn_str in connections:
+            connection_dict[conn_str] = []
+            for conn in getattr(self, conn_str):
+                if site in conn.connection_members:
+                    connection_dict[conn_str].append(conn)
+        return connection_dict
+
     def get_lj_scale(self, *, molecule_id=None, interaction=None):
         """Return the selected lj_scales defined for this topology."""
         return self._get_scaling_factor(molecule_id, interaction, "lj_scale", 0)
@@ -649,19 +661,10 @@ class Topology(object):
 
     def remove_site(self, site):
         """"""
-        site_connections = [con for con in site.connections]
-        for connection in site_connections:
-            try:
-                self.remove_connection(connection)
-            except KeyError:
-                pass
         self._sites.remove(site)
 
     def remove_connection(self, connection):
         """"""
-        connection_sites = [site for site in connection.connection_members]
-        for site in connection_sites:
-            site.connections.remove(connection)
         if isinstance(connection, gmso.core.bond.Bond):
             self._bonds.remove(connection)
         elif isinstance(connection, gmso.core.angle.Angle):
@@ -855,8 +858,6 @@ class Topology(object):
             Improper: self._impropers,
         }
         connections_sets[type(connection)].add(connection)
-        for site in connection.connection_members:
-            site.connections.add(connection)
         if update_types:
             self.update_topology()
 

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -649,7 +649,8 @@ class Topology(object):
 
     def remove_site(self, site):
         """"""
-        for connection in site.connections:
+        site_connections = [con for con in site.connections]
+        for connection in site_connections:
             try:
                 self.remove_connection(connection)
             except KeyError:
@@ -658,6 +659,9 @@ class Topology(object):
 
     def remove_connection(self, connection):
         """"""
+        connection_sites = [site for site in connection.connection_members]
+        for site in connection_sites:
+            site.connections.remove(connection)
         if isinstance(connection, gmso.core.bond.Bond):
             self._bonds.remove(connection)
         elif isinstance(connection, gmso.core.angle.Angle):

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -669,7 +669,9 @@ class Topology(object):
             raise ValueError(
                 f"Site {site} is not currently part of this topology."
             )
-        site_connections = [conn for conn in self.iter_connections_by_site(site)]
+        site_connections = [
+            conn for conn in self.iter_connections_by_site(site)
+        ]
         for conn in site_connections:
             self.remove_connection(conn)
         self._sites.remove(site)

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -831,7 +831,8 @@ class Topology(object):
             Improper: self._impropers,
         }
         connections_sets[type(connection)].add(connection)
-
+        for site in connection.connection_members:
+            site.connections.add(connection)
         if update_types:
             self.update_topology()
 

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -669,8 +669,9 @@ class Topology(object):
             raise ValueError(
                 f"Site {site} is not currently part of this topology."
             )
-        for connection in self.iter_connections_by_site(site):
-            self.remove_connection(connection)
+        site_connections = [conn for conn in self.iter_connections_by_site(site)]
+        for conn in site_connections:
+            self.remove_connection(conn)
         self._sites.remove(site)
 
     def remove_connection(self, connection):

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -59,6 +59,12 @@ class TestTopology(BaseTest):
         assert ethane.n_sites == 2
         assert ethane.n_connections == 1
 
+    def test_remove_site_not_in_top(self, ethane):
+        top = Topology()
+        site = Atom(name="site")
+        with pytest.raises(ValueError):
+            top.remove_site(site)
+
     def test_add_connection(self):
         top = Topology()
         atom1 = Atom(name="atom1")
@@ -82,6 +88,14 @@ class TestTopology(BaseTest):
         top.add_site(atom2)
         top.remove_connection(connect)
         assert top.n_connections == 0
+
+    def test_remove_connection(self):
+        top = Topology()
+        atom1 = Atom(name="atom1")
+        atom2 = Atom(name="atom2")
+        connect = Bond(connection_members=[atom1, atom2])
+        with pytest.raises(ValueError):
+            top.remove_connection(connect)
 
     def test_add_box(self):
         top = Topology()

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -89,7 +89,7 @@ class TestTopology(BaseTest):
         top.remove_connection(connect)
         assert top.n_connections == 0
 
-    def test_remove_connection(self):
+    def test_remove_connection_not_in_top(self):
         top = Topology()
         atom1 = Atom(name="atom1")
         atom2 = Atom(name="atom2")

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -951,6 +951,15 @@ class TestTopology(BaseTest):
         ):
             assert site in conn.connection_members
 
+    def test_iter_connections_by_site_bad_param(self, ethane):
+        ethane.identify_connections()
+        site = ethane.sites[0]
+        with pytest.raises(ValueError):
+            for conn in ethane.iter_connections_by_site(
+                site=site, connections=["bond"]
+            ):
+                pass
+
     def test_write_forcefield(self, typed_water_system):
         forcefield = typed_water_system.get_forcefield()
         assert "opls_111" in forcefield.atom_types

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -974,6 +974,13 @@ class TestTopology(BaseTest):
             ):
                 pass
 
+    def test_iter_connections_by_site_not_in_top(self):
+        top = Topology()
+        site = Atom(name="site")
+        with pytest.raises(ValueError):
+            for conn in top.iter_connections_by_site(site):
+                pass
+
     def test_write_forcefield(self, typed_water_system):
         forcefield = typed_water_system.get_forcefield()
         assert "opls_111" in forcefield.atom_types


### PR DESCRIPTION
This is still a work in progress, but this PR does a couple things:

**1. Within the `Site` class, we can access all the connections a site is directly involved in.**
- The `Site.connections` property is updated anytime `Topology.add_connection` is used as well as any time `Topology.remove_connection` is used.

**EDIT: After some conversation; this PR instead adds a method to `Toplogy` that returns a dict of all the connections that belong to a site.**

- The idea here is to have more direct access to connections from a particle-up approach rather than topology-down approach.  This way we can avoid larger nested for-loops. 

**2. Adds methods for removing a site and a connection from a topology.**

This addresses #736 and #161 and should replace PR #370 

This is still a WIP, I need to add unit tests and doc strings, and definitely need some feedback in terms of syntax, functionality and to make sure I'm following good pydantic practices. I'm interested what everyone else thinks.

[Here is a gist](https://gist.github.com/chrisjonesBSU/cd2b5b8d4fda72b20e497a022195c95c) showing an example.