### PR TITLE
Sorting of improper types

### DIFF
--- a/gmso/tests/test_dihedral.py
+++ b/gmso/tests/test_dihedral.py
@@ -153,3 +153,35 @@ class TestDihedral(BaseTest):
             tuple(dihedral.connection_members)
             in dihedral_not_eq.equivalent_members()
         )
+
+    def test_sort_dihedral_types(self):
+        from gmso.utils.sorting import sort_by_classes, sort_by_types
+
+        atom1 = Atom(
+            name="atom1", position=[0, 0, 0], atom_type=AtomType(name="A")
+        )
+        atom2 = Atom(
+            name="atom2", position=[1, 0, 0], atom_type=AtomType(name="B")
+        )
+        atom3 = Atom(
+            name="atom3", position=[1, 1, 0], atom_type=AtomType(name="C")
+        )
+        atom4 = Atom(
+            name="atom4", position=[1, 1, 4], atom_type=AtomType(name="D")
+        )
+
+        consituentList = [
+            atom2.atom_type.name,
+            atom4.atom_type.name,
+            atom3.atom_type.name,
+            atom1.atom_type.name,
+        ]
+        dihtype = DihedralType(
+            member_types=consituentList, member_classes=consituentList
+        )
+
+        expected_sortingList = tuple(
+            [atom.atom_type.name for atom in [atom1, atom3, atom4, atom2]]
+        )
+        assert sort_by_classes(dihtype) == expected_sortingList
+        assert sort_by_types(dihtype) == expected_sortingList

--- a/gmso/tests/test_improper.py
+++ b/gmso/tests/test_improper.py
@@ -152,3 +152,35 @@ class TestImproper(BaseTest):
             tuple(improper.connection_members)
             in improper_not_eq.equivalent_members()
         )
+
+    def test_sort_improper_types(self):
+        from gmso.utils.sorting import sort_by_classes, sort_by_types
+
+        atom1 = Atom(
+            name="atom1", position=[0, 0, 0], atom_type=AtomType(name="A")
+        )
+        atom2 = Atom(
+            name="atom2", position=[1, 0, 0], atom_type=AtomType(name="B")
+        )
+        atom3 = Atom(
+            name="atom3", position=[1, 1, 0], atom_type=AtomType(name="C")
+        )
+        atom4 = Atom(
+            name="atom4", position=[1, 1, 4], atom_type=AtomType(name="D")
+        )
+
+        consituentList = [
+            atom2.atom_type.name,
+            atom4.atom_type.name,
+            atom3.atom_type.name,
+            atom1.atom_type.name,
+        ]
+        imptype = ImproperType(
+            member_types=consituentList, member_classes=consituentList
+        )
+
+        expected_sortingList = tuple(
+            [atom.atom_type.name for atom in [atom2, atom3, atom4, atom1]]
+        )
+        assert sort_by_classes(imptype) == expected_sortingList
+        assert sort_by_types(imptype) == expected_sortingList

--- a/gmso/utils/sorting.py
+++ b/gmso/utils/sorting.py
@@ -122,7 +122,8 @@ def sort_by_classes(potential):
     elif isinstance(potential, ImproperType):
         return (
             potential.member_classes[0],
-            *sorted(potential.member_classes[1:]),
+            *sorted(potential.member_classes[1:3]),
+            potential.member_classes[3],
         )
     return ValueError(
         f"Potential {potential} not one of {potential_attribute_map.values()}"
@@ -174,7 +175,8 @@ def sort_by_types(potential):
     elif isinstance(potential, ImproperType):
         return (
             potential.member_types[0],
-            *sorted(potential.member_types[1:]),
+            *sorted(potential.member_types[1:3]),
+            potential.member_types[3],
         )
     return ValueError(
         f"Potential {potential} not one of {potential_attribute_map.values()}"


### PR DESCRIPTION
Recently, some utilities have been added to gmso/utils/sorting.py. These helped to write out or reorder improper types in the forcefield in a way that was consistent. However, the improper sorting was allowing for the following conditions.

i, j, k, l == i, sorted(k, l, j)

In reality, we need to use the following equivalence:

i, j, k, l == i, sorted(k, l), j

This is because it matters in the improper which atom is considered as the last atom in the list, since the angle from the improper is the angle between planes i,j,k and j,k,l. So only j and k are interchangeable.

Now technically i and l are interchangeable as well, but for the sake of consistency we are defining that the central atom always must go first, so I believe it is useful to stay consistent and leave i and l in their positions, even if mathematically they're equivalent.

- [ ] issues raised/addressed
- [x] tests done
- [x] feature implemented