### PR TITLE
Fix hoomd version handling in `convert_hoomd.py`

### DIFF
--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -30,6 +30,7 @@ if has_gsd:
     import gsd.hoomd
 if has_hoomd:
     import hoomd
+
     hoomd_version = hoomd.version.version.split(".")
 else:
     hoomd_version = None
@@ -46,7 +47,6 @@ AKMA_UNITS = {
     "length": u.angstrom,
     "mass": u.g / u.mol,  # aka amu
 }
-
 
 
 def to_gsd_snapshot(

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -30,6 +30,9 @@ if has_gsd:
     import gsd.hoomd
 if has_hoomd:
     import hoomd
+    hoomd_version = hoomd.version.version.split(".")
+else:
+    hoomd_version = None
 
 # Note, charge will always be assumed to be in elementary_charge
 MD_UNITS = {
@@ -44,7 +47,6 @@ AKMA_UNITS = {
     "mass": u.g / u.mol,  # aka amu
 }
 
-hoomd_version = hoomd.version.version.split(".")
 
 
 def to_gsd_snapshot(


### PR DESCRIPTION
I've noticed a bug that you will get `hoomd not defined` error when importing anything from `gmso.external` (even `from_mbuild` and `to_mbuild`) and don't have hoomd in your environment.

This is happening because the hoomd import in `convert_hoomd` is under an if statement, but a few lines later we call `hoomd.version`

@CalCraven @daico007 should we do a quick patch release to get this fix in the conda package asap?

