### PR TITLE
Handlers for template potentials that are different forms of the same equation.

### DIFF
--- a/gmso/abc/abstract_potential.py
+++ b/gmso/abc/abstract_potential.py
@@ -1,6 +1,5 @@
 """Abstract representation of a Potential object."""
 
-from abc import abstractmethod
 from typing import Any, Dict, Iterator, List
 
 import unyt as u
@@ -159,11 +158,6 @@ class AbstractPotential(GMSOBase):
         if isinstance(v, dict):
             v = PotentialExpression(**v)
         return v
-
-    @abstractmethod
-    def set_expression(self):
-        """Set the functional form of the expression."""
-        raise NotImplementedError
 
     def __setattr__(self, key: Any, value: Any) -> None:
         """Set attributes of the potential."""

--- a/gmso/lib/potential_templates.py
+++ b/gmso/lib/potential_templates.py
@@ -1,6 +1,7 @@
 """Module supporting template potential objects."""
 
 import json
+from copy import deepcopy
 from pathlib import Path
 from typing import Dict
 
@@ -113,9 +114,11 @@ class PotentialTemplate(AbstractPotential):
         """Return the expected dimensions of the parameters for this template."""
         return self.__dict__.get("expected_parameters_dimensions_")
 
-    def set_expression(self, *args, **kwargs):
+    def set_expression(self, new_expression):
         """Set the expression of the PotentialTemplate."""
-        raise NotImplementedError
+        copied_template = deepcopy(self)
+        copied_template.expression = new_expression
+        return copied_template
 
     def assert_can_parameterize_with(
         self, parameters: Dict[str, u.unyt_quantity]

--- a/gmso/tests/test_conversions.py
+++ b/gmso/tests/test_conversions.py
@@ -4,6 +4,7 @@ import sympy
 import unyt as u
 from sympy import sympify
 
+from gmso.exceptions import EngineIncompatibilityError
 from gmso.tests.base_test import BaseTest
 from gmso.utils.conversions import (
     convert_kelvin_to_energy_units,
@@ -239,3 +240,9 @@ class TestConversions(BaseTest):
             n_decimals=6,
         )
         assert np.isclose(float(paramStr), 1 / 3**4, atol=1e-6)
+
+    def test_failed_conversion_method(self, typed_ethane):
+        with pytest.raises(
+            EngineIncompatibilityError,
+        ):
+            typed_ethane.convert_potential_styles({"bond": 2})

--- a/gmso/tests/test_hoomd.py
+++ b/gmso/tests/test_hoomd.py
@@ -388,7 +388,7 @@ class TestGsd(BaseTest):
     @pytest.mark.skipif(not has_hoomd, reason="hoomd is not installed")
     @pytest.mark.skipif(not has_mbuild, reason="mbuild not installed")
     @pytest.mark.skipif(
-        int(hoomd_version[0]) <= 3.8, reason="Deprecated features in HOOMD 4"
+        int(hoomd_version[0]) < 4.5, reason="No periodic impropers in hoomd < 4.5"
     )
     def test_gaff_sim(self, gaff_forcefield):
         base_units = {

--- a/gmso/tests/test_template.py
+++ b/gmso/tests/test_template.py
@@ -34,8 +34,10 @@ class TestTemplate(BaseTest):
             independent_variables={"x"},
             expected_parameters_dimensions={"a": "length", "b": "length"},
         )
-        with pytest.raises(NotImplementedError):
-            template.set_expression(expression="a*y+b")
+        with pytest.raises(ValueError):
+            template.set_expression(new_expression="a*y+b")
+        template2 = template.set_expression(new_expression="3*a*x+b")
+        assert template2.expression != template.expression
 
     def test_parameterization_non_dict_expected_dimensions(self):
         template = PotentialTemplate(

--- a/gmso/utils/conversions.py
+++ b/gmso/utils/conversions.py
@@ -1,5 +1,6 @@
 """Module for standard conversions needed in molecular simulations."""
-
+from __future__ import annotations
+from typing import TYPE_CHECKING
 import re
 from functools import lru_cache
 
@@ -9,7 +10,9 @@ import sympy
 import unyt as u
 from unyt.dimensions import length, mass, time
 
-import gmso
+if TYPE_CHECKING:
+        import gmso
+
 from gmso.exceptions import EngineIncompatibilityError, GMSOError
 from gmso.lib.potential_templates import (
     PotentialTemplate,
@@ -57,7 +60,7 @@ def _try_sympy_conversions(pot1, pot2):
 
 def _conversion_from_template_name(
     top, connStr: str, conn_typeStr: str, convStr: str
-) -> gmso.Topology:
+) -> 'gmso.Topology':
     """Use the name of convStr to identify function to convert sympy expressions."""
     conversions_map = {  # these are predefined between template types
         # More functions, and `(to, from)` key pairs added to this dictionary
@@ -101,7 +104,7 @@ def _conversion_from_template_name(
 
 
 def _conversion_from_template_obj(
-    top: gmso.Topology,
+    top: 'gmso.Topology',
     connStr: str,
     conn_typeStr: str,
     potential_template: gmso.core.ParametricPotential,

--- a/gmso/utils/conversions.py
+++ b/gmso/utils/conversions.py
@@ -57,7 +57,7 @@ def _try_sympy_conversions(pot1, pot2):
 
 def _conversion_from_template_name(
     top, connStr: str, conn_typeStr: str, convStr: str
-) -> "Topology":
+) -> gmso.Topology:
     """Use the name of convStr to identify function to convert sympy expressions."""
     conversions_map = {  # these are predefined between template types
         # More functions, and `(to, from)` key pairs added to this dictionary
@@ -101,10 +101,10 @@ def _conversion_from_template_name(
 
 
 def _conversion_from_template_obj(
-    top: "Topology",
+    top: gmso.Topology,
     connStr: str,
     conn_typeStr: str,
-    potential_template: "ParametricPotential",
+    potential_template: gmso.core.ParametricPotential,
 ):
     """Use a passed template object to identify conversion between expressions."""
     for conn in getattr(top, connStr):
@@ -140,12 +140,6 @@ def convert_topology_expressions(top, expressionMap={}):
     # handler for various keys passed to expressionMap for conversion
     for connStr, conv in expressionMap.items():
         possible_connections = ["bond", "angle", "dihedral", "improper"]
-        possible_endings = ["", "s", "_atypes"]
-        possible_connection_labels = [
-            connection + ending
-            for connection in possible_connections
-            for ending in possible_endings
-        ]
         if connStr.lower() in [
             "sites",
             "site",

--- a/gmso/utils/conversions.py
+++ b/gmso/utils/conversions.py
@@ -10,8 +10,11 @@ import unyt as u
 from unyt.dimensions import length, mass, time
 
 import gmso
-from gmso.exceptions import GMSOError
-from gmso.lib.potential_templates import PotentialTemplateLibrary
+from gmso.exceptions import EngineIncompatibilityError, GMSOError
+from gmso.lib.potential_templates import (
+    PotentialTemplate,
+    PotentialTemplateLibrary,
+)
 
 templates = PotentialTemplateLibrary()
 
@@ -52,6 +55,71 @@ def _try_sympy_conversions(pot1, pot2):
     return None
 
 
+def _conversion_from_template_name(
+    top, connStr: str, conn_typeStr: str, convStr: str
+) -> "Topology":
+    """Use the name of convStr to identify function to convert sympy expressions."""
+    conversions_map = {  # these are predefined between template types
+        # More functions, and `(to, from)` key pairs added to this dictionary
+        (
+            "OPLSTorsionPotential",
+            "RyckaertBellemansTorsionPotential",
+        ): convert_opls_to_ryckaert,
+        (
+            "RyckaertBellemansTorsionPotential",
+            "OPLSTorsionPotential",
+        ): convert_ryckaert_to_opls,
+        (
+            "RyckaertBellemansTorsionPotential",
+            "FourierTorsionPotential",
+        ): convert_ryckaert_to_opls,
+    }  # map of all accessible conversions currently supported
+
+    # check all connections with these types for compatibility
+    for conn in getattr(top, connStr):
+        current_expression = getattr(conn, conn_typeStr[:-1])  # strip off extra s
+        # convert it using pre-defined names with conversion functions
+        conversion_from_conversion_toTuple = (current_expression.name, convStr)
+        if (
+            conversion_from_conversion_toTuple in conversions_map
+        ):  # Try mapped conversions
+            new_conn_type = conversions_map.get(conversion_from_conversion_toTuple)(
+                current_expression
+            )
+            setattr(conn, conn_typeStr[:-1], new_conn_type)
+            continue
+
+        # convert it using sympy expression conversion (handles constant multipliers)
+        new_potential = templates[convStr]
+        modified_connection_parametersDict = _try_sympy_conversions(
+            current_expression, new_potential
+        )
+        if modified_connection_parametersDict:  # try sympy conversions
+            current_expression.name = new_potential.name
+            current_expression.expression = new_potential.expression
+            current_expression.parameters.update(modified_connection_parametersDict)
+
+
+def _conversion_from_template_obj(
+    top: "Topology",
+    connStr: str,
+    conn_typeStr: str,
+    potential_template: "ParametricPotential",
+):
+    """Use a passed template object to identify conversion between expressions."""
+    for conn in getattr(top, connStr):
+        current_expression = getattr(conn, conn_typeStr[:-1])  # strip off extra s
+
+        # convert it using sympy expression conversion (handles constant multipliers)
+        modified_connection_parametersDict = _try_sympy_conversions(
+            current_expression, potential_template
+        )
+        if modified_connection_parametersDict:  # try sympy conversions
+            current_expression.name = potential_template.name
+            current_expression.expression = potential_template.expression
+            current_expression.parameters.update(modified_connection_parametersDict)
+
+
 def convert_topology_expressions(top, expressionMap={}):
     """Convert from one parameter form to another.
 
@@ -68,55 +136,46 @@ def convert_topology_expressions(top, expressionMap={}):
     # TODO: Raise errors
 
     # Apply from predefined conversions or easy sympy conversions
-    conversions_map = {
-        (
-            "OPLSTorsionPotential",
-            "RyckaertBellemansTorsionPotential",
-        ): convert_opls_to_ryckaert,
-        (
-            "RyckaertBellemansTorsionPotential",
-            "OPLSTorsionPotential",
-        ): convert_ryckaert_to_opls,
-        (
-            "RyckaertBellemansTorsionPotential",
-            "FourierTorsionPotential",
-        ): convert_ryckaert_to_opls,
-    }  # map of all accessible conversions currently supported
 
-    for conv in expressionMap:
-        # check all connections with these types for compatibility
-        for conn in getattr(top, conv):
-            current_expression = getattr(conn, conv[:-1] + "_type")
-            if (
-                current_expression.name == expressionMap[conv]
-            ):  # check to see if we can skip this one
-                # TODO: Do something instead of just comparing the names
-                continue
+    # handler for various keys passed to expressionMap for conversion
+    for connStr, conv in expressionMap.items():
+        possible_connections = ["bond", "angle", "dihedral", "improper"]
+        possible_endings = ["", "s", "_atypes"]
+        possible_connection_labels = [
+            connection + ending
+            for connection in possible_connections
+            for ending in possible_endings
+        ]
+        if connStr.lower() in [
+            "sites",
+            "site",
+            "atom",
+            "atoms",
+            "atom_types",
+            "atom_type",
+            "atomtype",
+            "atomtypes",
+        ]:
+            # handle renaming type names in relationship to the site or connection
+            conn_typeStr = "atom_types"
+            connStr = "sites"
+        for possible_connection in possible_connections:
+            if possible_connection in connStr.lower():
+                connStr = possible_connection + "s"
+                conn_typeStr = possible_connection + "_types"
+                break
 
-            # convert it using pre-defined conversion functions
-            conversion_from_conversion_toTuple = (
-                current_expression.name,
-                expressionMap[conv],
-            )
-            if (
-                conversion_from_conversion_toTuple in conversions_map
-            ):  # Try mapped conversions
-                new_conn_type = conversions_map.get(conversion_from_conversion_toTuple)(
-                    current_expression
-                )
-                setattr(conn, conv[:-1] + "_type", new_conn_type)
-                continue
-
-            # convert it using sympy expression conversion
-            new_potential = templates[expressionMap[conv]]
-            modified_connection_parametersDict = _try_sympy_conversions(
-                current_expression, new_potential
-            )
-            if modified_connection_parametersDict:  # try sympy conversions
-                current_expression.name = new_potential.name
-                current_expression.expression = new_potential.expression
-                current_expression.parameters.update(modified_connection_parametersDict)
-
+        if isinstance(conv, str):
+            _conversion_from_template_name(top, connStr, conn_typeStr, conv)
+        elif isinstance(conv, PotentialTemplate):
+            _conversion_from_template_obj(top, connStr, conn_typeStr, conv)
+        else:
+            connType = list(getattr(top, conn_typeStr))[0]
+            errormsg = f"""
+            Failed to convert {top} for {connStr} components, with conversion
+            of {connType.name}: {connType} to {conv} as {type(conv)}.
+            """
+            raise EngineIncompatibilityError(errormsg)
     return top
 
 

--- a/gmso/utils/conversions.py
+++ b/gmso/utils/conversions.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import re
 from functools import lru_cache
-from typing import TYPE_CHECKING
 
 import numpy as np
 import symengine
@@ -12,8 +11,7 @@ import sympy
 import unyt as u
 from unyt.dimensions import length, mass, time
 
-if TYPE_CHECKING:
-    import gmso
+import gmso
 
 from gmso.exceptions import EngineIncompatibilityError, GMSOError
 from gmso.lib.potential_templates import (

--- a/gmso/utils/conversions.py
+++ b/gmso/utils/conversions.py
@@ -12,7 +12,6 @@ import unyt as u
 from unyt.dimensions import length, mass, time
 
 import gmso
-
 from gmso.exceptions import EngineIncompatibilityError, GMSOError
 from gmso.lib.potential_templates import (
     PotentialTemplate,
@@ -174,7 +173,9 @@ def convert_topology_expressions(top, expressionMap={}):
             connType = list(getattr(top, conn_typeStr))[0]
             errormsg = f"""
             Failed to convert {top} for {connStr} components, with conversion
-            of {connType.name}: {connType} to {conv} as {type(conv)}.
+            of {connType.name}: Attempted to convert {connType} with style {conv}, which is a {type(conv)}.
+            Please use a template conversion from gmso.lib.potential_templates by passing the name: i.e.
+            HarmonicBondPotential, or by loading a template from gmso.lib.potential_template PotentialTemplateLibrary().
             """
             raise EngineIncompatibilityError(errormsg)
     return top


### PR DESCRIPTION
Add support for modifying template expression via set expression, and testing for handling accepted_potentials as scaled versions of template potentials.
For example:
```
expression1 = "epsilon*((sigma/r)**12 - (sigma/r)**6)" # missing scalar 4
expression2 = "4*epsilon*((sigma/r)**12 - (sigma/r)**6)" # standard lj
```

If expression1 is the atomtype potential, and expression2 is the accepted potential, since it is the same form as the `LennardJonesPotential` in lib/jsons, then this was previously handled okay. 

However, if expression2 was the atomtype potential, and you were trying to write to a format for _accepted_potentials that is expression1, then this was not supported unless we added a .json file for this modified LJ equation. The current PR seeks to allow a list of `accepted_potentials` where the expression can be reset to and therefore the original LJ template form can be used, but then slightly tweaked for each individual writer. Necessary for PR #848.

This PR also adds the ability to automate scalar equation conversions by loading templates from the name, or directly passing a template object. This allows the user to load the template in the writer, modify the equation slightly, then pass that template for conversion. 

Thoughts on ways to regulate the overwriting of the expression? Should we throw errors if the expression cannot be validated with the independent variables? If so, we'll need to explicitly switch the templates over to `_parametric_potentials`, since they are currently treated as `non_parameteric_potentials`

#### TODO:
- [ ] Tests for all new functionality
