### PR TITLE
Add settles_tag

### DIFF
--- a/gmso/tests/files/settles_ref.top
+++ b/gmso/tests/files/settles_ref.top
@@ -11,13 +11,13 @@ opls_112    1        1.01100     0.41700	A        1.00000     0.00000
 
 [ moleculetype ]
 ; name	nrexcl
-WaterTIP3P	3
+water	3
 
 [ atoms ]
 ; nr	type	resnr	residue		atom	cgnr	charge	mass
-1       opls_111    1       WaterTIP3P  O       1       -0.83400    16.00000
-2       opls_112    1       WaterTIP3P  H       1        0.41700     1.01100
-3       opls_112    1       WaterTIP3P  H       1        0.41700     1.01100
+1       opls_111    1     water     O       1       -0.83400    16.00000
+2       opls_112    1     water     H       1        0.41700     1.01100
+3       opls_112    1     water     H       1        0.41700     1.01100
 
 [ settles ] ;Water specific constraint algorithm
 ; OW_idx	funct	doh	dhh
@@ -34,4 +34,4 @@ tip3p
 
 [ molecules ]
 ; molecule	nmols
-WaterTIP3P	1
+water	1


### PR DESCRIPTION
Users may or may not have water in their system, and want to use the special rigid treatment in GROMACS called settles. However, being required to call the molecule "water", meant that the GROMACS residue file also had to have residues name "water", but commonly, water is name "WAT" in many practical cases. 

### PR Summary:

This PR, aims to make an argument to `write_top`, that allows users to purposefully set what residues/molecules they want to match for defining the settles section in a GROMACS Topology file.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
