### PR TITLE
Replace `importlib_resources` with  built in importlib library

### DIFF
--- a/gmso/core/element.py
+++ b/gmso/core/element.py
@@ -2,10 +2,10 @@
 
 import json
 import logging
+from importlib.resources import as_file, files
 from re import sub
 from typing import Union
 
-import importlib_resources
 import numpy as np
 import unyt as u
 from pydantic import ConfigDict, Field, field_serializer
@@ -339,8 +339,8 @@ def element_by_atom_type(atom_type, verbose=False):
 
 
 # Get the JSON file from ele package for a standard representation
-fn = importlib_resources.files("ele") / "lib/elements.json"
-with importlib_resources.as_file(fn) as path:
+fn = files("ele") / "lib/elements.json"
+with as_file(fn) as path:
     elements_dict = None
     elements = []
     with open(path, "r") as el_json_file:

--- a/gmso/tests/parameterization/test_opls_gmso.py
+++ b/gmso/tests/parameterization/test_opls_gmso.py
@@ -1,6 +1,6 @@
+from importlib.resources import as_file, files
 from pathlib import Path
 
-import importlib_resources
 import parmed as pmd
 import pytest
 
@@ -12,10 +12,10 @@ from gmso.tests.parameterization.parameterization_base_test import (
 
 
 def get_foyer_opls_test_dirs():
-    fn = importlib_resources.files("foyer") / "opls_validation"
+    fn = files("foyer") / "opls_validation"
     all_dirs = fn.glob("*")
-    tests_fn = importlib_resources.files("foyer") / "tests/implemented_opls_tests.txt"
-    with importlib_resources.as_file(tests_fn) as tempPath:
+    tests_fn = files("foyer") / "tests/implemented_opls_tests.txt"
+    with as_file(tests_fn) as tempPath:
         with open(tempPath) as impl_file:
             correctly_implemented = set(impl_file.read().strip().split("\n"))
 

--- a/gmso/tests/parameterization/test_trappe_gmso.py
+++ b/gmso/tests/parameterization/test_trappe_gmso.py
@@ -1,6 +1,6 @@
+from importlib.resources import files
 from pathlib import Path
 
-import importlib_resources
 import pytest
 
 from gmso.core.topology import Topology
@@ -12,9 +12,9 @@ from gmso.tests.parameterization.parameterization_base_test import (
 
 
 def get_foyer_trappe_test_dirs():
-    fn = importlib_resources.files("foyer") / "trapped_validation"
+    fn = files("foyer") / "trapped_validation"
     all_dirs = fn.glob("*")
-    tests_fn = importlib_resources.files("foyer") / "tests/implemented_trappe_tests.txt"
+    tests_fn = files("foyer") / "tests/implemented_trappe_tests.txt"
     with open(tests_fn) as impl_file:
         correctly_implemented = set(impl_file.read().strip().split("\n"))
 

--- a/gmso/utils/io.py
+++ b/gmso/utils/io.py
@@ -5,9 +5,8 @@ import inspect
 import os
 import sys
 import textwrap
+from importlib.resources import files
 from unittest import SkipTest
-
-import importlib_resources
 
 MESSAGES = dict()
 MESSAGES["matplotlib.pyplot"] = """
@@ -50,7 +49,7 @@ def get_fn(filename):
     fn : str
         Full path to filename
     """
-    fn = importlib_resources.files("gmso") / "utils/files" / filename
+    fn = files("gmso") / "utils/files" / filename
     if not os.path.exists(fn):
         raise IOError("Sorry! {} does not exists.".format(fn))
     return str(fn)


### PR DESCRIPTION
### PR Summary:

This was done in mBuild and foyer, but all tests are failing until we can get it added here.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
