### PR TITLE
Passable Neighborlist to Hoomd Blue forcefield

### DIFF
--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -788,10 +788,10 @@ def to_hoomd_forcefield(
         The typed topology to be converted
     r_cut : float
         r_cut for the nonbonded forces.
-    nlist : hoomd.md.nlist.NeighborList, optional, default=None
-        Neighborlist for simulation cell. Its unit is the same as that
-        used to defined GMSO Topology Box. If None, the default value used will be a
-        hoomd.md.nlist.Cell(buffer=0.4)
+    nlist : hoomd.md.nlist.NeighborList or tuple or list or None, optional, default=None
+        Neighborlist object to use for nonbonded forcefield. Can also be a list or tuple of neighborlists
+        where the first neighborlist is used for nonbonded pair forces, and the second with coulombic forces.
+        If None, the default value used will be a hoomd.md.nlist.Cell(exclusions=exclusions, buffer=0.4).
     pppm_kwargs : dict
         Keyword arguments to pass to hoomd.md.long_range.make_pppm_coulomb_forces().
     base_units : dict or str, optional, default=None
@@ -913,8 +913,9 @@ def _parse_nonbonded_forces(
         Topology object holding system information.
     r_cut : float
         Cut-off radius in simulation units
-    nlist_buffer : float
-        Buffer argument ot pass to hoomd.md.nlist.Cell.
+    nlist : hoomd.md.nlist.NeighborList or tuple or list
+        neighborlist object to use for nonbonded forcefield. Can also be a list or tuple of neighborlists
+        where the first neighborlist is used for nonbonded pair forces, and the second with coulombic forces.
     potential_types : dict
         Output from _validate_compatibility().
     potential_refs : dict

--- a/gmso/tests/test_hoomd.py
+++ b/gmso/tests/test_hoomd.py
@@ -461,7 +461,7 @@ class TestHoomd(BaseTest):
             r_cut=1.4,
             base_units=base_units,
             pppm_kwargs={"resolution": (32, 32, 32), "order": 5},
-            nlist=(nlist_nb, nlist_coul),
+            nlist=nlist_coul,
         )
         for force in gmso_forces["nonbonded"]:
             if isinstance(force, hoomd.md.pair.LJ):
@@ -477,3 +477,9 @@ class TestHoomd(BaseTest):
                 assert list(force.nlist.exclusions) == ["bond", "1-3", "1-4"]
                 assert force.nlist.buffer == 1
                 assert force.r_cut == 1.4
+        with pytest.raises(ValueError):
+            gmso_forces, forces_base_units = to_hoomd_forcefield(
+                top,
+                r_cut=1.4,
+                nlist="Error",
+            )

--- a/gmso/tests/test_hoomd.py
+++ b/gmso/tests/test_hoomd.py
@@ -1,4 +1,3 @@
-import forcefield_utilities as ffutils
 import hoomd
 import numpy as np
 import pytest
@@ -185,7 +184,7 @@ class TestHoomd(BaseTest):
 
         top = from_mbuild(com_box)
         top.identify_connections()
-        oplsaa = ffutils.FoyerFFs().load("oplsaa").to_gmso_ff()
+        oplsaa = ForceField("oplsaa")
         top = apply(top, oplsaa, remove_untyped=True)
 
         gmso_snapshot, _ = to_hoomd_snapshot(top, base_units=base_units)
@@ -210,7 +209,7 @@ class TestHoomd(BaseTest):
 
         top = from_mbuild(com_box)
         top.identify_connections()
-        oplsaa = ffutils.FoyerFFs().load("oplsaa").to_gmso_ff()
+        oplsaa = ForceField("oplsaa")
         top = apply(top, oplsaa, remove_untyped=True)
 
         gmso_snapshot, _ = to_hoomd_snapshot(
@@ -240,7 +239,7 @@ class TestHoomd(BaseTest):
 
         top = from_mbuild(com_box)
         top.identify_connections()
-        oplsaa = ffutils.FoyerFFs().load("oplsaa").to_gmso_ff()
+        oplsaa = ForceField("oplsaa")
         top = apply(top, oplsaa, remove_untyped=True)
 
         gmso_snapshot, snapshot_base_units = to_hoomd_snapshot(
@@ -264,7 +263,7 @@ class TestHoomd(BaseTest):
 
         top = from_mbuild(com_box)
         top.identify_connections()
-        oplsaa = ffutils.FoyerFFs().load("oplsaa").to_gmso_ff()
+        oplsaa = ForceField("oplsaa")
         top = apply(top, oplsaa, remove_untyped=True)
 
         gmso_snapshot, snapshot_base_units = to_hoomd_snapshot(top)
@@ -279,9 +278,7 @@ class TestHoomd(BaseTest):
         ethane = mb.lib.molecules.Ethane()
         top = from_mbuild(ethane)
         top.identify_connections()
-        ff_zero_param = (
-            ffutils.FoyerFFs().load(get_path("ethane_zero_parameter.xml")).to_gmso_ff()
-        )
+        ff_zero_param = ForceField(get_path("ethane_zero_parameter.xml"))
         top = apply(top, ff_zero_param, remove_untyped=True)
         base_units = {
             "mass": u.g / u.mol,
@@ -313,7 +310,7 @@ class TestHoomd(BaseTest):
         com_box = mb.packing.fill_box(compound, box=[5, 5, 5], n_compounds=2)
         top = from_mbuild(com_box)
         top.identify_connections()
-        oplsaa = ffutils.FoyerFFs().load("oplsaa").to_gmso_ff()
+        oplsaa = ForceField("oplsaa")
         top = apply(top, oplsaa, remove_untyped=True)
         for site in top.sites:
             site.charge = 0
@@ -478,7 +475,7 @@ class TestHoomd(BaseTest):
                 assert force.nlist.buffer == 1
                 assert force.r_cut == 1.4
         with pytest.raises(ValueError):
-            gmso_forces, forces_base_units = to_hoomd_forcefield(
+            to_hoomd_forcefield(
                 top,
                 r_cut=1.4,
                 nlist="Error",

--- a/gmso/tests/test_hoomd.py
+++ b/gmso/tests/test_hoomd.py
@@ -398,3 +398,82 @@ class TestHoomd(BaseTest):
         assert "CT-CT-CT-HC" in list(forces["dihedrals"][0].params)
         for conntype in snapshot.dihedrals.types:
             assert conntype in list(forces["dihedrals"][0].params)
+
+    def test_pass_nlist(self):
+        from gmso.external.convert_hoomd import get_cell_nlist
+
+        compound = mb.load("CC", smiles=True)
+        com_box = mb.packing.fill_box(compound, box=[5, 5, 5], n_compounds=2)
+        base_units = {
+            "mass": u.amu,
+            "length": u.nm,
+            "energy": u.kJ / u.mol,
+        }
+
+        top = com_box.to_gmso()
+        oplsaa = ForceField("oplsaa")
+        oplsaa.scaling_factors = {
+            "nonBonded12Scale": 0.0,
+            "nonBonded13Scale": 0.5,
+            "nonBonded14Scale": 1.0,
+            "electrostatics12Scale": 1.0,
+            "electrostatics13Scale": 0.5,
+            "electrostatics14scale": 0,
+        }
+        top = apply(top, oplsaa, remove_untyped=True, identify_connections=True)
+        nlist_nb, nlist_coul = get_cell_nlist(top, buffer=1)
+
+        gmso_forces, forces_base_units = to_hoomd_forcefield(
+            top,
+            r_cut=1.4,
+            base_units=base_units,
+            pppm_kwargs={"resolution": (32, 32, 32), "order": 5},
+            nlist=(nlist_nb, nlist_coul),
+        )
+        for force in gmso_forces["nonbonded"]:
+            if isinstance(force, hoomd.md.pair.LJ):
+                assert force.nlist == nlist_nb
+                assert list(force.nlist.exclusions) == ["bond", "1-3"]
+                assert force.nlist.buffer == 1
+            elif isinstance(force, hoomd.md.pair.Ewald):
+                assert force.nlist == nlist_coul
+                assert list(force.nlist.exclusions) == ["1-3", "1-4"]
+                assert force.nlist.buffer == 1
+            elif isinstance(force, hoomd.md.long_range.pppm.Coulomb):
+                assert force.nlist == nlist_coul
+                assert list(force.nlist.exclusions) == ["1-3", "1-4"]
+                assert force.nlist.buffer == 1
+                assert force.r_cut == 1.4
+
+        oplsaa.scaling_factors = {
+            "nonBonded12Scale": 0.0,
+            "nonBonded13Scale": 0.0,
+            "nonBonded14Scale": 0.5,
+            "electrostatics12Scale": 0.0,
+            "electrostatics13Scale": 0.0,
+            "electrostatics14scale": 0.5,
+        }
+        top = com_box.to_gmso()
+        top = apply(top, oplsaa, remove_untyped=True, identify_connections=True)
+        nlist_nb, nlist_coul = get_cell_nlist(top, buffer=1)
+        gmso_forces, forces_base_units = to_hoomd_forcefield(
+            top,
+            r_cut=1.4,
+            base_units=base_units,
+            pppm_kwargs={"resolution": (32, 32, 32), "order": 5},
+            nlist=(nlist_nb, nlist_coul),
+        )
+        for force in gmso_forces["nonbonded"]:
+            if isinstance(force, hoomd.md.pair.LJ):
+                assert force.nlist == nlist_nb
+                assert list(force.nlist.exclusions) == ["bond", "1-3", "1-4"]
+                assert force.nlist.buffer == 1
+            elif isinstance(force, hoomd.md.pair.Ewald):
+                assert force.nlist == nlist_nb
+                assert list(force.nlist.exclusions) == ["bond", "1-3", "1-4"]
+                assert force.nlist.buffer == 1
+            elif isinstance(force, hoomd.md.long_range.pppm.Coulomb):
+                assert force.nlist == nlist_nb
+                assert list(force.nlist.exclusions) == ["bond", "1-3", "1-4"]
+                assert force.nlist.buffer == 1
+                assert force.r_cut == 1.4


### PR DESCRIPTION
### PR Summary: Try to allow for passing of a neighborlist to the hoomd-blue forcefield function. This allows someone to use a neighborlist that is not hoomd.md.nlist.Cell, which was the old default. Also, fixes a bug where the scaling_factors for electrostatics were not being considered, as only a single neighborlist for the nonbonded interactions was passed.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [x] Issue(s) raised/addressed?
