### PR TITLE
Reduce tests in CI workflow

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -151,7 +151,7 @@ jobs:
           echo Docker Image tags: ${DOCKER_TAGS}
 
       - name: Build and Push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: true
           tags: ${{ env.DOCKER_TAGS }}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -88,7 +88,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout Branch / Pull Request
 
       - name: Install Mamba

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -13,12 +13,12 @@ on:
 jobs:
   test:
     if: github.event.pull_request.draft == false
-    name: GMSO Tests
+    name: GMSO Tests (python)
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macOS-latest, macOS-13, ubuntu-latest]
+        os: [ubuntu-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     defaults:
@@ -48,6 +48,37 @@ jobs:
           name: GMSO-Coverage
           verbose: true
 
+  arch-test:
+    if: github.event.pull_request.draft == false
+    name: GMSO Tests (arch)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macOS-latest, macOS-13, ubuntu-latest]
+        python-version: ["3.12"]
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout Branch / Pull Request
+
+      - name: Install Mamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: environment-dev.yml
+          create-args: >-
+            python=${{ matrix.python-version }}
+
+      - name: Install Package
+        run: python -m pip install -e .
+
+      - name: Test (OS -> ${{ matrix.os }} / Python -> ${{ matrix.python-version }})
+        run: python -m pytest -v --color yes --pyargs gmso
+
   bleeding-edge-test:
     if: github.event.pull_request.draft == false
     name: Bleeding Edge mosdef Tests for GMSO
@@ -64,7 +95,7 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: environment-dev.yml
-          create-args: python=3.10
+          create-args: python=3.12
 
       - name: Clone mBuild and Foyer and forcefield-utilities
         run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -26,7 +26,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout Branch / Pull Request
 
       - name: Install Mamba
@@ -43,7 +43,7 @@ jobs:
         run: python -m pytest -v --cov=gmso --cov-report=xml --cov-append --cov-config=setup.cfg --color yes --pyargs gmso
 
       - name: Upload Coverage Report
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
           name: GMSO-Coverage
           verbose: true
@@ -63,7 +63,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout Branch / Pull Request
 
       - name: Install Mamba

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ ci:
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.5.5
+  rev: v0.5.6
   hooks:
     # Run the linter.
     - id: ruff


### PR DESCRIPTION
This PR changes the testing matrices similar to what we did in https://github.com/mosdef-hub/foyer/pull/571

So now, we only use `ubuntu-latest` to test the various python versions, and only use the latest python version (3.12) when testing different OS images.