### PR TITLE
Fix `__repr__` method in `abstract_site.Molecule` and `abstract_site.Residue`

### DIFF
--- a/gmso/abc/abstract_site.py
+++ b/gmso/abc/abstract_site.py
@@ -24,7 +24,7 @@ PositionType = Union[Sequence[float], np.ndarray, u.unyt_array]
 class Molecule(GMSOBase):
     def __repr__(self):
         return (
-            f"Molecule(name={self.name}, residue={self.residue}, isrigid={self.isrigid}"
+            f"Molecule(name={self.name}, number={self.number}, isrigid={self.isrigid})"
         )
 
     __iterable_attributes__: ClassVar[set] = {
@@ -88,7 +88,7 @@ class Molecule(GMSOBase):
 
 class Residue(GMSOBase):
     def __repr__(self):
-        return f"Residue(name={self.name}, residue={self.residue}"
+        return f"Residue(name={self.name}, number={self.number}, residue={self.residue}"
 
     __iterable_attributes__: ClassVar[set] = {
         "name",
@@ -149,6 +149,17 @@ def default_position():
 
 
 class Site(GMSOBase):
+    def __repr__(self):
+        """Return the formatted representation of the site."""
+        return (
+            f"<{self.__class__.__name__} {self.name},\n "
+            f"position: {self.position},\n "
+            f"label: {self.label if self.label else None},\n "
+            f"Molecule: {self.molecule},\n"
+            f"Residue: {self.residue},\n"
+            f"id: {id(self)}>"
+        )
+
     __iterable_attributes__: ClassVar[set] = {
         "name",
         "label",
@@ -253,15 +264,6 @@ class Site(GMSOBase):
     @field_serializer("position_")
     def serialize_position(self, position_: PositionType):
         return unyt_to_dict(position_)
-
-    def __repr__(self):
-        """Return the formatted representation of the site."""
-        return (
-            f"<{self.__class__.__name__} {self.name},\n "
-            f"position: {self.position},\n "
-            f"label: {self.label if self.label else None},\n "
-            f"id: {id(self)}>"
-        )
 
     def __str__(self):
         """Return the string representation of the site."""

--- a/gmso/abc/abstract_site.py
+++ b/gmso/abc/abstract_site.py
@@ -88,7 +88,7 @@ class Molecule(GMSOBase):
 
 class Residue(GMSOBase):
     def __repr__(self):
-        return f"Residue(name={self.name}, number={self.number}, residue={self.residue}"
+        return f"Residue(name={self.name}, number={self.number}"
 
     __iterable_attributes__: ClassVar[set] = {
         "name",

--- a/gmso/tests/abc/test_abc.py
+++ b/gmso/tests/abc/test_abc.py
@@ -7,13 +7,13 @@ from gmso.tests.base_test import BaseTest
 class TestSite(BaseTest):
     def test_molecule(self):
         molecule = Molecule()
-        molecule
+        molecule.__repr__()
         assert molecule.number == 0
         assert molecule.isrigid is False
 
     def test_residue(self):
         residue = Residue()
-        residue
+        residue.__repr__()
         assert residue.number == 0
 
     def test_site(self):

--- a/gmso/tests/abc/test_abc.py
+++ b/gmso/tests/abc/test_abc.py
@@ -1,0 +1,21 @@
+import pytest
+
+from gmso.abc.abstract_site import Molecule, Residue, Site
+from gmso.tests.base_test import BaseTest
+
+
+class TestSite(BaseTest):
+    def test_molecule(self):
+        molecule = Molecule()
+        molecule
+        assert molecule.number == 0
+        assert molecule.isrigid is False
+
+    def test_residue(self):
+        residue = Residue()
+        residue
+        assert residue.number == 0
+
+    def test_site(self):
+        with pytest.raises(TypeError):
+            Site()

--- a/gmso/tests/base_test.py
+++ b/gmso/tests/base_test.py
@@ -420,7 +420,7 @@ class BaseTest:
         }
 
         def test_connection_equality(conn1, conn2):
-            if not type(conn1) == type(conn2):
+            if type(conn1) is not type(conn2):
                 return False
             conn1_eq_members = conn1.equivalent_members()
             conn2_eq_members = conn2.equivalent_members()


### PR DESCRIPTION
When poking around some things while working on #850 I got a strange error when trying to look at a `Molecule` instance in a notebook. There is an error in the `__repr__` method of both the `Molecule` and `Residue` classes in `abstract_site.py` where it tries to call an attribute that doesn't exist.

This PR fixes that, and adds some extremely simple tests that should have caught this.

Also, I added fields for Residue and Molecule to the `__repr__` method for `Site` as I think it provides helpful info.

```
>>> from gmso.abc.abstract_site import Molecule
>>> mol = Molecule()
>>> mol

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/chris/mambaforge/envs/flowermd-dev/lib/python3.11/site-packages/gmso/abc/abstract_site.py", line 27, in __repr__
    f"Molecule(name={self.name}, residue={self.residue}, isrigid={self.isrigid}"
                                          ^^^^^^^^^^^^
  File "/home/chris/mambaforge/envs/flowermd-dev/lib/python3.11/site-packages/pydantic/main.py", line 828, in __getattr__
    raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')
AttributeError: 'Molecule' object has no attribute 'residue'
```