### PR TITLE
Add some topology slicing methods.

### DIFF
--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -1447,7 +1447,7 @@ class Topology(object):
                 if getattr(site, key) == value:
                     yield site
 
-    def iter_sites_by_residue(self, residue_tag):
+    def iter_sites_by_residue(self, residue_tag, residue_number=None):
         """Iterate through this topology's sites which contain this specific residue name.
 
         See Also
@@ -1457,12 +1457,24 @@ class Topology(object):
         """
         if isinstance(residue_tag, str):
             for site in self._sites:
-                if site.residue and getattr(site, "residue").name == residue_tag:
-                    yield site
+                if residue_tag and residue_number is None:
+                    if site.molecule and getattr(site, "residue").name == residue_tag:
+                        yield site
+                elif residue_number and residue_tag is None:
+                    if site.molecule and getattr(site, "residue").number == residue_number:
+                        yield site
+                else:
+                    if all(
+                        [
+                            site.molecule and getattr(site, "residue").name == residue_tag,
+                            site.molecule and getattr(site, "residue").number == residue_number
+                        ]
+                    ):
+                        yield site
         else:
             return self.iter_sites("residue", residue_tag)
 
-    def iter_sites_by_molecule(self, molecule_tag):
+    def iter_sites_by_molecule(self, molecule_tag, molecule_number=None):
         """Iterate through this topology's sites which contain this specific molecule name.
 
         See Also
@@ -1472,8 +1484,20 @@ class Topology(object):
         """
         if isinstance(molecule_tag, str):
             for site in self._sites:
-                if site.molecule and getattr(site, "molecule").name == molecule_tag:
-                    yield site
+                if molecule_tag and molecule_number is None:
+                    if site.molecule and getattr(site, "molecule").name == molecule_tag:
+                        yield site
+                elif molecule_number and molecule_tag is None:
+                    if site.molecule and getattr(site, "molecule").number == molecule_number:
+                        yield site
+                else:
+                    if all(
+                        [
+                            site.molecule and getattr(site, "molecule").name == molecule_tag,
+                            site.molecule and getattr(site, "molecule").number == molecule_number
+                        ]
+                    ):
+                        yield site
         else:
             return self.iter_sites("molecule", molecule_tag)
 

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -1461,13 +1461,18 @@ class Topology(object):
                     if site.molecule and getattr(site, "residue").name == residue_tag:
                         yield site
                 elif residue_number and residue_tag is None:
-                    if site.molecule and getattr(site, "residue").number == residue_number:
+                    if (
+                        site.molecule
+                        and getattr(site, "residue").number == residue_number
+                    ):
                         yield site
                 else:
                     if all(
                         [
-                            site.molecule and getattr(site, "residue").name == residue_tag,
-                            site.molecule and getattr(site, "residue").number == residue_number
+                            site.molecule
+                            and getattr(site, "residue").name == residue_tag,
+                            site.molecule
+                            and getattr(site, "residue").number == residue_number,
                         ]
                     ):
                         yield site
@@ -1488,13 +1493,18 @@ class Topology(object):
                     if site.molecule and getattr(site, "molecule").name == molecule_tag:
                         yield site
                 elif molecule_number and molecule_tag is None:
-                    if site.molecule and getattr(site, "molecule").number == molecule_number:
+                    if (
+                        site.molecule
+                        and getattr(site, "molecule").number == molecule_number
+                    ):
                         yield site
                 else:
                     if all(
                         [
-                            site.molecule and getattr(site, "molecule").name == molecule_tag,
-                            site.molecule and getattr(site, "molecule").number == molecule_number
+                            site.molecule
+                            and getattr(site, "molecule").name == molecule_tag,
+                            site.molecule
+                            and getattr(site, "molecule").number == molecule_number,
                         ]
                     ):
                         yield site

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -1262,7 +1262,7 @@ class Topology(object):
         molecules = set()
         for site in self.sites:
             molecules.add(site.molecule.name)
-    
+
         # Figure out how to handle the tags
         for mol in molecules:
             mol_slice = slice_topology_by_molecule(topology=self, molecule_tag=0)
@@ -1270,8 +1270,6 @@ class Topology(object):
             openff_mol.assign_partial_charges(method=method)
             for atom in openff_mol.atoms:
                 print(atom.partial_charge)
-
-
 
     def write_forcefield(self, filename, overwrite=False):
         """Save an xml file for all parameters found in the topology.

--- a/gmso/core/topology.py
+++ b/gmso/core/topology.py
@@ -1251,6 +1251,23 @@ class Topology(object):
 
         return index
 
+    def calculate_charges(self, method="am1bcc", slice_by="Molecule"):
+        print("Not implemented yet. We are working on it.")
+        # Get all of the moleucles types in the topology
+        molecules = set()
+        for site in self.sites:
+            molecules.add(site.molecule.name)
+    
+        # Figure out how to handle the tags
+        for mol in molecules:
+            mol_slice = slice_topology_by_molecule(topology=self, molecule_tag=0)
+            openff_mol = to_openff_molecule(mol_slice)
+            openff_mol.assign_partial_charges(method=method)
+            for atom in openff_mol.atoms:
+                print(atom.partial_charge)
+
+
+
     def write_forcefield(self, filename, overwrite=False):
         """Save an xml file for all parameters found in the topology.
 

--- a/gmso/external/convert_openmm.py
+++ b/gmso/external/convert_openmm.py
@@ -4,16 +4,14 @@
 """Convert to and from an OpenMM Topology or System object."""
 
 import unyt as u
+from openff.toolkit import Molecule as openFF_Molecule
 
 from gmso.utils.io import has_openmm, has_openmm_unit, import_
-
-from openff.toolkit import Molecule as openFF_Molecule
 
 if has_openmm & has_openmm_unit:
     openmm_unit = import_("openmm.unit")
     from openmm import *
     from openmm.app import *
-
 
 
 def to_openff_molecule(topology):
@@ -25,12 +23,12 @@ def to_openff_molecule(topology):
     sites = []
     for site in topology.sites:
         sites.append(site)
-    
+
     # Index-to-index mapping with sites list
     is_aromatic = [False for i in sites]
     bond_pairs = []
     bond_orders = []
-    
+
     for bond in topology.bonds:
         bond_pair = []
         bond_orders.append(bond.bond_order)
@@ -40,17 +38,21 @@ def to_openff_molecule(topology):
                 is_aromatic[site_index] = True
             bond_pair.append(site_index)
         bond_pairs.append(bond_pair)
-    # Now that we have parsed all sites for aromaticity, add each to Molecule 
+    # Now that we have parsed all sites for aromaticity, add each to Molecule
     for site, aromatic in zip(sites, is_aromatic):
-        mol.add_atom(atomic_number=site.element.atomic_number, is_aromatic=aromatic, formal_charge=0)
-    
+        mol.add_atom(
+            atomic_number=site.element.atomic_number,
+            is_aromatic=aromatic,
+            formal_charge=0,
+        )
+
     for bond, border in zip(bond_pairs, bond_orders):
         mol.add_bond(
             atom1=bond[0],
             atom2=bond[1],
             bond_order=int(border),
             fractional_bond_order=border,
-            is_aromatic=True if border==1.5 else False
+            is_aromatic=True if border == 1.5 else False,
         )
     return mol
 

--- a/gmso/external/convert_openmm.py
+++ b/gmso/external/convert_openmm.py
@@ -7,10 +7,52 @@ import unyt as u
 
 from gmso.utils.io import has_openmm, has_openmm_unit, import_
 
+from openff.toolkit import Molecule as openFF_Molecule
+
 if has_openmm & has_openmm_unit:
     openmm_unit = import_("openmm.unit")
     from openmm import *
     from openmm.app import *
+
+
+
+def to_openff_molecule(topology):
+    """Converts a GMSO topology into an OpenFF Molecule."""
+    mol = openFF_Molecule()
+    # Bond order not available at the site level
+    # But, it can be set during openFF's add_atom'
+    # Build up a list of sites first to track their bond orders later
+    sites = []
+    for site in topology.sites:
+        sites.append(site)
+    
+    # Index-to-index mapping with sites list
+    is_aromatic = [False for i in sites]
+    bond_pairs = []
+    bond_orders = []
+    
+    for bond in topology.bonds:
+        bond_pair = []
+        bond_orders.append(bond.bond_order)
+        for site in bond.connection_members:
+            site_index = sites.index(site)
+            if bond.bond_order == 1.5:
+                is_aromatic[site_index] = True
+            bond_pair.append(site_index)
+        bond_pairs.append(bond_pair)
+    # Now that we have parsed all sites for aromaticity, add each to Molecule 
+    for site, aromatic in zip(sites, is_aromatic):
+        mol.add_atom(atomic_number=site.element.atomic_number, is_aromatic=aromatic, formal_charge=0)
+    
+    for bond, border in zip(bond_pairs, bond_orders):
+        mol.add_bond(
+            atom1=bond[0],
+            atom2=bond[1],
+            bond_order=int(border),
+            fractional_bond_order=border,
+            is_aromatic=True if border==1.5 else False
+        )
+    return mol
 
 
 def to_openmm(topology, openmm_object="topology"):

--- a/gmso/tests/test_topology.py
+++ b/gmso/tests/test_topology.py
@@ -886,6 +886,17 @@ class TestTopology(BaseTest):
             for site in labeled_top.iter_sites_by_molecule(molecule_name):
                 assert site.molecule.name == molecule_name
 
+    def test_iter_sites_by_molecule_tag_and_number(self, labeled_top):
+        molecules = labeled_top.unique_site_labels("molecule", name_only=False)
+        for molecule in molecules:
+            for site in labeled_top.iter_sites_by_molecule(molecule):
+                assert site.residue == molecule
+
+        molecule_names = labeled_top.unique_site_labels("molecule", name_only=True)
+        for molecule_name in molecule_names:
+            for site in labeled_top.iter_sites_by_molecule(molecule_name):
+                assert site.molecule.name == molecule_name
+
     @pytest.mark.parametrize(
         "connections",
         ["bonds", "angles", "dihedrals", "impropers"],

--- a/gmso/tests/test_utils.py
+++ b/gmso/tests/test_utils.py
@@ -8,8 +8,11 @@ from gmso.core.dihedral import Dihedral
 from gmso.utils.geometry import moment_of_inertia
 from gmso.utils.io import run_from_ipython
 from gmso.utils.misc import unyt_to_hashable
+from gmso.utils.slicing import (
+    slice_topology_by_molecule,
+    slice_topology_by_residue,
+)
 from gmso.utils.sorting import sort_connection_members, sort_connection_strings
-from gmso.utils.slicing import slice_topology_by_molecule, slice_topology_by_residue
 
 
 def test_unyt_to_hashable():
@@ -91,7 +94,7 @@ def test_slice_by_molecule():
     ethane = mb.load("CC", smiles=True)
     ethane.name = "Ethane"
 
-    system = mb.fill_box(compound=[benzene, ethane], n_compounds=[2, 2], box=[2,2,2])
+    system = mb.fill_box(compound=[benzene, ethane], n_compounds=[2, 2], box=[2, 2, 2])
     topology = system.to_gmso()
     topology.identify_connections()
 
@@ -99,7 +102,7 @@ def test_slice_by_molecule():
     assert single_benzene_top.n_sites == 12
 
     all_benzene_top = slice_topology_by_molecule(topology, "Benzene")
-    assert all_benzene_top.n_sites == 24 
+    assert all_benzene_top.n_sites == 24
 
 
 def test_slice_by_residue():
@@ -108,14 +111,12 @@ def test_slice_by_residue():
     ethane = mb.load("CC", smiles=True)
     ethane.name = "Ethane"
 
-    system = mb.fill_box(compound=[benzene, ethane], n_compounds=[2, 2], box=[2,2,2])
+    system = mb.fill_box(compound=[benzene, ethane], n_compounds=[2, 2], box=[2, 2, 2])
     topology = system.to_gmso()
     topology.identify_connections()
 
     single_ethane_top = slice_topology_by_residue(topology, "Ethane", 0)
-    assert single_ethane_top.n_sites == 8 
+    assert single_ethane_top.n_sites == 8
 
     all_ethane_top = slice_topology_by_residue(topology, "Ethane")
-    assert all_ethane_top.n_sites == 16 
-
-
+    assert all_ethane_top.n_sites == 16

--- a/gmso/tests/test_utils.py
+++ b/gmso/tests/test_utils.py
@@ -1,3 +1,4 @@
+import mbuild as mb
 import numpy as np
 import pytest
 import unyt as u
@@ -8,6 +9,7 @@ from gmso.utils.geometry import moment_of_inertia
 from gmso.utils.io import run_from_ipython
 from gmso.utils.misc import unyt_to_hashable
 from gmso.utils.sorting import sort_connection_members, sort_connection_strings
+from gmso.utils.slicing import slice_topology_by_molecule, slice_topology_by_residue
 
 
 def test_unyt_to_hashable():
@@ -81,3 +83,39 @@ def test_moment_of_inertia():
         masses=np.array([1.0 for i in xyz]),
     )
     assert np.array_equal(tensor, np.array([1, 1, 2]))
+
+
+def test_slice_by_molecule():
+    benzene = mb.load("c1ccccc1", smiles=True)
+    benzene.name = "Benzene"
+    ethane = mb.load("CC", smiles=True)
+    ethane.name = "Ethane"
+
+    system = mb.fill_box(compound=[benzene, ethane], n_compounds=[2, 2], box=[2,2,2])
+    topology = system.to_gmso()
+    topology.identify_connections()
+
+    single_benzene_top = slice_topology_by_molecule(topology, "Benzene", 0)
+    assert single_benzene_top.n_sites == 12
+
+    all_benzene_top = slice_topology_by_molecule(topology, "Benzene")
+    assert all_benzene_top.n_sites == 24 
+
+
+def test_slice_by_residue():
+    benzene = mb.load("c1ccccc1", smiles=True)
+    benzene.name = "Benzene"
+    ethane = mb.load("CC", smiles=True)
+    ethane.name = "Ethane"
+
+    system = mb.fill_box(compound=[benzene, ethane], n_compounds=[2, 2], box=[2,2,2])
+    topology = system.to_gmso()
+    topology.identify_connections()
+
+    single_ethane_top = slice_topology_by_residue(topology, "Ethane", 0)
+    assert single_ethane_top.n_sites == 8 
+
+    all_ethane_top = slice_topology_by_residue(topology, "Ethane")
+    assert all_ethane_top.n_sites == 16 
+
+

--- a/gmso/utils/charges.py
+++ b/gmso/utils/charges.py
@@ -1,0 +1,19 @@
+"""Calculate charges for a gmso Topology."""
+from gmso.external.convert_openmm import to_openff_molecule
+from gmso.utils.slicing import slice_topology_by_molecule
+
+def calculate_charges(topology, method="am1bcc", slice_by="Molecule"):
+    # Get all of the moleucles types in the topology
+    charges_dict = dict()
+
+    molecules = set()
+    for site in topology.sites:
+        molecules.add(site.molecule.name)
+
+    # Figure out how to handle the tags
+    for mol in molecules:
+        mol_slice = slice_topology_by_molecule(topology=topology, molecule_tag=0)
+        openff_mol = to_openff_molecule(mol_slice)
+        openff_mol.assign_partial_charges(partial_charge_method=method)
+        for atom in openff_mol.atoms:
+            print(atom.partial_charge)

--- a/gmso/utils/charges.py
+++ b/gmso/utils/charges.py
@@ -1,6 +1,8 @@
 """Calculate charges for a gmso Topology."""
+
 from gmso.external.convert_openmm import to_openff_molecule
 from gmso.utils.slicing import slice_topology_by_molecule
+
 
 def calculate_charges(topology, method="am1bcc", slice_by="Molecule"):
     # Get all of the moleucles types in the topology

--- a/gmso/utils/slicing.py
+++ b/gmso/utils/slicing.py
@@ -1,0 +1,71 @@
+from gmso.core.topology import Topology
+
+
+def slice_topology_by_molecule(topology, molecule_tag, molecule_number=None):
+    """Create a Topology that contains a subset of molecules from another Topology.
+
+    Parameters
+    ----------
+    topology : gmso.core.topology.Topology
+        The gmso Topology to perform the slice on
+    molecule_tag : str
+        The name of the gmso.abstract_site.Molecule object to include in the slice
+    molecule_number : int, default None
+        If given, only include a single molecule's sites 
+        If None, then all sites in every molecule matching `molecule_tag` are included
+        in the sliced topology.
+
+    Returns
+    -------
+    gmso.core.topology.Topology
+        A new Topology instance containing only sites and connections from matching molecules.
+    """
+    sites = [s for s in topology.iter_sites_by_molecule(molecule_tag=molecule_tag, molecule_number=molecule_number)]
+    return slice_by_sites(topology=topology, sites=sites)
+
+
+def slice_topology_by_residue(topology, residue_tag, residue_number=None):
+    """Create a Topology that contains a subset of residues from another Topology.
+
+    Parameters
+    ----------
+    topology : gmso.core.topology.Topology
+        The gmso Topology to perform the slice on.
+    residue_tag : str
+        The name of the gmso.abstract_site.Residue object to include in the slice.
+    residue_number : int, default None
+        If given, only include a single residue's sites 
+        If None, then all sites in every residue matching `residue_tag` are included 
+        in the sliced topology.
+
+    Returns
+    -------
+    gmso.core.topology.Topology
+        A new Topology instance containing only sites and connections from matching molecules.
+    """
+    sites = [s for s in topology.iter_sites_by_residue(residue_tag=residue_tag, residue_number=residue_number)]
+    return slice_by_sites(topology=topology, sites=sites)
+
+
+def slice_by_sites(topology, sites):
+    """Used by slice_topology_by_molecule() and slice_topology_by_residue()
+
+    Parameters
+    ----------
+    sites : list of gmso.core.atom.Atom
+        List of sites to include in the sub-topology.
+    topology : gmso.core.topology.Topology
+        The topology being sliced.
+    """
+    new_topology = Topology()
+
+    connections = set()
+    for site in sites:
+        new_topology.add_site(site)
+        for connection in topology.iter_connections_by_site(site):
+            connections.add(connection)
+
+    for connection in connections:
+        new_topology.add_connection(connection)
+
+    return new_topology

--- a/gmso/utils/slicing.py
+++ b/gmso/utils/slicing.py
@@ -11,7 +11,7 @@ def slice_topology_by_molecule(topology, molecule_tag, molecule_number=None):
     molecule_tag : str
         The name of the gmso.abstract_site.Molecule object to include in the slice
     molecule_number : int, default None
-        If given, only include a single molecule's sites 
+        If given, only include a single molecule's sites
         If None, then all sites in every molecule matching `molecule_tag` are included
         in the sliced topology.
 
@@ -20,7 +20,12 @@ def slice_topology_by_molecule(topology, molecule_tag, molecule_number=None):
     gmso.core.topology.Topology
         A new Topology instance containing only sites and connections from matching molecules.
     """
-    sites = [s for s in topology.iter_sites_by_molecule(molecule_tag=molecule_tag, molecule_number=molecule_number)]
+    sites = [
+        s
+        for s in topology.iter_sites_by_molecule(
+            molecule_tag=molecule_tag, molecule_number=molecule_number
+        )
+    ]
     return slice_by_sites(topology=topology, sites=sites)
 
 
@@ -34,8 +39,8 @@ def slice_topology_by_residue(topology, residue_tag, residue_number=None):
     residue_tag : str
         The name of the gmso.abstract_site.Residue object to include in the slice.
     residue_number : int, default None
-        If given, only include a single residue's sites 
-        If None, then all sites in every residue matching `residue_tag` are included 
+        If given, only include a single residue's sites
+        If None, then all sites in every residue matching `residue_tag` are included
         in the sliced topology.
 
     Returns
@@ -43,7 +48,12 @@ def slice_topology_by_residue(topology, residue_tag, residue_number=None):
     gmso.core.topology.Topology
         A new Topology instance containing only sites and connections from matching molecules.
     """
-    sites = [s for s in topology.iter_sites_by_residue(residue_tag=residue_tag, residue_number=residue_number)]
+    sites = [
+        s
+        for s in topology.iter_sites_by_residue(
+            residue_tag=residue_tag, residue_number=residue_number
+        )
+    ]
     return slice_by_sites(topology=topology, sites=sites)
 
 

--- a/gmso/utils/slicing.py
+++ b/gmso/utils/slicing.py
@@ -1,5 +1,6 @@
 import gmso
 
+
 def slice_topology_by_molecule(topology, molecule_tag, molecule_number=None):
     """Create a Topology that contains a subset of molecules from another Topology.
 

--- a/gmso/utils/slicing.py
+++ b/gmso/utils/slicing.py
@@ -1,5 +1,4 @@
-from gmso.core.topology import Topology
-
+import gmso
 
 def slice_topology_by_molecule(topology, molecule_tag, molecule_number=None):
     """Create a Topology that contains a subset of molecules from another Topology.
@@ -67,7 +66,7 @@ def slice_by_sites(topology, sites):
     topology : gmso.core.topology.Topology
         The topology being sliced.
     """
-    new_topology = Topology()
+    new_topology = gmso.core.topology.Topology()
 
     connections = set()
     for site in sites:


### PR DESCRIPTION
### PR Summary:
This is ultimately an effort to help out @JAGarcia03 with his project, but it should be a useful addition in general.

`utils.py` gets new slicing methods where the goal is to create a new topology object that contains a subset of another topology's molecules or residues. This should live in `utils.py` as we have been wanting to reduce the amount of methods and code in general within `Topology`, and this file will be a good place to add other, more creative slicing methods.

This also adds the ability to filter by number in addition to tag within `iter_sites_by_molecule` and `iter_sites_by_residue`. 

For example, if you want to get just the sites belonging to the 0th "Benzene" (instead of all of them) you can now do:

`for site in topology.iter_sites_by_molecule(molecule_tag="Benzene", molecule_number=0)`

A quick example:

```
import mbuild as mb
import gmso
from gmso.core.topology import Topology
from gmso.utils.slicing import slice_topology_by_molecule

benzene = mb.load("c1ccccc1", smiles=True)
benzene.name = "Benzene"
ethane = mb.load("CC", smiles=True)
ethane.name = "Ethane"

system = mb.fill_box(compound=[benzene, ethane], n_compounds=[2, 2], box=[2,2,2])
topology = system.to_gmso()
topology.identify_connections()

single_benzene_top = slice_topology_by_molecule(topology=topology, molecule_tag="Benzene", molecule_number=0)

all_benzene_top = slice_topology_by_molecule(topology=topology, molecule_tag="Benzene", molecule_number=None)

```

I still need to make the slicing tests more thorough, and add new tests for the changes to `iter_sites_by_*`


### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
