### PR TITLE
Attempt to unpin some of our dependencies

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,7 +6,7 @@ dependencies:
   - boltons
   - numpy
   - sympy
-  - unyt
+  - unyt>=2.9.5
   - boltons
   - lxml
   - pydantic

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -4,9 +4,9 @@ channels:
 dependencies:
   - python>=3.8
   - boltons
-  - numpy=1.24.2
+  - numpy
   - sympy
-  - unyt<=2.9.2
+  - unyt
   - boltons
   - lxml
   - pydantic

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - boltons
   - numpy
   - sympy
-  - unyt
+  - unyt>=2.9.5
   - boltons
   - lxml
   - pydantic

--- a/environment.yml
+++ b/environment.yml
@@ -4,9 +4,9 @@ channels:
 dependencies:
   - python>=3.8
   - boltons
-  - numpy=1.24.2
+  - numpy
   - sympy
-  - unyt<=2.9.2
+  - unyt
   - boltons
   - lxml
   - pydantic


### PR DESCRIPTION
Local testing indicates that our tests run fine with the later version of numpy and unyt (?). I am not sure what changes might have happened upstream, but I think it's probably good time to unpin those packages.