### PR TITLE
Replace setuptools in GMSO

### DIFF
--- a/gmso/core/element.py
+++ b/gmso/core/element.py
@@ -5,9 +5,9 @@ import warnings
 from re import sub
 from typing import Union
 
+import importlib_resources
 import numpy as np
 import unyt as u
-import importlib_resources
 from pydantic import ConfigDict, Field, field_serializer
 
 from gmso.abc.gmso_base import GMSOBase
@@ -337,7 +337,7 @@ def element_by_atom_type(atom_type, verbose=False):
 
 
 # Get the JSON file from ele package for a standard representation
-fn = importlib_resources.files('ele') / "lib/elements.json"
+fn = importlib_resources.files("ele") / "lib/elements.json"
 with importlib_resources.as_file(fn) as path:
     elements_dict = None
     elements = []

--- a/gmso/core/element.py
+++ b/gmso/core/element.py
@@ -7,7 +7,7 @@ from typing import Union
 
 import numpy as np
 import unyt as u
-from pkg_resources import resource_filename
+import importlib_resources
 from pydantic import ConfigDict, Field, field_serializer
 
 from gmso.abc.gmso_base import GMSOBase
@@ -337,12 +337,13 @@ def element_by_atom_type(atom_type, verbose=False):
 
 
 # Get the JSON file from ele package for a standard representation
-elements_json_loc = resource_filename("ele", "lib/elements.json")
-elements_dict = None
-elements = []
-with open(elements_json_loc, "r") as el_json_file:
-    elements_dict = json.load(el_json_file)
-    elements_dict = {int(key): value for key, value in elements_dict.items()}
+fn = importlib_resources.files('ele') / "lib/elements.json"
+with importlib_resources.as_file(fn) as path:
+    elements_dict = None
+    elements = []
+    with open(path, "r") as el_json_file:
+        elements_dict = json.load(el_json_file)
+        elements_dict = {int(key): value for key, value in elements_dict.items()}
 
 
 for atom_number, element_properties in elements_dict.items():

--- a/gmso/tests/parameterization/test_opls_gmso.py
+++ b/gmso/tests/parameterization/test_opls_gmso.py
@@ -1,9 +1,8 @@
-import glob
 from pathlib import Path
 
 import parmed as pmd
 import pytest
-from pkg_resources import resource_filename
+import importlib_resources
 
 from gmso.external.convert_parmed import from_parmed
 from gmso.parameterization.parameterize import apply
@@ -13,11 +12,12 @@ from gmso.tests.parameterization.parameterization_base_test import (
 
 
 def get_foyer_opls_test_dirs():
-    all_dirs = glob.glob(resource_filename("foyer", "opls_validation") + "/*")
-    with open(
-        resource_filename("foyer", "tests/implemented_opls_tests.txt")
-    ) as impl_file:
-        correctly_implemented = set(impl_file.read().strip().split("\n"))
+    fn = importlib_resources.files('foyer') / "opls_validation"
+    all_dirs = fn.glob("*")
+    tests_fn = importlib_resources.files('foyer') / "tests/implemented_opls_tests.txt"
+    with importlib_resources.as_file(tests_fn) as tempPath:
+        with open(tempPath) as impl_file:
+            correctly_implemented = set(impl_file.read().strip().split("\n"))
 
     parent_dirs = map(Path, all_dirs)
     parent_dirs = list(

--- a/gmso/tests/parameterization/test_opls_gmso.py
+++ b/gmso/tests/parameterization/test_opls_gmso.py
@@ -1,8 +1,8 @@
 from pathlib import Path
 
+import importlib_resources
 import parmed as pmd
 import pytest
-import importlib_resources
 
 from gmso.external.convert_parmed import from_parmed
 from gmso.parameterization.parameterize import apply
@@ -12,9 +12,9 @@ from gmso.tests.parameterization.parameterization_base_test import (
 
 
 def get_foyer_opls_test_dirs():
-    fn = importlib_resources.files('foyer') / "opls_validation"
+    fn = importlib_resources.files("foyer") / "opls_validation"
     all_dirs = fn.glob("*")
-    tests_fn = importlib_resources.files('foyer') / "tests/implemented_opls_tests.txt"
+    tests_fn = importlib_resources.files("foyer") / "tests/implemented_opls_tests.txt"
     with importlib_resources.as_file(tests_fn) as tempPath:
         with open(tempPath) as impl_file:
             correctly_implemented = set(impl_file.read().strip().split("\n"))

--- a/gmso/tests/parameterization/test_trappe_gmso.py
+++ b/gmso/tests/parameterization/test_trappe_gmso.py
@@ -1,8 +1,7 @@
-import glob
 from pathlib import Path
 
 import pytest
-from pkg_resources import resource_filename
+import importlib_resources
 
 from gmso.core.topology import Topology
 from gmso.external.convert_parmed import from_parmed, to_parmed
@@ -13,10 +12,10 @@ from gmso.tests.parameterization.parameterization_base_test import (
 
 
 def get_foyer_trappe_test_dirs():
-    all_dirs = glob.glob(resource_filename("foyer", "trappe_validation") + "/*")
-    with open(
-        resource_filename("foyer", "tests/implemented_trappe_tests.txt")
-    ) as impl_file:
+    fn = importlib_resources.files('foyer') / "trapped_validation"
+    all_dirs = fn.glob("*")
+    tests_fn = importlib_resources.files('foyer') / "tests/implemented_trappe_tests.txt"
+    with open(tests_fn) as impl_file:
         correctly_implemented = set(impl_file.read().strip().split("\n"))
 
     parent_dirs = map(Path, all_dirs)

--- a/gmso/tests/parameterization/test_trappe_gmso.py
+++ b/gmso/tests/parameterization/test_trappe_gmso.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-import pytest
 import importlib_resources
+import pytest
 
 from gmso.core.topology import Topology
 from gmso.external.convert_parmed import from_parmed, to_parmed
@@ -12,9 +12,9 @@ from gmso.tests.parameterization.parameterization_base_test import (
 
 
 def get_foyer_trappe_test_dirs():
-    fn = importlib_resources.files('foyer') / "trapped_validation"
+    fn = importlib_resources.files("foyer") / "trapped_validation"
     all_dirs = fn.glob("*")
-    tests_fn = importlib_resources.files('foyer') / "tests/implemented_trappe_tests.txt"
+    tests_fn = importlib_resources.files("foyer") / "tests/implemented_trappe_tests.txt"
     with open(tests_fn) as impl_file:
         correctly_implemented = set(impl_file.read().strip().split("\n"))
 

--- a/gmso/utils/io.py
+++ b/gmso/utils/io.py
@@ -50,7 +50,7 @@ def get_fn(filename):
     fn : str
         Full path to filename
     """
-    fn = importlib_resources.files('gmso') / "utils/files" / filename
+    fn = importlib_resources.files("gmso") / "utils/files" / filename
     if not os.path.exists(fn):
         raise IOError("Sorry! {} does not exists.".format(fn))
     return str(fn)

--- a/gmso/utils/io.py
+++ b/gmso/utils/io.py
@@ -7,7 +7,7 @@ import sys
 import textwrap
 from unittest import SkipTest
 
-from pkg_resources import resource_filename
+import importlib_resources
 
 MESSAGES = dict()
 MESSAGES["matplotlib.pyplot"] = """
@@ -50,10 +50,10 @@ def get_fn(filename):
     fn : str
         Full path to filename
     """
-    fn = resource_filename("gmso", os.path.join("utils", "files", filename))
+    fn = importlib_resources.files('gmso') / "utils/files" / filename
     if not os.path.exists(fn):
         raise IOError("Sorry! {} does not exists.".format(fn))
-    return fn
+    return str(fn)
 
 
 def import_(module):


### PR DESCRIPTION
### PR Summary:
Removal of setuptools in favor for migration to importlib_resources for handling package files and module Path identification. [Here is some documentation](https://importlib-resources.readthedocs.io/en/latest/migration.html) of the migration changes.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
