### PR TITLE
Add python 3.12 to CI workflow and environment files

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11"]
+        os: [macOS-latest, macOS-13, ubuntu-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     defaults:
       run:

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,9 +2,9 @@ name: gmso-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.8,<3.12
+  - python>=3.8,<=3.12
   - boltons
-  - numpy
+  - numpy=1.26.4
   - sympy
   - unyt>=2.9.5
   - boltons

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,7 +2,7 @@ name: gmso-dev
 channels:
   - conda-forge
 dependencies:
-  - python>=3.8,<=3.12
+  - python>=3.9,<=3.12
   - boltons
   - numpy=1.26.4
   - sympy

--- a/environment.yml
+++ b/environment.yml
@@ -2,9 +2,9 @@ name: gmso
 channels:
   - conda-forge
 dependencies:
-  - python>=3.8, <3.12
+  - python>=3.8, <=3.12
   - boltons
-  - numpy
+  - numpy=1.26.4
   - sympy
   - unyt>=2.9.5
   - boltons

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: gmso
 channels:
   - conda-forge
 dependencies:
-  - python>=3.8, <=3.12
+  - python>=3.9, <=3.12
   - boltons
   - numpy=1.26.4
   - sympy


### PR DESCRIPTION
Now that mbuild 0.17.1 is released, I think we're ready to bump everything up to python 3.12 in GMSO.