### PR TITLE
Removed sorted() from bonded groups in GSD writer

### DIFF
--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -672,7 +672,7 @@ def _parse_bond_information(snapshot, top, site_indexMap, n_rigid=0):
 
         bond_types.append(bond_type)
         bond_groups.append(
-            sorted(tuple(site_indexMap[site] + n_rigid for site in connection_members))
+            tuple(site_indexMap[site] + n_rigid for site in connection_members)
         )
     unique_bond_types = list(set(bond_types))
     type_to_id = {btype: i for i, btype in enumerate(unique_bond_types)}
@@ -724,7 +724,7 @@ def _parse_angle_information(snapshot, top, site_indexMap, n_rigid=0):
 
         angle_types.append(angle_type)
         angle_groups.append(
-            sorted(tuple(site_indexMap[site] + n_rigid for site in connection_members))
+            tuple(site_indexMap[site] + n_rigid for site in connection_members)
         )
 
     unique_angle_types = list(set(angle_types))
@@ -776,7 +776,7 @@ def _parse_dihedral_information(snapshot, top, site_indexMap, n_rigid=0):
 
         dihedral_types.append(dihedral_type)
         dihedral_groups.append(
-            sorted(tuple(site_indexMap[site] + n_rigid for site in connection_members))
+            tuple(site_indexMap[site] + n_rigid for site in connection_members)
         )
 
     unique_dihedral_types = list(set(dihedral_types))
@@ -827,7 +827,7 @@ def _parse_improper_information(snapshot, top, site_indexMap, n_rigid=0):
 
         improper_types.append(improper_type)
         improper_groups.append(
-            sorted(tuple(site_indexMap[site] + n_rigid for site in connection_members))
+            tuple(site_indexMap[site] + n_rigid for site in connection_members)
         )
 
     unique_improper_types = list(set(improper_types))

--- a/gmso/tests/test_hoomd.py
+++ b/gmso/tests/test_hoomd.py
@@ -150,8 +150,11 @@ class TestGsd(BaseTest):
         top = methane.to_gmso()
         top.identify_connections()
         snap, _ = to_gsd_snapshot(top)
+        for group in snap.bonds.group:
+            assert group[0] < group[1]
         for group in snap.angles.group:
             assert group[1] == 0
+            assert group[0] < group[2]
 
 
 class TestHoomd(BaseTest):

--- a/gmso/tests/test_hoomd.py
+++ b/gmso/tests/test_hoomd.py
@@ -145,7 +145,7 @@ class TestGsd(BaseTest):
         with pytest.raises(RuntimeError):
             to_gsd_snapshot(top)
 
-    def test_angle_sorting(self):
+    def test_sorting(self):
         methane = mb.load("C", smiles=True)
         top = methane.to_gmso()
         top.identify_connections()

--- a/gmso/tests/test_hoomd.py
+++ b/gmso/tests/test_hoomd.py
@@ -145,6 +145,14 @@ class TestGsd(BaseTest):
         with pytest.raises(RuntimeError):
             to_gsd_snapshot(top)
 
+    def test_angle_sorting(self):
+        methane = mb.load("C", smiles=True)
+        top = methane.to_gmso()
+        top.identify_connections()
+        snap, _ = to_gsd_snapshot(top)
+        for group in snap.angles.group:
+            assert group[1] == 0
+
 
 class TestHoomd(BaseTest):
     def test_hoomd_simulation(self):


### PR DESCRIPTION
### PR Summary:
Fixes a bug where bonded groups were being sorted with all connection members, resulting in angle ordering losing information about the middle site, and the same happening for dihedrals and impropers.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
