### PR TITLE
Remove deprecated newshape parameter from some numpy methods.

### DIFF
--- a/gmso/abc/abstract_site.py
+++ b/gmso/abc/abstract_site.py
@@ -291,7 +291,7 @@ class Site(GMSOBase):
             logger.info("Positions are assumed to be in nm")
 
         try:
-            position = np.reshape(position, newshape=(3,), order="C")
+            position = np.reshape(position, shape=(3,), order="C")
             if position.units != u.dimensionless:
                 position.convert_to_units(u.nm)
         except ValueError:

--- a/gmso/core/box.py
+++ b/gmso/core/box.py
@@ -22,7 +22,7 @@ def _validate_lengths(lengths):
     input_unit = lengths.units
 
     lengths = np.asarray(lengths, dtype=float, order="C")
-    np.reshape(lengths, newshape=(3,), order="C")
+    np.reshape(lengths, shape=(3,), order="C")
 
     lengths *= input_unit
     if input_unit != u.Unit("dimensionless"):
@@ -71,7 +71,7 @@ def _validate_angles(angles):
         input_unit = angles.units
 
         angles = np.asarray(angles, dtype=float, order="C")
-        np.reshape(angles, newshape=(3, 1), order="C")
+        np.reshape(angles, shape=(3, 1), order="C")
 
         angles *= input_unit
         angles.convert_to_units(u.degree)


### PR DESCRIPTION
### PR Summary:

I thought these were removed in #38 but it looks like we missed a couple instances.

See https://numpy.org/doc/stable/reference/generated/numpy.reshape.html. The parameter is now `shape` instead of `newshape`

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
