### PR TITLE
Speedup gsd snapshot and forcefield writing for convert_hoomd

### DIFF
--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -1065,7 +1065,7 @@ def _parse_coulombic(
         coulombic = hoomd.md.long_range.pppm.make_pppm_coulomb_forces(
             nlist=nlist, resolution=resolution, order=order, r_cut=r_cut
         )
-    if not np.all(scaling_factors):
+    if not np.any(scaling_factors):
         return [*coulombic]  # return early
     # Handle 1-2, 1-3, and 1-4 scaling
     # TODO: Figure out a more general way to do this and handle molecule scaling factors
@@ -1116,7 +1116,7 @@ def _parse_lj(top, atypes, combining_rule, r_cut, nlist, scaling_factors):
     # Handle 1-2, 1-3, and 1-4 scaling
     # TODO: Figure out a more general way to do this
     # and handle molecule scaling factors
-    if not np.all(scaling_factors):
+    if not np.any(scaling_factors):
         return [lj]
     special_lj = hoomd.md.special_pair.LJ()
 

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -185,6 +185,9 @@ def to_gsd_snapshot(
         "Special pairs are not currently written to GSD files",
     )
 
+    # Create IndexMap
+    site_indexMap = {id(site): i for i, site in enumerate(top.sites)}
+
     n_rigid, rigid_info = _parse_particle_information(
         gsd_snapshot,
         top,
@@ -193,15 +196,15 @@ def to_gsd_snapshot(
         u.unyt_array([lx, ly, lz]),
     )
     if parse_special_pairs:
-        _parse_pairs_information(gsd_snapshot, top, n_rigid)
+        _parse_pairs_information(gsd_snapshot, top, site_indexMap, n_rigid)
     if top.n_bonds > 0:
-        _parse_bond_information(gsd_snapshot, top, n_rigid)
+        _parse_bond_information(gsd_snapshot, top, site_indexMap, n_rigid)
     if top.n_angles > 0:
-        _parse_angle_information(gsd_snapshot, top, n_rigid)
+        _parse_angle_information(gsd_snapshot, top, site_indexMap, n_rigid)
     if top.n_dihedrals > 0:
-        _parse_dihedral_information(gsd_snapshot, top, n_rigid)
+        _parse_dihedral_information(gsd_snapshot, top, site_indexMap, n_rigid)
     if top.n_impropers > 0:
-        _parse_improper_information(gsd_snapshot, top, n_rigid)
+        _parse_improper_information(gsd_snapshot, top, site_indexMap, n_rigid)
 
     if rigid_info:
         return gsd_snapshot, base_units, rigid_info
@@ -316,6 +319,9 @@ def to_hoomd_snapshot(
         "Special pairs are not currently written to GSD files",
     )
 
+    # Create IndexMap
+    site_indexMap = {id(site): i for i, site in enumerate(top.sites)}
+
     n_rigid, rigid_info = _parse_particle_information(
         hoomd_snapshot,
         top,
@@ -324,15 +330,15 @@ def to_hoomd_snapshot(
         u.unyt_array([lx, ly, lz]),
     )
     if parse_special_pairs:
-        _parse_pairs_information(hoomd_snapshot, top, n_rigid)
+        _parse_pairs_information(hoomd_snapshot, top, site_indexMap, n_rigid)
     if top.n_bonds > 0:
-        _parse_bond_information(hoomd_snapshot, top, n_rigid)
+        _parse_bond_information(hoomd_snapshot, top, site_indexMap, n_rigid)
     if top.n_angles > 0:
-        _parse_angle_information(hoomd_snapshot, top, n_rigid)
+        _parse_angle_information(hoomd_snapshot, top, site_indexMap, n_rigid)
     if top.n_dihedrals > 0:
-        _parse_dihedral_information(hoomd_snapshot, top, n_rigid)
+        _parse_dihedral_information(hoomd_snapshot, top, site_indexMap, n_rigid)
     if top.n_impropers > 0:
-        _parse_improper_information(hoomd_snapshot, top, n_rigid)
+        _parse_improper_information(hoomd_snapshot, top, site_indexMap, n_rigid)
 
     hoomd_snapshot.wrap()
     if rigid_info:
@@ -363,128 +369,162 @@ def _parse_particle_information(
     box_lengths : list() of length 3
         Lengths of box in x, y, z
     """
-    # Set up all require
-    xyz = u.unyt_array(
-        [site.position.to_value(base_units["length"]) for site in top.sites]
-    )
+    n_sites = top.n_sites
+    length_unit = base_units["length"]
+    mass_unit = base_units["mass"]
+    energy_unit = base_units["energy"]
+
+    # --- Single pass over top.sites to collect all per-site data ---
+    xyz_raw = np.empty((n_sites, 3), dtype=np.float64)
+    masses_raw = np.empty(n_sites, dtype=np.float64)
+    charges_list = np.empty(n_sites, dtype=np.float64)
+    types = [None] * n_sites
+    has_rigid = False
+
+    zero_charge = (0 * u.elementary_charge).to_value(u.elementary_charge)
+    default_mass = 1.0  # dimensionless, matching `1 * base_units["mass"]` via to_value
+
+    for i, site in enumerate(top.sites):
+        xyz_raw[i] = site.position.to_value(length_unit)
+        types[i] = site.name if site.atom_type is None else site.atom_type.name
+        masses_raw[i] = site.mass.to_value(mass_unit) if site.mass else default_mass
+        charges_list[i] = (
+            site.charge.to_value(u.elementary_charge)
+            if site.charge
+            else zero_charge
+        )
+        if not has_rigid and site.molecule.isrigid:
+            has_rigid = True
+
+    # Dimensionless — to_value() already converted to base unit magnitudes
+    xyz = u.unyt_array(xyz_raw)
+    masses = u.unyt_array(masses_raw)
+    charges = u.unyt_array(charges_list, u.elementary_charge)
+
     if shift_coords:
         logger.info("Shifting coordinates to [-L/2, L/2]")
         xyz = coord_shift(xyz, box_lengths)
 
-    types = [
-        site.name if site.atom_type is None else site.atom_type.name
-        for site in top.sites
-    ]
-    masses = u.unyt_array(
-        [
-            site.mass.to_value(base_units["mass"])
-            if site.mass
-            else 1 * base_units["mass"]
-            for site in top.sites
-        ]
-    )
-    charges = u.unyt_array(
-        [site.charge if site.charge else 0 * u.elementary_charge for site in top.sites]
-    )
-    moment_of_inertias = [[1, 0, 0] for i in xyz]
-    # GMSO and mBuild don't store particle orientation; use default
-    orientations = [[1, 0, 0, 0] for i in xyz]
-    unique_types = sorted(list(set(types)))
-    typeids = np.array([unique_types.index(t) for t in types])
-    # Check for rigid molecules
-    rigid_mols = any([site.molecule.isrigid for site in top.sites])
-    if rigid_mols:
-        rigid_ids = [
-            site.molecule.number if site.molecule.isrigid else -1 for site in top.sites
-        ]
-        # Check that the hierarchy is correct
-        if -1 in rigid_ids:
-            first_neg_index = rigid_ids.index(-1)
-            if not all(i == -1 for i in rigid_ids[first_neg_index:]):
-                raise RuntimeError(
-                    "When using a combination of rigid and non-rigid molecules, ",
-                    "all of the rigid molecules must come first in the mBuild/GMSO hierarchy. ",
-                )
-        rigid_body_sets = dict()
-        for site in top.sites:
+    # --- Build type IDs with dict lookup instead of list.index() ---
+    unique_types = sorted(set(types))
+    type_to_id = {t: idx for idx, t in enumerate(unique_types)}
+    typeids = np.array([type_to_id[t] for t in types], dtype=np.int32)
+
+    # Default orientations and moments of inertia
+    moment_of_inertias = np.tile([1.0, 0.0, 0.0], (n_sites, 1))
+    orientations = np.tile([1.0, 0.0, 0.0, 0.0], (n_sites, 1))
+
+    # --- Rigid body handling ---
+    if has_rigid:
+        rigid_ids = np.empty(n_sites, dtype=np.int64)
+        rigid_body_sets = {}
+
+        for i, site in enumerate(top.sites):
             if site.molecule.isrigid:
-                if site.molecule.name in rigid_body_sets.keys():
-                    rigid_body_sets[site.molecule.name].add(site.molecule.number)
-                else:
-                    rigid_body_sets[site.molecule.name] = {site.molecule.number}
-        # Number of unique types of rigid molecules
-        n_rigid_types = len(rigid_body_sets.keys())
-        # Total number of rigid molecules
-        n_rigid = sum([len(mols) for mols in rigid_body_sets.values()])
-        # Create place holder arrays for rigid particle properties
+                mol_num = site.molecule.number
+                mol_name = site.molecule.name
+                rigid_ids[i] = mol_num
+                if mol_name not in rigid_body_sets:
+                    rigid_body_sets[mol_name] = set()
+                rigid_body_sets[mol_name].add(mol_num)
+            else:
+                rigid_ids[i] = -1
+
+        # Validate hierarchy: all rigid sites must precede non-rigid sites
+        non_rigid_mask = rigid_ids == -1
+        if non_rigid_mask.any():
+            first_neg_index = int(np.argmax(non_rigid_mask))
+            if not non_rigid_mask[first_neg_index:].all():
+                raise RuntimeError(
+                    "When using a combination of rigid and non-rigid molecules, "
+                    "all of the rigid molecules must come first in the mBuild/GMSO hierarchy."
+                )
+
+        n_rigid_types = len(rigid_body_sets)
+        n_rigid = sum(len(mols) for mols in rigid_body_sets.values())
+
+        # Dimensionless placeholders to match xyz/masses
         rigid_charges = np.zeros(n_rigid) * charges.units
-        rigid_masses = np.zeros(n_rigid) * masses.units
-        rigid_xyz = np.zeros((n_rigid, 3)) * xyz.units
-        rigid_moits = np.zeros((n_rigid, 3)) * xyz.units
-        rigid_orientations = [[1, 0, 0, 0] for i in rigid_xyz]
-        # Rigid particles get type IDs from 0 to n_rigid_types
-        rigid_type_ids = []
-        for i, rigid_type in enumerate(rigid_body_sets.keys()):
-            rigid_type_ids.extend([i] * len(rigid_body_sets[rigid_type]))
-        # Hoomd rigid constraint obj needed to run rigid body simulations
+        rigid_masses = u.unyt_array(np.zeros(n_rigid))
+        rigid_xyz = u.unyt_array(np.zeros((n_rigid, 3)))
+        rigid_moits = u.unyt_array(np.zeros((n_rigid, 3)))
+        rigid_orientations = np.tile([1.0, 0.0, 0.0, 0.0], (n_rigid, 1))
+
+        # Build rigid type IDs
+        rigid_type_ids = np.empty(n_rigid, dtype=np.int32)
+        offset = 0
+        for i, rigid_type in enumerate(rigid_body_sets):
+            count = len(rigid_body_sets[rigid_type])
+            rigid_type_ids[offset : offset + count] = i
+            offset += count
+
+        # Precompute group indices for each rigid body ID (avoids repeated np.where)
+        group_indices_map = {}
+        for i in range(n_sites):
+            rid = rigid_ids[i]
+            if rid != -1:
+                if rid not in group_indices_map:
+                    group_indices_map[rid] = []
+                group_indices_map[rid].append(i)
+        for rid in group_indices_map:
+            group_indices_map[rid] = np.array(group_indices_map[rid], dtype=np.intp)
+
         rigid_constraint = hoomd.md.constrain.Rigid()
         mol_count = 0
-        # Populate rigid particle placeholder arrays created above
-        for rigid_mol in rigid_body_sets.keys():
-            for idx, _id in enumerate(rigid_body_sets[rigid_mol]):
-                # Get values for rigid body properties from their constituent particles
-                group_indices = np.where(np.array(rigid_ids) == _id)[0]
+
+        for rigid_mol in rigid_body_sets:
+            sorted_ids = sorted(rigid_body_sets[rigid_mol])
+            for idx, _id in enumerate(sorted_ids):
+                group_indices = group_indices_map[_id]
                 group_positions = xyz[group_indices]
                 group_masses = masses[group_indices]
-                group_orientations = [[1, 0, 0, 0] for i in group_indices]
-                com_xyz = np.sum(group_positions.T * group_masses, axis=1) / sum(
-                    group_masses
-                )
-                rigid_masses[idx + mol_count] = sum(group_masses)
-                rigid_xyz[idx + mol_count] = com_xyz
-                rigid_moits[idx + mol_count] = moment_of_inertia(
+
+                total_mass = group_masses.sum()
+                com_xyz = (group_positions.T * group_masses).sum(axis=1) / total_mass
+
+                pos_idx = idx + mol_count
+                rigid_masses[pos_idx] = total_mass
+                rigid_xyz[pos_idx] = com_xyz
+                rigid_moits[pos_idx] = moment_of_inertia(
                     group_positions, group_masses, com_xyz
                 )
-                # Only need to make one entry per rigid body type
+
                 if idx == 0:
                     const_ids = typeids[group_indices]
                     const_types = [unique_types[i] for i in const_ids]
-
+                    group_orientations = [[1, 0, 0, 0] for _ in group_indices]
                     rigid_constraint.body[rigid_mol] = {
                         "constituent_types": const_types,
                         "positions": group_positions,
                         "orientations": group_orientations,
                     }
             mol_count += len(rigid_body_sets[rigid_mol])
-        # Combine properties for rigid body particles and constituent particles
-        # All rigid body propeties should be at the beginning, others get bumped
+
+        # Prepend rigid body data
         unique_types = list(rigid_body_sets.keys()) + unique_types
-        typeids = np.concatenate((np.array(rigid_type_ids), typeids + n_rigid_types))
+        typeids = np.concatenate((rigid_type_ids, typeids + n_rigid_types))
         masses = np.concatenate((rigid_masses, masses))
         xyz = np.concatenate((rigid_xyz, xyz))
         charges = np.concatenate((rigid_charges, charges))
-        orientations = rigid_orientations + orientations
-        moment_of_inertias = np.concatenate((rigid_moits, moment_of_inertias))
+        orientations = np.concatenate((rigid_orientations, orientations), axis=0)
+        moment_of_inertias = np.concatenate((rigid_moits, moment_of_inertias), axis=0)
         rigid_id_tags = np.concatenate((np.arange(n_rigid), rigid_ids))
     else:
         n_rigid = 0
         rigid_constraint = None
 
-    """
-    Permittivity of free space = 2.39725e-4 e^2/((kcal/mol)(angstrom)),
-    where e is the elementary charge
-    """
-
+    # Compute charge factor
     e0 = u.physical_constants.eps_0.in_units(
-        u.elementary_charge**2 / (base_units["energy"] * base_units["length"])
+        u.elementary_charge**2 / (energy_unit * length_unit)
     )
-    charge_factor = (
-        4.0 * np.pi * e0 * base_units["length"] * base_units["energy"]
-    ) ** 0.5
-    # Write out all of the snapshot attributes
-    if isinstance(snapshot, hoomd.Snapshot):
-        snapshot.particles.N = top.n_sites + n_rigid
-        snapshot.particles.types = unique_types
+    charge_factor = (4.0 * np.pi * e0 * length_unit * energy_unit) ** 0.5
+
+    # --- Write snapshot (deduplicated) ---
+    is_hoomd_snapshot = isinstance(snapshot, hoomd.Snapshot)
+    snapshot.particles.N = n_sites + n_rigid
+    snapshot.particles.types = unique_types
+
+    if is_hoomd_snapshot:
         snapshot.particles.position[0:] = xyz
         snapshot.particles.typeid[0:] = typeids
         snapshot.particles.mass[0:] = masses
@@ -493,9 +533,7 @@ def _parse_particle_information(
         if n_rigid:
             snapshot.particles.body[0:] = rigid_id_tags
             snapshot.particles.moment_inertia[0:] = moment_of_inertias
-    elif isinstance(snapshot, gsd.hoomd.Frame):
-        snapshot.particles.N = top.n_sites + n_rigid
-        snapshot.particles.types = unique_types
+    else:  # gsd.hoomd.Frame
         snapshot.particles.position = xyz
         snapshot.particles.typeid = typeids
         snapshot.particles.mass = masses
@@ -504,10 +542,10 @@ def _parse_particle_information(
         if n_rigid:
             snapshot.particles.body = rigid_id_tags
             snapshot.particles.moment_inertia = moment_of_inertias
+
     return n_rigid, rigid_constraint
 
-
-def _parse_pairs_information(snapshot, top, n_rigid=0):
+def _parse_pairs_information(snapshot, top, site_indexMap, n_rigid=0):
     """Parse sacled pair types.
 
     Parameters
@@ -541,7 +579,7 @@ def _parse_pairs_information(snapshot, top, n_rigid=0):
             pair_types.append(pair_type)
         pair_typeids.append(pair_types.index(pair_type))
         pairs.append(
-            (top.get_index(pair[0]) + n_rigid, top.get_index(pair[1]) + n_rigid)
+            (site_indexMap[id(pair[0])] + n_rigid, site_indexMap[id(pair[1])] + n_rigid)
         )
 
     if isinstance(snapshot, hoomd.Snapshot):
@@ -556,7 +594,7 @@ def _parse_pairs_information(snapshot, top, n_rigid=0):
         snapshot.pairs.typeid = pair_typeids
 
 
-def _parse_bond_information(snapshot, top, n_rigid=0):
+def _parse_bond_information(snapshot, top, site_indexMap, n_rigid=0):
     """Parse bonds information from topology.
 
     Parameters
@@ -588,11 +626,12 @@ def _parse_bond_information(snapshot, top, n_rigid=0):
 
         bond_types.append(bond_type)
         bond_groups.append(
-            sorted(tuple(top.get_index(site) + n_rigid for site in connection_members))
+            sorted(tuple(site_indexMap[id(site)] + n_rigid for site in connection_members))
         )
 
     unique_bond_types = list(set(bond_types))
-    bond_typeids = [unique_bond_types.index(i) for i in bond_types]
+    type_to_id = {btype: i for i, btype in enumerate(unique_bond_types)}
+    bond_typeids = [type_to_id[btype] for btype in bond_types]  # O(n)
 
     if isinstance(snapshot, hoomd.Snapshot):
         snapshot.bonds.types = unique_bond_types
@@ -606,7 +645,7 @@ def _parse_bond_information(snapshot, top, n_rigid=0):
     logger.info(f"{len(unique_bond_types)} unique bond types detected")
 
 
-def _parse_angle_information(snapshot, top, n_rigid=0):
+def _parse_angle_information(snapshot, top, site_indexMap, n_rigid=0):
     """Parse angles information from topology.
 
     Parameters
@@ -638,11 +677,12 @@ def _parse_angle_information(snapshot, top, n_rigid=0):
 
         angle_types.append(angle_type)
         angle_groups.append(
-            tuple(top.get_index(site) + n_rigid for site in connection_members)
+            sorted(tuple(site_indexMap[id(site)] + n_rigid for site in connection_members))
         )
 
     unique_angle_types = list(set(angle_types))
-    angle_typeids = [unique_angle_types.index(i) for i in angle_types]
+    type_to_id = {atype: i for i, atype in enumerate(unique_angle_types)}
+    angle_typeids = [type_to_id[atype] for atype in angle_types]
 
     if isinstance(snapshot, hoomd.Snapshot):
         snapshot.angles.types = unique_angle_types
@@ -657,7 +697,7 @@ def _parse_angle_information(snapshot, top, n_rigid=0):
     logger.info(f"{len(unique_angle_types)} unique angle types detected")
 
 
-def _parse_dihedral_information(snapshot, top, n_rigid=0):
+def _parse_dihedral_information(snapshot, top, site_indexMap, n_rigid=0):
     """Parse dihedral information from topology.
 
     Parameters
@@ -687,11 +727,12 @@ def _parse_dihedral_information(snapshot, top, n_rigid=0):
 
         dihedral_types.append(dihedral_type)
         dihedral_groups.append(
-            tuple(top.get_index(site) + n_rigid for site in connection_members)
+            sorted(tuple(site_indexMap[id(site)] + n_rigid for site in connection_members))
         )
 
     unique_dihedral_types = list(set(dihedral_types))
-    dihedral_typeids = [unique_dihedral_types.index(i) for i in dihedral_types]
+    type_to_id = {dtype: i for i, dtype in enumerate(unique_dihedral_types)}
+    dihedral_typeids = [type_to_id[dtype] for dtype in dihedral_types]
 
     if isinstance(snapshot, hoomd.Snapshot):
         snapshot.dihedrals.types = unique_dihedral_types
@@ -706,7 +747,7 @@ def _parse_dihedral_information(snapshot, top, n_rigid=0):
     logger.info(f"{len(unique_dihedral_types)} unique dihedral types detected")
 
 
-def _parse_improper_information(snapshot, top, n_rigid=0):
+def _parse_improper_information(snapshot, top, site_indexMap, n_rigid=0):
     """Parse impropers information from topology.
 
     Parameters
@@ -735,11 +776,12 @@ def _parse_improper_information(snapshot, top, n_rigid=0):
 
         improper_types.append(improper_type)
         improper_groups.append(
-            tuple(top.get_index(site) + n_rigid for site in connection_members)
+            sorted(tuple(site_indexMap[id(site)] + n_rigid for site in connection_members))
         )
 
     unique_improper_types = list(set(improper_types))
-    improper_typeids = [unique_improper_types.index(i) for i in improper_types]
+    type_to_id = {itype: i for i, itype in enumerate(unique_improper_types)}
+    improper_typeids = [type_to_id[itype] for itype in improper_types]
 
     if isinstance(snapshot, hoomd.Snapshot):
         snapshot.impropers.types = unique_improper_types

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -389,9 +389,7 @@ def _parse_particle_information(
         types[i] = site.name if site.atom_type is None else site.atom_type.name
         masses_raw[i] = site.mass.to_value(mass_unit) if site.mass else default_mass
         charges_list[i] = (
-            site.charge.to_value(u.elementary_charge)
-            if site.charge
-            else zero_charge
+            site.charge.to_value(u.elementary_charge) if site.charge else zero_charge
         )
         if not has_rigid and site.molecule.isrigid:
             has_rigid = True
@@ -545,6 +543,7 @@ def _parse_particle_information(
 
     return n_rigid, rigid_constraint
 
+
 def _parse_pairs_information(snapshot, top, site_indexMap, n_rigid=0):
     """Parse sacled pair types.
 
@@ -626,7 +625,9 @@ def _parse_bond_information(snapshot, top, site_indexMap, n_rigid=0):
 
         bond_types.append(bond_type)
         bond_groups.append(
-            sorted(tuple(site_indexMap[id(site)] + n_rigid for site in connection_members))
+            sorted(
+                tuple(site_indexMap[id(site)] + n_rigid for site in connection_members)
+            )
         )
 
     unique_bond_types = list(set(bond_types))
@@ -677,7 +678,9 @@ def _parse_angle_information(snapshot, top, site_indexMap, n_rigid=0):
 
         angle_types.append(angle_type)
         angle_groups.append(
-            sorted(tuple(site_indexMap[id(site)] + n_rigid for site in connection_members))
+            sorted(
+                tuple(site_indexMap[id(site)] + n_rigid for site in connection_members)
+            )
         )
 
     unique_angle_types = list(set(angle_types))
@@ -727,7 +730,9 @@ def _parse_dihedral_information(snapshot, top, site_indexMap, n_rigid=0):
 
         dihedral_types.append(dihedral_type)
         dihedral_groups.append(
-            sorted(tuple(site_indexMap[id(site)] + n_rigid for site in connection_members))
+            sorted(
+                tuple(site_indexMap[id(site)] + n_rigid for site in connection_members)
+            )
         )
 
     unique_dihedral_types = list(set(dihedral_types))
@@ -776,7 +781,9 @@ def _parse_improper_information(snapshot, top, site_indexMap, n_rigid=0):
 
         improper_types.append(improper_type)
         improper_groups.append(
-            sorted(tuple(site_indexMap[id(site)] + n_rigid for site in connection_members))
+            sorted(
+                tuple(site_indexMap[id(site)] + n_rigid for site in connection_members)
+            )
         )
 
     unique_improper_types = list(set(improper_types))

--- a/gmso/tests/test_convert_parmed.py
+++ b/gmso/tests/test_convert_parmed.py
@@ -368,7 +368,7 @@ class TestConvertParmEd(BaseTest):
 
         for j in range(10):
             dih = pmd.Dihedral(
-                *[struct.atoms[i] for i in range(j,j+4)],
+                *[struct.atoms[i] for i in range(j, j + 4)],
                 improper=True if j % 2 == 0 else False,
             )
             struct.dihedrals.append(dih)
@@ -400,7 +400,7 @@ class TestConvertParmEd(BaseTest):
 
         for j in range(10):
             dih = pmd.Dihedral(
-                *[struct.atoms[i] for i in range(j,j+4)],
+                *[struct.atoms[i] for i in range(j, j + 4)],
                 improper=True if j % 2 == 0 else False,
             )
             struct.dihedrals.append(dih)

--- a/gmso/tests/test_convert_parmed.py
+++ b/gmso/tests/test_convert_parmed.py
@@ -368,7 +368,7 @@ class TestConvertParmEd(BaseTest):
 
         for j in range(10):
             dih = pmd.Dihedral(
-                *random.sample(struct.atoms, 4),
+                *[struct.atoms[i] for i in range(j,j+4)],
                 improper=True if j % 2 == 0 else False,
             )
             struct.dihedrals.append(dih)
@@ -400,7 +400,7 @@ class TestConvertParmEd(BaseTest):
 
         for j in range(10):
             dih = pmd.Dihedral(
-                *random.sample(struct.atoms, 4),
+                *[struct.atoms[i] for i in range(j,j+4)],
                 improper=True if j % 2 == 0 else False,
             )
             struct.dihedrals.append(dih)

--- a/gmso/tests/test_hoomd.py
+++ b/gmso/tests/test_hoomd.py
@@ -551,9 +551,12 @@ class TestHoomd(BaseTest):
         np.testing.assert_allclose(forces["bonds"][0].params["CT-HC"]["sigma"], 1)
         np.testing.assert_allclose(forces["bonds"][0].params["CT-HC"]["delta"], 0.1)
 
-    def test_no_special(self, typed_ethane):
-        typed_ethane.scaling_factors[0][2] = 0
-        typed_ethane.scaling_factors[1][2] = 0
+    def test_no_special(self, ethane):
+        oplsaa = ForceField("oplsaa")
+        oplsaa.scaling_factors["electrostatics14Scale"] = 0
+        oplsaa.scaling_factors["nonBonded14Scale"] = 0
+
+        typed_ethane = apply(ethane, oplsaa)
         # 1-4 lj and charge
         forces, _ = to_hoomd_forcefield(typed_ethane, r_cut=1.2)
         assert len(forces["nonbonded"]) == 3  # no special_pairs forces


### PR DESCRIPTION
### PR Summary: 
Speedup cataloging of indexing for different objects when writing out to hoomd. Notably, replace all top.index(site) calls with a map of site_indexMap[id(site)] for indexing. Also remove separate iterations through top.sites for isrigid() checks, performing that during the main loop through Topology sites. Also perform some numpy improvements by initializing size arrays, and filling in xyz[i] as we iterate through the Topology.

### PR Checklist
------------
 - [x] Includes appropriate unit test(s)
 - [x] Appropriate docstring(s) are added/updated
 - [x] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
