### PR TITLE
Drop support for hoomd 3, include Hoomd 5 in environment

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -38,7 +38,7 @@ dependencies:
   - pandas
   - symengine
   - python-symengine
-  - hoomd>=4.0,<5.0
+  - hoomd>=4.0
   - importlib_resources
   - pip:
       - git+https://github.com/mosdef-hub/mbuild.git@main

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -13,7 +13,7 @@ import unyt as u
 from unyt.array import allclose_units
 
 from gmso.core.views import PotentialFilters
-from gmso.exceptions import NotYetImplementedWarning
+from gmso.exceptions import EngineIncompatibilityError, NotYetImplementedWarning
 from gmso.lib.potential_templates import PotentialTemplateLibrary
 from gmso.utils.connectivity import generate_pairs_lists
 from gmso.utils.conversions import convert_ryckaert_to_opls
@@ -106,7 +106,9 @@ def to_gsd_snapshot(
     read force field parameters from a Foyer XML file.
     """
     if int(hoomd_version[0]) < 4:
-        raise RuntimeError("GMSO is only compatible with Hoomd-Blue >= 4.0")
+        raise EngineIncompatibilityError(
+            "GMSO is only compatible with Hoomd-Blue >= 4.0"
+        )
     base_units = _validate_base_units(base_units, top, auto_scale)
     gsd_snapshot = gsd.hoomd.Frame()
 
@@ -207,7 +209,9 @@ def to_hoomd_snapshot(
     read force field parameters from a Foyer XML file.
     """
     if int(hoomd_version[0]) < 4:
-        raise RuntimeError("GMSO is only compatible with Hoomd-Blue >= 4.0")
+        raise EngineIncompatibilityError(
+            "GMSO is only compatible with Hoomd-Blue >= 4.0"
+        )
     base_units = _validate_base_units(base_units, top, auto_scale)
     hoomd_snapshot = hoomd.Snapshot()
 
@@ -619,7 +623,9 @@ def to_hoomd_forcefield(
 
     """
     if int(hoomd_version[0]) < 4:
-        raise RuntimeError("GMSO is only compatible with Hoomd-Blue >= 4.0")
+        raise EngineIncompatibilityError(
+            "GMSO is only compatible with Hoomd-Blue >= 4.0"
+        )
     potential_types = _validate_compatibility(top)
     base_units = _validate_base_units(base_units, top, auto_scale, potential_types)
 

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -105,6 +105,8 @@ def to_gsd_snapshot(
     manually in a HOOMD input script. Work on a HOOMD plugin is underway to
     read force field parameters from a Foyer XML file.
     """
+    if int(hoomd_version[0]) < 4:
+        raise RuntimeError("GMSO is only compatible with Hoomd-Blue >= 4.0")
     base_units = _validate_base_units(base_units, top, auto_scale)
     gsd_snapshot = gsd.hoomd.Frame()
 
@@ -156,7 +158,7 @@ def to_hoomd_snapshot(
     parse_special_pairs=True,
     auto_scale=False,
 ):
-    """Create a gsd.snapshot objcet (HOOMD default data format).
+    """Create a gsd.snapshot object (HOOMD default data format).
 
     The gsd snapshot is molecular structure of HOOMD-Blue. This file
     can be used as a starting point for a HOOMD-Blue simulation, for analysis,
@@ -204,6 +206,8 @@ def to_hoomd_snapshot(
     manually in a HOOMD input script. Work on a HOOMD plugin is underway to
     read force field parameters from a Foyer XML file.
     """
+    if int(hoomd_version[0]) < 4:
+        raise RuntimeError("GMSO is only compatible with Hoomd-Blue >= 4.0")
     base_units = _validate_base_units(base_units, top, auto_scale)
     hoomd_snapshot = hoomd.Snapshot()
 
@@ -614,6 +618,8 @@ def to_hoomd_forcefield(
         Based units dictionary utilized during the conversion.
 
     """
+    if int(hoomd_version[0]) < 4:
+        raise RuntimeError("GMSO is only compatible with Hoomd-Blue >= 4.0")
     potential_types = _validate_compatibility(top)
     base_units = _validate_base_units(base_units, top, auto_scale, potential_types)
 

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -57,7 +57,7 @@ def to_gsd_snapshot(
     parse_special_pairs=True,
     auto_scale=False,
 ):
-    """Create a gsd.snapshot objcet (HOOMD v3 default data format).
+    """Create a gsd.snapshot objcet (HOOMD default data format).
 
     The gsd snapshot is molecular structure of HOOMD-Blue. This file
     can be used as a starting point for a HOOMD-Blue simulation, for analysis,
@@ -156,7 +156,7 @@ def to_hoomd_snapshot(
     parse_special_pairs=True,
     auto_scale=False,
 ):
-    """Create a gsd.snapshot objcet (HOOMD v3 default data format).
+    """Create a gsd.snapshot objcet (HOOMD default data format).
 
     The gsd snapshot is molecular structure of HOOMD-Blue. This file
     can be used as a starting point for a HOOMD-Blue simulation, for analysis,

--- a/gmso/tests/test_hoomd.py
+++ b/gmso/tests/test_hoomd.py
@@ -7,6 +7,7 @@ from gmso import ForceField
 from gmso.external import from_mbuild
 from gmso.external.convert_hoomd import to_hoomd_forcefield, to_hoomd_snapshot
 from gmso.parameterization import apply
+from gmso.tests.base_test import BaseTest
 from gmso.tests.utils import get_path
 from gmso.utils.io import has_hoomd, has_mbuild, import_
 
@@ -18,7 +19,7 @@ if has_mbuild:
     mb = import_("mbuild")
 
 
-def run_hoomd_nvt(snapshot, forces, vhoomd=4):
+def run_hoomd_nvt(snapshot, forces):
     cpu = hoomd.device.CPU()
     sim = hoomd.Simulation(device=cpu)
     sim.create_state_from_snapshot(snapshot)
@@ -28,15 +29,10 @@ def run_hoomd_nvt(snapshot, forces, vhoomd=4):
 
     temp = 300 * u.K
     kT = temp.to_equivalent("kJ/mol", "thermal").value
-    if vhoomd == 4:
-        thermostat = hoomd.md.methods.thermostats.MTTK(kT=kT, tau=1.0)
-        nvt = hoomd.md.methods.ConstantVolume(
-            thermostat=thermostat, filter=hoomd.filter.All()
-        )
-    elif vhoomd == 3:
-        nvt = hoomd.md.methods.NVT(kT=kT, filter=hoomd.filter.All(), tau=1.0)
-    else:
-        raise ImportError("Wrong version of hoomd.")
+    thermostat = hoomd.md.methods.thermostats.MTTK(kT=kT, tau=1.0)
+    nvt = hoomd.md.methods.ConstantVolume(
+        thermostat=thermostat, filter=hoomd.filter.All()
+    )
     integrator.methods.append(nvt)
     sim.operations.integrator = integrator
 
@@ -48,10 +44,9 @@ def run_hoomd_nvt(snapshot, forces, vhoomd=4):
     sim.operations.computes.append(thermodynamic_properties)
     return sim
 
-    @pytest.mark.skipif(
-        int(hoomd_version[0]) < 4, reason="Unsupported features in HOOMD 3"
-    )
-    def test_hoomd4_simulation(self):
+
+class TestHoomd(BaseTest):
+    def test_hoomd_simulation(self):
         compound = mb.load("CCC", smiles=True)
         com_box = mb.packing.fill_box(compound, box=[5, 5, 5], n_compounds=2)
         base_units = {
@@ -76,10 +71,7 @@ def run_hoomd_nvt(snapshot, forces, vhoomd=4):
         sim = run_hoomd_nvt(gmso_snapshot, gmso_forces)
         sim.run(100)
 
-    @pytest.mark.skipif(
-        int(hoomd_version[0]) < 4, reason="Deprecated features in HOOMD 4"
-    )
-    def test_hoomd4_simulation_auto_scaled(self):
+    def test_hoomd_simulation_auto_scaled(self):
         compound = mb.load("CCC", smiles=True)
         com_box = mb.packing.fill_box(compound, box=[5, 5, 5], n_compounds=2)
         base_units = {
@@ -107,95 +99,6 @@ def run_hoomd_nvt(snapshot, forces, vhoomd=4):
         )
 
         sim = run_hoomd_nvt(gmso_snapshot, gmso_forces)
-        sim.run(100)
-
-    @pytest.mark.skipif(
-        int(hoomd_version[0]) >= 4, reason="Deprecated features in HOOMD 4"
-    )
-    def test_hoomd3_simulation(self):
-        compound = mb.load("CCC", smiles=True)
-        com_box = mb.packing.fill_box(compound, box=[5, 5, 5], n_compounds=2)
-        base_units = {
-            "mass": u.g / u.mol,
-            "length": u.nm,
-            "energy": u.kJ / u.mol,
-        }
-
-        top = from_mbuild(com_box)
-        top.identify_connections()
-        oplsaa = ffutils.FoyerFFs().load("oplsaa").to_gmso_ff()
-        top = apply(top, oplsaa, remove_untyped=True)
-
-        gmso_snapshot, snapshot_base_units = to_hoomd_snapshot(
-            top, base_units=base_units
-        )
-        gmso_forces, forces_base_units = to_hoomd_forcefield(
-            top,
-            r_cut=1.4,
-            base_units=base_units,
-            pppm_kwargs={"resolution": (64, 64, 64), "order": 7},
-        )
-
-        sim = run_hoomd_nvt(gmso_snapshot, gmso_forces, vhoomd=3)
-        sim.run(100)
-
-    @pytest.mark.skipif(
-        int(hoomd_version[0]) >= 4, reason="Deprecated features in HOOMD 4"
-    )
-    def test_hoomd3_simulation_auto_scaled(self):
-        compound = mb.load("CCC", smiles=True)
-        com_box = mb.packing.fill_box(compound, box=[5, 5, 5], n_compounds=2)
-        base_units = {
-            "mass": u.g / u.mol,
-            "length": u.nm,
-            "energy": u.kJ / u.mol,
-        }
-
-        top = from_mbuild(com_box)
-        top.identify_connections()
-        oplsaa = ffutils.FoyerFFs().load("oplsaa").to_gmso_ff()
-        top = apply(top, oplsaa, remove_untyped=True)
-
-        gmso_snapshot, snapshot_base_units = to_hoomd_snapshot(
-            top,
-            base_units=base_units,
-            auto_scale=True,
-        )
-        gmso_forces, forces_base_units = to_hoomd_forcefield(
-            top,
-            r_cut=1.4,
-            base_units=base_units,
-            pppm_kwargs={"resolution": (64, 64, 64), "order": 7},
-            auto_scale=True,
-        )
-
-        integrator_forces = list()
-        for cat in gmso_forces:
-            for force in gmso_forces[cat]:
-                integrator_forces.append(force)
-
-        temp = 300 * u.K
-        kT = temp.to_equivalent("kJ/mol", "thermal").value
-
-        cpu = hoomd.device.CPU()
-        sim = hoomd.Simulation(device=cpu)
-        sim.create_state_from_snapshot(gmso_snapshot)
-
-        integrator = hoomd.md.Integrator(dt=0.001)
-        # cell = hoomd.md.nlist.Cell(buffer=0.4)
-        integrator.forces = integrator_forces
-        # integrator.forces = mb_forcefield
-
-        nvt = hoomd.md.methods.NVT(kT=kT, filter=hoomd.filter.All(), tau=1.0)
-        integrator.methods.append(nvt)
-        sim.operations.integrator = integrator
-
-        sim.state.thermalize_particle_momenta(filter=hoomd.filter.All(), kT=kT)
-        thermodynamic_properties = hoomd.md.compute.ThermodynamicQuantities(
-            filter=hoomd.filter.All()
-        )
-
-        sim.operations.computes.append(thermodynamic_properties)
         sim.run(100)
 
     def test_diff_base_units(self):


### PR DESCRIPTION
### PR Summary:

Hoomd-Blue 5 was released a couple of months ago. We have a few checks in `convert_hoomd.py` that juggle between functionality of Hoomd 3 and 4. I think it's time to drop support for Hoomd 3. As far as the writers in `convert_hoomd` are concerned, there is really no difference between all versions of Hoomd >= 4.5, so supporting both versions is easy enough, but we'll still have one conditional in place for Hoomd 4 - 4.4 for the time being.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
