### PR TITLE
Update equation_compare.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 project = "gmso"
 copyright = "2024, mosdef-hub, Vanderbilt University"
-author = "Matt Thompson, Alex Yang, Ray Matsumoto, Parashara Shamaprasad, Umesh Timalsina, Co D. Quach, Ryan S. DeFever, Justin Gilmer"
+author = "Matt Thompson, Alex Yang, Ray Matsumoto, Parashara Shamaprasad, Umesh Timalsina, Co D. Quach, Ryan S. DeFever, Justin Gilmer, Nicholas C. Craven, Christopher R. Iacovella, Brad Crawford, and Chris Jones"
 
 # The full version, including alpha/beta/rc tags
 version = "0.12.4"

--- a/gmso/utils/equation_compare.py
+++ b/gmso/utils/equation_compare.py
@@ -483,7 +483,7 @@ def evaluate_OPLS_torsion_format_with_scaler(new_torsion_form, base_torsion_form
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.sympify(new_torsion_form) / sympy.sympify(base_torsion_form),
+                - sympy.nsimplify(new_torsion_form) / sympy.nsimplify(base_torsion_form),
             ],
             [eqn_ratio],
         )

--- a/gmso/utils/equation_compare.py
+++ b/gmso/utils/equation_compare.py
@@ -483,7 +483,8 @@ def evaluate_OPLS_torsion_format_with_scaler(new_torsion_form, base_torsion_form
         values = sympy.nonlinsolve(
             [
                 eqn_ratio
-                - sympy.nsimplify(new_torsion_form) / sympy.nsimplify(base_torsion_form),
+                - sympy.nsimplify(new_torsion_form)
+                / sympy.nsimplify(base_torsion_form),
             ],
             [eqn_ratio],
         )


### PR DESCRIPTION
Changing 'sympy.symplify' to 'sympy.nsimplify' allows the less simple equations to be solved with the 0.5 decimals in it (example OPLS dihedral).  This was the only was to improve or actually solve for the scalers in the equations when using non-integers in the forms like the OPLS dihedral.

Added me to author list also