### PR TITLE
Drop `importlib_resources` dependency

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -39,7 +39,6 @@ dependencies:
   - symengine
   - python-symengine
   - hoomd>=4.0
-  - importlib_resources
   - pip:
       - git+https://github.com/mosdef-hub/mbuild.git@main
       - git+https://github.com/mosdef-hub/foyer.git@main

--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,3 @@ dependencies:
   - forcefield-utilities>=0.2.1
   - symengine
   - python-symengine
-  - importlib_resources


### PR DESCRIPTION
### PR Summary:

This PR drops `importlib_resources` from tooling. It's not used in the source code and is obsolete with Python 3.10+

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
