### PR TITLE
Add `to_xml` method to Topology

### DIFF
--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -1228,6 +1228,22 @@ class Topology(object):
 
         return index
 
+    def to_xml(self, filename, overwrite=False, backend="gmso"):
+        """Save an lxml ElementTree representation of the topology's parameters
+
+        Parameters
+        ----------
+        filename: Union[str, pathlib.Path], default=None
+            The filename to write the XML file to
+        overwrite: bool, default=False
+            If True, overwrite an existing file if it exists
+        backend: str, default="gmso"
+            Can be "gmso" or "forcefield-utilities". This will define the methods to
+            write the xml.
+        """
+        ff = self.get_forcefield()
+        ff.to_xml(filename=filename, overwrite=overwrite, backend=backend)
+
     def to_dataframe(self, parameter="sites", site_attrs=None, unyts_bool=True):
         """Return a pandas dataframe object for the sites in a topology
 

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -1240,6 +1240,11 @@ class Topology(object):
         backend: str, default="gmso"
             Can be "gmso" or "forcefield-utilities". This will define the methods to
             write the xml.
+
+        Raises
+        ------
+        GMSOError
+            If the topology is untyped
         """
         ff = self.get_forcefield()
         ff.to_xml(filename=filename, overwrite=overwrite, backend=backend)

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -1250,7 +1250,7 @@ class Topology(object):
             If the topology is untyped
         """
         ff = self.get_forcefield()
-        ff.to_xml(filename=filename, overwrite=overwrite, backend=backend)
+        ff.to_xml(filename=filename, overwrite=overwrite)
 
     def to_dataframe(self, parameter="sites", site_attrs=None, unyts_bool=True):
         """Return a pandas dataframe object for the sites in a topology

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -1228,8 +1228,8 @@ class Topology(object):
 
         return index
 
-    def to_xml(self, filename, overwrite=False, backend="gmso"):
-        """Save an lxml ElementTree representation of the topology's parameters
+    def write_forcefield(self, filename, overwrite=False):
+        """Save an xml file for all parameters found in the topology.
 
         Parameters
         ----------
@@ -1237,9 +1237,12 @@ class Topology(object):
             The filename to write the XML file to
         overwrite: bool, default=False
             If True, overwrite an existing file if it exists
-        backend: str, default="gmso"
-            Can be "gmso" or "forcefield-utilities". This will define the methods to
-            write the xml.
+
+        Notes
+        -----
+        This method can be used to save a small, trimmed down forcefield
+        from a larger forcefield (e.g. oplsaa). This is useful for
+        editing, saving, and sharing forcefield parameters.
 
         Raises
         ------

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -1,3 +1,4 @@
+import os
 from copy import deepcopy
 
 import numpy as np
@@ -1010,3 +1011,7 @@ class TestTopology(BaseTest):
             1.60217662e-19 * u.Coulomb,
             0.1 * u.Unit("test_charge", registry=reg.reg),
         )
+
+    def test_to_xml(self, typed_benzene_aa_system):
+        typed_benzene_aa_system.to_xml("benzene.xml")
+        assert os.path.isfile("benzene.xml")

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -982,13 +982,18 @@ class TestTopology(BaseTest):
             for conn in top.iter_connections_by_site(site):
                 pass
 
-    def test_write_forcefield(self, typed_water_system):
+    def test_write_forcefield(
+        self, typed_water_system, typed_benzene_aa_system
+    ):
         forcefield = typed_water_system.get_forcefield()
         assert "opls_111" in forcefield.atom_types
         assert "opls_112" in forcefield.atom_types
         top = Topology()
         with pytest.raises(GMSOError):
             top.get_forcefield()
+
+        typed_benzene_aa_system.write_forcefield("benzene.xml")
+        assert os.path.isfile("benzene.xml")
 
     def test_units(self, typed_ethane):
         reg = UnitReg()
@@ -1011,7 +1016,3 @@ class TestTopology(BaseTest):
             1.60217662e-19 * u.Coulomb,
             0.1 * u.Unit("test_charge", registry=reg.reg),
         )
-
-    def test_write_forcefield(self, typed_benzene_aa_system):
-        typed_benzene_aa_system.write_forcefield("benzene.xml")
-        assert os.path.isfile("benzene.xml")

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -1012,6 +1012,6 @@ class TestTopology(BaseTest):
             0.1 * u.Unit("test_charge", registry=reg.reg),
         )
 
-    def test_to_xml(self, typed_benzene_aa_system):
-        typed_benzene_aa_system.to_xml("benzene.xml")
+    def test_write_forcefield(self, typed_benzene_aa_system):
+        typed_benzene_aa_system.write_forcefield("benzene.xml")
         assert os.path.isfile("benzene.xml")


### PR DESCRIPTION
This is a small PR that simplifies the workflow of saving a topology specific xml file by adding a `to_xml` method to `Topology`.  This method just calls both `Toplogy.get_forcefield` and `gmso.core.forcefield.to_xml`, so the unit tests don't check for things like consistency of the new XML file since that is already tested in `test_forcefield.py`.

I think it it will be helpful to have this functionality work as a single step at the `Topology` level.