### PR TITLE
Drop support/testing for py3.8

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [macOS-latest, ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
         pydantic-version: ["2"]
 
     defaults:

--- a/gmso/external/convert_parmed.py
+++ b/gmso/external/convert_parmed.py
@@ -72,10 +72,10 @@ def from_parmed(structure, refer_type=True):
                 charge=atom.charge * u.elementary_charge,
                 position=[atom.xx, atom.xy, atom.xz] * u.angstrom,
                 atom_type=None,
-                residue=(residue.name, residue.idx + 1),
+                residue=(residue.name, residue.number),
                 element=element,
             )
-            site.molecule = (residue.name, residue.idx + 1) if ind_res else None
+            site.molecule = (residue.name, residue.number) if ind_res else None
             site.atom_type = (
                 copy.deepcopy(pmd_top_atomtypes[atom.atom_type])
                 if refer_type and isinstance(atom.atom_type, pmd.AtomType)
@@ -474,7 +474,7 @@ def to_parmed(top, refer_type=True):
             structure.add_atom(
                 pmd_atom,
                 resname=site.residue.name,
-                resnum=site.residue.number - 1,
+                resnum=site.residue.number,
             )
         else:
             structure.add_atom(pmd_atom, resname="RES", resnum=-1)


### PR DESCRIPTION
Relate to #778. I think it's time to drop 3.8 from the testing cycle. 