### PR TITLE
create virtual site test and pass tip4p finding types

### DIFF
--- a/gmso/core/virtual_type.py
+++ b/gmso/core/virtual_type.py
@@ -300,12 +300,12 @@ class VirtualType(GMSOBase):
             and self.charge == other.charge
         )
 
-    def clone(self):
+    def clone(self, fast_copy=False):
         """Clone this VirtualType."""
         return VirtualType(
             name=str(self.name),
-            virtual_position=self.virtual_position.clone(),
-            virtual_potential=self.virtual_potential.clone(),
+            virtual_position=self.virtual_position.clone(fast_copy),
+            virtual_potential=self.virtual_potential.clone(fast_copy),
             member_types=self.member_types,
             member_classes=self.member_classes,
             charge=self.charge,

--- a/gmso/parameterization/utils.py
+++ b/gmso/parameterization/utils.py
@@ -5,6 +5,7 @@ from gmso.core.atom import Atom
 from gmso.core.bond import Bond
 from gmso.core.dihedral import Dihedral
 from gmso.core.improper import Improper
+from gmso.core.virtual_site import VirtualSite
 
 POTENTIAL_GROUPS = {
     Bond: "bond_type",
@@ -12,4 +13,5 @@ POTENTIAL_GROUPS = {
     Dihedral: "dihedral_type",
     Improper: "improper_type",
     Atom: "atom_type",
+    VirtualSite: "virtual_type",
 }

--- a/gmso/tests/parameterization/test_virtual_site_parameterization.py
+++ b/gmso/tests/parameterization/test_virtual_site_parameterization.py
@@ -1,0 +1,37 @@
+import unyt as u
+from sympy import sympify
+
+from gmso.core.forcefield import ForceField
+from gmso.core.topology import Topology
+from gmso.parameterization.parameterize import apply
+from gmso.tests.parameterization.parameterization_base_test import (
+    ParameterizationBaseTest,
+)
+from gmso.tests.utils import get_path
+from gmso.utils.io import get_fn
+
+
+class TestTIP4PGMSO(ParameterizationBaseTest):
+    def test_tip4p_files(self):
+        mol2_file = get_path("tip3p.mol2")
+        gmso_top = Topology.load(mol2_file)
+        ff = ForceField(get_fn("gmso_xmls/test_ffstyles/tip4p_2005.xml"))
+        apply(
+            gmso_top,
+            ff,
+            speedup_by_molgraph=False,
+            identify_connections=True,
+        )
+        assert len(gmso_top.virtual_sites) == 1
+        vtype = gmso_top.virtual_sites[0].virtual_type
+        assert ("HW", "OW", "HW") == vtype.member_classes
+        assert vtype.virtual_potential.expression == sympify(
+            "4*epsilon*(-sigma**6/r**6 + sigma**12/r**12)"
+        )
+        assert vtype.virtual_potential.parameters["epsilon"] == 0.0 * u.kJ / u.mol
+        assert vtype.virtual_potential.parameters["sigma"] == 0.0 * u.nm
+        assert vtype.virtual_position.expression == sympify(
+            "ri + b*(rj-ri+a*(rk-rj))/norm(rj-ri+a*(rk-rj))"
+        )
+        assert vtype.virtual_position.parameters["a"] == 0.5 * u.dimensionless
+        assert vtype.virtual_position.parameters["b"] == 0.15 * u.dimensionless

--- a/gmso/utils/files/gmso_xmls/test_ffstyles/tip4p_2005.xml
+++ b/gmso/utils/files/gmso_xmls/test_ffstyles/tip4p_2005.xml
@@ -48,7 +48,7 @@
       <ParametersUnitDef parameter="epsilon" unit="kJ/mol"/>
       <ParametersUnitDef parameter="sigma" unit="nm"/>
     </Potential>
-    <VirtualSiteType name="VirtualSiteType-3fd" type1="opls_112" type2="opls_111" type3="opls_112">
+    <VirtualSiteType name="VirtualSiteType-3fd" class1="HW" class2="OW" class3="HW">
       <Position>
         <Parameters>
           <Parameter name="a" value="0.5"/>


### PR DESCRIPTION
### PR Summary:
This automates the application of virtual_sites and virtual_types from a forcefield. Uses networkx graph isomorphism checks to check for the atomtypes or atomclasses in the `VirtualSiteType` tag in the forcefield xml. These are checked, bonded in the order class1, class2, class3, ... etc. as a linear graph in the full Topology.

### PR Checklist
------------
 - [ ] Core functionality
 - [ ] Raise missing/strange behavior Errors
 - [ ] Set gmso.parameterization.apply arguments with respect to virtual_sites
 - [ ] speedup identification across many molecules
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
