### PR TITLE
Sympy Numpy expressions

### DIFF
--- a/gmso/tests/files/ff-example2.xml
+++ b/gmso/tests/files/ff-example2.xml
@@ -1,0 +1,98 @@
+<ForceField version="0.0.2" name="NumpyExpressions">
+    <FFMetaData electrostatics14Scale="0.5" nonBonded14Scale="0.67" combiningRule="lorentz">
+        <Units energy="kb" distance="nm" mass="amu" charge="coulomb"/>
+    </FFMetaData>
+    <AtomTypes expression="(A*cos(-B/r) - C/r**6)+norm(C)">
+        <ParametersUnitDef parameter="A" unit="kcal/mol"/>
+        <ParametersUnitDef parameter="B" unit="nm"/>
+        <ParametersUnitDef parameter="C" unit="kcal/mol*nm**6"/>
+        <AtomType name="Ar" element="Ar" charge="0.0" atomclass="Ar" mass="39.948" definition="Ar" description="Argon atom">
+            <Parameters>
+                <Parameter name="A" value="0.1"/>
+                <Parameter name="B" value="4.0"/>
+                <Parameter name="C" value="0.5"/>
+            </Parameters>
+        </AtomType>
+        <AtomType name="Xe" element="Xe" atomclass="Xe" charge="0.0" mass="131.293" definition="Xe" description="Xenon atom">
+            <Parameters>
+                <Parameter name="A" value="0.2"/>
+                <Parameter name="B" value="5.0"/>
+                <Parameter name="C" value="0.3"/>
+            </Parameters>
+        </AtomType>
+        <AtomType name="Li" element="Li" charge="1.0" mass="6.941" definition="Li" description="Lithium atom">
+            <Parameters>
+                <Parameter name="A" value="0.2"/>
+                <Parameter name="B" value="5.0"/>
+                <Parameter name="C" value="0.3"/>
+            </Parameters>
+        </AtomType>
+    </AtomTypes>
+    <BondTypes expression="0.5 * k * (r-r_eq)**2/tan(1)">
+        <ParametersUnitDef parameter="r_eq" unit="nm"/>
+        <ParametersUnitDef parameter="k" unit="kJ/mol"/>
+        <BondType name="BondType1" type1='Ar' type2='Ar'>
+            <Parameters>
+                <Parameter name='r_eq' value="10.0"/>
+                <Parameter name='k' value="10000"/>
+            </Parameters>
+        </BondType>
+        <BondType name="BondType2" type1='Xe' type2="Xe">
+            <Parameters>
+                <Parameter name='r_eq' value="10"/>
+                <Parameter name='k' value="20000"/>
+            </Parameters>
+        </BondType>
+    </BondTypes>
+    <AngleTypes expression="dot(z,r) * (r-r_eq)**2">
+        <ParametersUnitDef parameter="r_eq" unit="nm"/>
+        <ParametersUnitDef parameter="z" unit="kJ/mol"/>
+        <AngleType name="AngleType1" type1='Ar' type2='Ar' type3="Ar">
+            <Parameters>
+                <Parameter name='r_eq' value="10.0"/>
+                <Parameter name='z' value="100"/>
+            </Parameters>
+        </AngleType>
+        <AngleType name="AngleType2" class1='Xe' class2="Xe" class3="Xe">
+            <Parameters>
+                <Parameter name='r_eq' value="10"/>
+                <Parameter name='z' value="20"/>
+            </Parameters>
+        </AngleType>
+    </AngleTypes>
+
+    <DihedralTypes expression="0.5 * z * (r-r_eq)**2">
+        <ParametersUnitDef parameter="r_eq" unit="nm"/>
+        <ParametersUnitDef parameter="z" unit="kJ/mol"/>
+        <DihedralType name="DihedralType1" class1='Ar' class2='Ar' class3="Ar" class4="Ar">
+            <Parameters>
+                <Parameter name='r_eq' value="10.0"/>
+                <Parameter name='z' value="100"/>
+            </Parameters>
+        </DihedralType>
+        <ImproperType name="ImproperType1" type1='Xe' type2="Xe" type3="Xe" type4="Xe">
+            <Parameters>
+                <Parameter name='r_eq' value="10"/>
+                <Parameter name='z' value="20"/>
+            </Parameters>
+        </ImproperType>
+        <DihedralType name="DihedralType2" class1='Xe' class2="Xe" class3="Xe" class4="Xe">
+            <Parameters>
+                <Parameter name='r_eq' value="10"/>
+                <Parameter name='z' value="20"/>
+            </Parameters>
+        </DihedralType>
+    </DihedralTypes>
+
+  <PairPotentialTypes expression="cos(4*k) * ((sigma/r)**12 - (sigma/r)**6)">
+    <ParametersUnitDef parameter="sigma" unit="nm"/>
+    <ParametersUnitDef parameter="k" unit="kJ/mol"/>
+    <PairPotentialType name="PairPotentialType-LJ-1" type1="Xe" type2="Xe">
+        <Parameters>
+            <Parameter name="k" value="0.1"/>
+            <Parameter name="sigma" value="10"/>
+        </Parameters>
+    </PairPotentialType>
+  </PairPotentialTypes>
+
+</ForceField>

--- a/gmso/tests/test_atom_type.py
+++ b/gmso/tests/test_atom_type.py
@@ -399,3 +399,29 @@ class TestAtomType(BaseTest):
             if id(value) == id(cloned):
                 assert isinstance(value, str)
                 assert isinstance(cloned, str)
+
+    def test_numpy_expression_atom_type(self, charge, mass):
+        from sympy import sympify
+
+        new_type = AtomType(
+            name="numpy_expression",
+            charge=charge,
+            mass=mass,
+            expression="norm(ji) + x * 1000 + sin(theta) * 180 / pi",
+            parameters={
+                "x": 1 * u.nm,
+                "theta": 60 * u.Unit("degree"),
+            },
+            independent_variables={"ji"},
+        )
+        assert new_type.name == "numpy_expression"
+        assert_allclose_units(new_type.charge, charge, rtol=1e-5, atol=1e-8)
+        assert_allclose_units(new_type.parameters["x"], 1 * u.nm, rtol=1e-5, atol=1e-8)
+        assert_allclose_units(
+            new_type.parameters["theta"],
+            60 * u.Unit("degree"),
+            rtol=1e-5,
+            atol=1e-8,
+        )
+        assert_allclose_units(new_type.mass, mass, rtol=1e-5, atol=1e-8)
+        assert new_type.expression == sympify("norm(ji) + x * 1000 + sin(theta)*180/pi")

--- a/gmso/tests/test_forcefield.py
+++ b/gmso/tests/test_forcefield.py
@@ -27,6 +27,10 @@ class TestForceField(BaseTest):
         return ForceField(get_path("ff-example1.xml"))
 
     @pytest.fixture
+    def ff_numpy(self):
+        return ForceField(get_path("ff-example2.xml"))
+
+    @pytest.fixture
     def opls_ethane_foyer(self):
         return ForceField(get_path(filename=get_path("oplsaa-ethane_foyer.xml")))
 
@@ -609,3 +613,76 @@ class TestForceField(BaseTest):
 
         with pytest.raises(GMSOError):
             opls_ethane_foyer.to_xml("test_xml_writer.xml", backend="bogus")
+
+    def test_ff_numpy(self, ff_numpy):
+        assert len(ff_numpy.atom_types) == 3
+
+        assert sympify("r") in ff_numpy.atom_types["Ar"].independent_variables
+        assert ff_numpy.atom_types["Ar"].parameters["A"] == u.unyt_quantity(
+            0.1, u.kcal / u.mol
+        )
+        assert ff_numpy.atom_types["Ar"].parameters["B"] == u.unyt_quantity(4.0, u.nm)
+        assert ff_numpy.atom_types["Ar"].parameters["C"] == u.unyt_quantity(
+            0.5, u.kcal / u.mol * u.nm**6
+        )
+        assert ff_numpy.atom_types["Ar"].mass == u.unyt_quantity(39.948, u.amu)
+        assert ff_numpy.atom_types["Ar"].charge == u.unyt_quantity(0.0, u.coulomb)
+        assert ff_numpy.atom_types["Ar"].description == "Argon atom"
+        assert ff_numpy.atom_types["Ar"].definition == "Ar"
+        assert ff_numpy.atom_types["Ar"].expression == sympify(
+            "(A*cos(-B/r) - C/r**6)+norm(C)"
+        )
+
+        assert sympify("r") in ff_numpy.atom_types["Xe"].independent_variables
+        assert "A" in ff_numpy.atom_types["Xe"].parameters
+        assert ff_numpy.atom_types["Xe"].parameters["A"] == u.unyt_quantity(
+            0.2, u.kcal / u.mol
+        )
+        assert ff_numpy.atom_types["Xe"].parameters["B"] == u.unyt_quantity(5.0, u.nm)
+        assert ff_numpy.atom_types["Xe"].parameters["C"] == u.unyt_quantity(
+            0.3, u.kcal / u.mol * u.nm**6
+        )
+        assert ff_numpy.atom_types["Xe"].mass == u.unyt_quantity(131.293, u.amu)
+        assert ff_numpy.atom_types["Xe"].charge == u.unyt_quantity(0.0, u.coulomb)
+        assert ff_numpy.atom_types["Xe"].description == "Xenon atom"
+        assert ff_numpy.atom_types["Xe"].definition == "Xe"
+        assert ff_numpy.atom_types["Xe"].expression == sympify(
+            "(A*cos(-B/r) - C/r**6)+norm(C)"
+        )
+
+        assert ff_numpy.atom_types["Li"].charge == u.unyt_quantity(1.0, u.coulomb)
+
+        assert len(ff_numpy.bond_types) == 2
+        assert sympify("r") in ff_numpy.bond_types["Ar~Ar"].independent_variables
+        assert ff_numpy.bond_types["Ar~Ar"].parameters["r_eq"] == u.unyt_quantity(
+            10.0, u.nm
+        )
+        assert ff_numpy.bond_types["Ar~Ar"].parameters["k"] == u.unyt_quantity(
+            10000, u.kJ / u.mol
+        )
+        assert ff_numpy.bond_types["Ar~Ar"].member_types == ("Ar", "Ar")
+        assert ff_numpy.bond_types["Ar~Ar"].expression == sympify(
+            "0.5 * k * (r-r_eq)**2/tan(1)"
+        )
+
+        assert len(ff_numpy.angle_types) == 2
+        assert sympify("r") in ff_numpy.angle_types["Ar~Ar~Ar"].independent_variables
+        assert ff_numpy.angle_types["Ar~Ar~Ar"].parameters["r_eq"] == u.unyt_quantity(
+            10.0, u.nm
+        )
+        assert ff_numpy.angle_types["Ar~Ar~Ar"].parameters["z"] == u.unyt_quantity(
+            100, u.kJ / u.mol
+        )
+        assert ff_numpy.angle_types["Ar~Ar~Ar"].member_types == ("Ar", "Ar", "Ar")
+
+        assert sympify("r") in ff_numpy.angle_types["Xe~Xe~Xe"].independent_variables
+        assert ff_numpy.angle_types["Xe~Xe~Xe"].parameters["r_eq"] == u.unyt_quantity(
+            10.0, u.nm
+        )
+        assert ff_numpy.angle_types["Xe~Xe~Xe"].parameters["z"] == u.unyt_quantity(
+            20, u.kJ / u.mol
+        )
+        assert ff_numpy.angle_types["Xe~Xe~Xe"].member_classes == ("Xe", "Xe", "Xe")
+        assert ff_numpy.angle_types["Xe~Xe~Xe"].expression == sympify(
+            "dot(z,r) * (r-r_eq)**2"
+        )

--- a/gmso/tests/test_potential.py
+++ b/gmso/tests/test_potential.py
@@ -294,3 +294,20 @@ class TestPotential(BaseTest):
         for connection_type in labelsList:
             conn = list(getattr(top, connection_type)())[0]
             assert sort_by_classes(conn) == sort_by_types(conn)
+
+    def test_numpy_potential(self):
+        new_potential = ParametricPotential(
+            name="numpy function",
+            expression="a*norm(x)+sin(b)",
+            parameters={"a": 1.0 * u.g, "b": 1.0 * u.m},
+            independent_variables={"x"},
+        )
+        assert new_potential.name == "numpy function"
+        assert new_potential.expression == sympy.sympify("a*norm(x)+sin(b)")
+        assert_allclose_units(
+            new_potential.parameters["a"], 1.0 * u.g, rtol=1e-5, atol=1e-8
+        )
+        assert_allclose_units(
+            new_potential.parameters["b"], 1.0 * u.m, rtol=1e-5, atol=1e-8
+        )
+        assert new_potential.independent_variables == {sympy.symbols("x")}


### PR DESCRIPTION
We have been running into the need to support more complex functional forms that have numpy matrix expressions, in them. To validate the use of this, I added a test forcefield and some more tests to parse that these are handled as expected.

### PR Summary:
This doesn't change any functionality, it just verifies that sympy will allow us to place these types of functions in the expression for a forcefield.

To note, we can use lambdify to actually evaluate these functions with numpy arrays, in case we need to do any of this during the writing steps or to evaluate the output of the function. Some example code is shown below.
```python
import numpy as np
from sympy import symbols, sympify
from sympy.utilities.lambdify import lambdify

# Define the expression
expression = "ri + sin(b)*(rj-ri+a*(rk-rj)) / norm(b)"

# Define the custom functions with their corresponding numpy functions
custom_functions = {'sin': np.sin, "norm": np.linalg.norm}

# Define the variables as symbols
ri, rj, rk, a, b = symbols('ri rj rk a b')

# Lambdify the expression to convert it into a callable function
# that evaluates the expression for given values for ri, rj, rk, a, and b
func = lambdify([ri, rj, rk, a, b], expression, modules={'numpy': np, **custom_functions})

# Now func can be called with NumPy arrays or any other compatible types
# For example, to evaluate the function for specific values
ri_value = np.array([1, 0, 0])
rj_value = np.array([0, 1, 0])
rk_value = np.array([0, 0, 1])
a_value = 1
b_value = np.pi / 4  # 45 degrees in radians.

# Call the function with the specified values
result = func(ri_value, rj_value, rk_value, a_value, b_value)
print(result)
```

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
