### PR TITLE
Fix order of matching when atomtyping

### DIFF
--- a/gmso/parameterization/topology_parameterizer.py
+++ b/gmso/parameterization/topology_parameterizer.py
@@ -386,11 +386,11 @@ class TopologyParameterizer(GMSOBase):
         group = POTENTIAL_GROUPS[type(connection)]
         return group, [
             list(
-                member.atom_type.atomclass
+                member.atom_type.name
                 for member in connection.connection_members
             ),
             list(
-                member.atom_type.name
+                member.atom_type.atomclass
                 for member in connection.connection_members
             ),
         ]


### PR DESCRIPTION
Address #801. Flip the order of `connection_identifier` to consider atom type first when matching. 