### PR TITLE
Fix bug in GRO reader

### DIFF
--- a/gmso/formats/gro.py
+++ b/gmso/formats/gro.py
@@ -42,8 +42,8 @@ def read_gro(filename):
     Gro files do not specify connections between atoms, the returned topology
     will not have connections between sites either.
 
-    Currently this implementation does not support a gro file with more than 1
-    frame.
+    Currently this implementation does not support parsing velocities from a gro file or gro file
+    with more than 1 frame.
 
     All residues and resid information from the gro file are currently lost
     when converting to `topology`.
@@ -82,6 +82,11 @@ def read_gro(filename):
             site.molecule = (res_name, res_id)
             site.residue = (res_name, res_id)
             top.add_site(site, update_types=False)
+
+        if len(positions) == 6:
+            warnings.warn(
+                "Velocity information presents but will not be parsed."
+            )
         top.update_topology()
 
         # Box information

--- a/gmso/formats/gro.py
+++ b/gmso/formats/gro.py
@@ -57,7 +57,7 @@ def read_gro(filename):
         coords = u.nm * np.zeros(shape=(n_atoms, 3))
         for row, _ in enumerate(coords):
             line = gro_file.readline()
-            res_id = int(line[:5])
+            res_id = int(line[:5].strip())
             res_name = line[5:10].strip()
             atom_name = line[10:15].strip()
             atom_id = line[15:20].strip()

--- a/gmso/formats/gro.py
+++ b/gmso/formats/gro.py
@@ -57,7 +57,12 @@ def read_gro(filename):
         coords = u.nm * np.zeros(shape=(n_atoms, 3))
         for row, _ in enumerate(coords):
             line = gro_file.readline()
-            content = line.split()
+            res_id = int(line[:5])
+            res_name = line[5:10].strip()
+            atom_name = line[10:15].strip()
+            atom_id = line[15:20].strip()
+
+            positions = line[20:].split()
             if not line:
                 msg = (
                     "Incorrect number of lines in .gro file. Based on the "
@@ -66,22 +71,17 @@ def read_gro(filename):
                 )
                 raise ValueError(msg.format(n_atoms))
 
-            res = content[0]
-            atom_name = content[1]
-            atom_id = content[2]
             coords[row] = u.nm * np.array(
                 [
-                    float(content[3]),
-                    float(content[4]),
-                    float(content[5]),
+                    float(positions[0]),
+                    float(positions[1]),
+                    float(positions[2]),
                 ]
             )
             site = Atom(name=atom_name, position=coords[row])
 
-            r = re.compile("([0-9]+)([a-zA-Z]+)")
-            m = r.match(res)
-            site.molecule = (m.group(2), int(m.group(1)))
-            site.residue = (m.group(2), int(m.group(1)))
+            site.molecule = (res_name, res_id)
+            site.residue = (res_name, res_id)
             top.add_site(site, update_types=False)
         top.update_topology()
 

--- a/gmso/formats/gro.py
+++ b/gmso/formats/gro.py
@@ -57,12 +57,6 @@ def read_gro(filename):
         coords = u.nm * np.zeros(shape=(n_atoms, 3))
         for row, _ in enumerate(coords):
             line = gro_file.readline()
-            res_id = int(line[:5].strip())
-            res_name = line[5:10].strip()
-            atom_name = line[10:15].strip()
-            atom_id = line[15:20].strip()
-
-            positions = line[20:].split()
             if not line:
                 msg = (
                     "Incorrect number of lines in .gro file. Based on the "
@@ -70,7 +64,12 @@ def read_gro(filename):
                     "atoms were expected, but at least one fewer was found."
                 )
                 raise ValueError(msg.format(n_atoms))
+            res_id = int(line[:5].strip())
+            res_name = line[5:10].strip()
+            atom_name = line[10:15].strip()
+            atom_id = line[15:20].strip()
 
+            positions = line[20:].split()
             coords[row] = u.nm * np.array(
                 [
                     float(positions[0]),

--- a/gmso/tests/test_gro.py
+++ b/gmso/tests/test_gro.py
@@ -39,7 +39,7 @@ class TestGro(BaseTest):
         )
 
     def test_wrong_n_atoms(self):
-        with pytest.raises(IndexError):
+        with pytest.raises(ValueError):
             Topology.load(get_fn("too_few_atoms.gro"))
         with pytest.raises(ValueError):
             Topology.load(get_fn("too_many_atoms.gro"))


### PR DESCRIPTION
Address #774. Slicing line/string to populate atom/residue name/id when parsing gro file. Pending unit test. 