### PR TITLE
Fix invalid options in the  docstrings for `ignore_params` in `apply()`

### DIFF
--- a/gmso/parameterization/parameterize.py
+++ b/gmso/parameterization/parameterize.py
@@ -73,7 +73,7 @@ def apply(
         this should be changed to False if further modification of expressions are
         necessary post parameterization.
     """
-    ignore_params = set([option.lower() for option in ignore_params])
+    ignore_params = set([option.lower().rstrip("s") for option in ignore_params])
     config = TopologyParameterizationConfig.model_validate(
         dict(
             match_ff_by=match_ff_by,


### PR DESCRIPTION
### PR Summary:

The doc strings say options for `ignore_params` are bonds, angles, dihedrals, impropers, but this only works if they are in their singular form (bond, angle, dihedral, improper). This PR updates the doc strings to match actual behavior. We could also make it so either singular or plural forms work.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
