### PR TITLE
Use cache to speed up applying forcefield to connections

### DIFF
--- a/gmso/parameterization/molecule_utils.py
+++ b/gmso/parameterization/molecule_utils.py
@@ -80,12 +80,11 @@ def build_molecule_connection_index(top, is_group=False):
         for conn in connections:
             members = conn.connection_members
             labels = {_label_of(s) for s in members}
-            if len(labels) == 1:  # all members same molecule
-                label = labels.pop()
-                entry = index.setdefault(
-                    label, {"bonds": [], "angles": [], "dihedrals": [], "impropers": []}
-                )
-                entry[key].append(conn)
+            label = labels.pop()
+            entry = index.setdefault(
+                label, {"bonds": [], "angles": [], "dihedrals": [], "impropers": []}
+            )
+            entry[key].append(conn)
 
     _bucket(top.bonds, "bonds")
     _bucket(top.angles, "angles")

--- a/gmso/parameterization/molecule_utils.py
+++ b/gmso/parameterization/molecule_utils.py
@@ -61,9 +61,6 @@ def assert_no_boundary_bonds(top):
 def build_molecule_connection_index(top, is_group=False):
     """Build a dict mapping molecule/group label -> connection lists.
 
-    Scans each connection type once. Use this before a per-molecule
-    parameterization loop to avoid O(M * C) repeated filtering.
-
     Returns:
         dict: {
             label: {

--- a/gmso/parameterization/molecule_utils.py
+++ b/gmso/parameterization/molecule_utils.py
@@ -56,3 +56,48 @@ def assert_no_boundary_bonds(top):
         assert site1.molecule == site2.molecule, assertion_msg.format(
             site1.name, site1.molecule, site2.name, site2.molecule
         )
+
+
+def build_molecule_connection_index(top, is_group=False):
+    """Build a dict mapping molecule/group label -> connection lists.
+
+    Scans each connection type once. Use this before a per-molecule
+    parameterization loop to avoid O(M * C) repeated filtering.
+
+    Returns:
+        dict: {
+            label: {
+                "bonds": [...],
+                "angles": [...],
+                "dihedrals": [...],
+                "impropers": [...]
+            }
+        }
+    """
+    index = {}
+
+    def _label_of(site):
+        return getattr(site, "group") if is_group else site.molecule.name
+
+    def _bucket(connections, key):
+        for conn in connections:
+            members = conn.connection_members
+            labels = {_label_of(s) for s in members}
+            if len(labels) == 1:          # all members same molecule
+                label = labels.pop()
+                entry = index.setdefault(
+                    label, {
+                        "bonds": [],
+                        "angles": [],
+                        "dihedrals": [],
+                        "impropers": []
+                    }
+                )
+                entry[key].append(conn)
+
+    _bucket(top.bonds, "bonds")
+    _bucket(top.angles, "angles")
+    _bucket(top.dihedrals, "dihedrals")
+    _bucket(top.impropers, "impropers")
+
+    return index

--- a/gmso/parameterization/molecule_utils.py
+++ b/gmso/parameterization/molecule_utils.py
@@ -83,15 +83,10 @@ def build_molecule_connection_index(top, is_group=False):
         for conn in connections:
             members = conn.connection_members
             labels = {_label_of(s) for s in members}
-            if len(labels) == 1:          # all members same molecule
+            if len(labels) == 1:  # all members same molecule
                 label = labels.pop()
                 entry = index.setdefault(
-                    label, {
-                        "bonds": [],
-                        "angles": [],
-                        "dihedrals": [],
-                        "impropers": []
-                    }
+                    label, {"bonds": [], "angles": [], "dihedrals": [], "impropers": []}
                 )
                 entry[key].append(conn)
 

--- a/gmso/parameterization/topology_parameterizer.py
+++ b/gmso/parameterization/topology_parameterizer.py
@@ -231,8 +231,8 @@ class TopologyParameterizer(GMSOBase):
             if not match and error_on_missing:
                 group = POTENTIAL_GROUPS[type(connection)]
                 raise ParameterizationError(
-                    f"No parameters found for connection {connection}, group: {group} "
-                    f"in the Forcefield."
+                    f"No parameters found for connection {connection}, group: {group}, "
+                    f"identifiers: {connection_identifiers} in the force field."
                 )
             elif match:
                 setattr(connection, group, match[0].clone(self.config.fast_copy))

--- a/gmso/parameterization/topology_parameterizer.py
+++ b/gmso/parameterization/topology_parameterizer.py
@@ -202,11 +202,17 @@ class TopologyParameterizer(GMSOBase):
         visited = dict()
         sig_cache = dict()
         for connection in connections:
-            use_classes = all([site.atom_type.atomclass for site in connection.connection_members])
+            use_classes = all(
+                [site.atom_type.atomclass for site in connection.connection_members]
+            )
             if use_classes:
-                sig = tuple(site.atom_type.atomclass for site in connection.connection_members)
+                sig = tuple(
+                    site.atom_type.atomclass for site in connection.connection_members
+                )
             else:
-                sig = tuple(site.atom_type.name for site in connection.connection_members)
+                sig = tuple(
+                    site.atom_type.name for site in connection.connection_members
+                )
             if getattr(connection, "bonds", None):
                 sig += tuple(b.bond_order for b in connection.bonds)
             elif hasattr(connection, "bond_order"):

--- a/gmso/parameterization/topology_parameterizer.py
+++ b/gmso/parameterization/topology_parameterizer.py
@@ -20,11 +20,11 @@ from gmso.parameterization.isomorph import (
 )
 from gmso.parameterization.molecule_utils import (
     assert_no_boundary_bonds,
+    build_molecule_connection_index,
     molecule_angles,
     molecule_bonds,
     molecule_dihedrals,
     molecule_impropers,
-    build_molecule_connection_index,
 )
 from gmso.parameterization.utils import POTENTIAL_GROUPS
 from gmso.utils.connectivity import identify_virtual_sites
@@ -139,8 +139,7 @@ class TopologyParameterizer(GMSOBase):
         if label_type and label:
             if connection_index is not None:
                 entry = connection_index.get(
-                    label,
-                    {"bonds": [],"angles": [], "dihedrals": [], "impropers": []}
+                    label, {"bonds": [], "angles": [], "dihedrals": [], "impropers": []}
                 )
                 bonds = entry["bonds"]
                 angles = entry["angles"]
@@ -201,27 +200,39 @@ class TopologyParameterizer(GMSOBase):
     def _apply_connection_parameters(self, connections, ff, error_on_missing=True):
         """Find and assign potentials from the forcefield for the provided connections."""
         visited = dict()
+        sig_cache = dict()
         for connection in connections:
-            group, connection_identifiers = self.connection_identifier(connection)
-            match = None
-            for identifier_key in connection_identifiers:
-                if tuple(identifier_key) in visited:
-                    match = visited[tuple(identifier_key)]
-                    break
+            sig = tuple(site.atom_type.name for site in connection.connection_members)
+            if getattr(connection, "bonds", None):
+                sig += tuple(b.bond_order for b in connection.bonds)
+            elif hasattr(connection, "bond_order"):
+                sig += (connection.bond_order,)
 
-                match = ff.get_potential(
-                    group=group,
-                    key=identifier_key,
-                    exact_match=True,
-                )
-                if match:
-                    visited[tuple(identifier_key)] = match
-                    break
+            if sig in sig_cache:
+                match = sig_cache[sig]
+            else:
+                group, connection_identifiers = self.connection_identifier(connection)
+                match = None
+                for identifier_key in connection_identifiers:
+                    id_tuple = tuple(identifier_key)
+                    if id_tuple in visited:
+                        match = visited[id_tuple]
+                        break
+                    match = ff.get_potential(
+                        group=group,
+                        key=identifier_key,
+                        exact_match=True,
+                    )
+                    if match:
+                        visited[id_tuple] = match
+                        break
+                sig_cache[sig] = match
 
             if not match and error_on_missing:
+                group = POTENTIAL_GROUPS[type(connection)]
                 raise ParameterizationError(
-                    f"No parameters found for connection {connection}, group: {group}, "
-                    f"identifiers: {connection_identifiers} in the Forcefield."
+                    f"No parameters found for connection {connection}, group: {group} "
+                    f"in the Forcefield."
                 )
             elif match:
                 setattr(connection, group, match[0].clone(self.config.fast_copy))
@@ -276,7 +287,13 @@ class TopologyParameterizer(GMSOBase):
                     )
 
     def _parameterize(
-        self, top, typemap, label_type=None, label=None, speedup_by_moltag=False, connection_index=None
+        self,
+        top,
+        typemap,
+        label_type=None,
+        label=None,
+        speedup_by_moltag=False,
+        connection_index=None,
     ):
         """Parameterize a topology/subtopology based on an atomtype map."""
         if label and label_type:
@@ -292,11 +309,7 @@ class TopologyParameterizer(GMSOBase):
             sites, typemap, forcefield, speedup_by_moltag=speedup_by_moltag
         )
         self._parameterize_connections(
-            top,
-            forcefield,
-            label_type,
-            label,
-            connection_index=connection_index
+            top, forcefield, label_type, label, connection_index=connection_index
         )
         if forcefield.virtual_types:
             self._parameterize_virtual_sites(top, sites, bonds, forcefield)
@@ -388,8 +401,10 @@ class TopologyParameterizer(GMSOBase):
                 )
 
             assert_no_boundary_bonds(self.topology)
-            is_group = (self.config.match_ff_by == "group")
-            connection_index = build_molecule_connection_index(self.topology, is_group=is_group)
+            is_group = self.config.match_ff_by == "group"
+            connection_index = build_molecule_connection_index(
+                self.topology, is_group=is_group
+            )
             for label in labels:
                 if label not in self.forcefields:
                     logger.warning(
@@ -451,12 +466,7 @@ class TopologyParameterizer(GMSOBase):
     ):  # This can extended to incorporate a pluggable object from the forcefield.
         """Return the group and list of identifiers for a connection to query the forcefield for its potential."""
         group = POTENTIAL_GROUPS[type(connection)]
-        return (
-            group,
-            [
-                *connection.get_connection_identifiers(),  # the viable keys made up of the bond orders
-            ],
-        )
+        return group, connection.get_connection_identifiers()
 
     @staticmethod
     def virtual_site_identifier(

--- a/gmso/parameterization/topology_parameterizer.py
+++ b/gmso/parameterization/topology_parameterizer.py
@@ -24,6 +24,7 @@ from gmso.parameterization.molecule_utils import (
     molecule_bonds,
     molecule_dihedrals,
     molecule_impropers,
+    build_molecule_connection_index,
 )
 from gmso.parameterization.utils import POTENTIAL_GROUPS
 from gmso.utils.connectivity import identify_virtual_sites
@@ -132,19 +133,25 @@ class TopologyParameterizer(GMSOBase):
         ff,
         label_type=None,
         label=None,
+        connection_index=None,
     ):
         """Parameterize connections with appropriate potentials from the forcefield."""
         if label_type and label:
-            bonds = molecule_bonds(top, label, True if label_type == "group" else False)
-            angles = molecule_angles(
-                top, label, True if label_type == "group" else False
-            )
-            dihedrals = molecule_dihedrals(
-                top, label, True if label_type == "group" else False
-            )
-            impropers = molecule_impropers(
-                top, label, True if label_type == "group" else False
-            )
+            if connection_index is not None:
+                entry = connection_index.get(
+                    label,
+                    {"bonds": [],"angles": [], "dihedrals": [], "impropers": []}
+                )
+                bonds = entry["bonds"]
+                angles = entry["angles"]
+                dihedrals = entry["dihedrals"]
+                impropers = entry["impropers"]
+            else:
+                is_group = True if label_type == "group" else False
+                bonds = molecule_bonds(top, label, is_group)
+                angles = molecule_angles(top, label, is_group)
+                dihedrals = molecule_dihedrals(top, label, is_group)
+                impropers = molecule_impropers(top, label, is_group)
         else:
             bonds = top.bonds
             angles = top.angles
@@ -269,7 +276,7 @@ class TopologyParameterizer(GMSOBase):
                     )
 
     def _parameterize(
-        self, top, typemap, label_type=None, label=None, speedup_by_moltag=False
+        self, top, typemap, label_type=None, label=None, speedup_by_moltag=False, connection_index=None
     ):
         """Parameterize a topology/subtopology based on an atomtype map."""
         if label and label_type:
@@ -289,6 +296,7 @@ class TopologyParameterizer(GMSOBase):
             forcefield,
             label_type,
             label,
+            connection_index=connection_index
         )
         if forcefield.virtual_types:
             self._parameterize_virtual_sites(top, sites, bonds, forcefield)
@@ -380,6 +388,8 @@ class TopologyParameterizer(GMSOBase):
                 )
 
             assert_no_boundary_bonds(self.topology)
+            is_group = (self.config.match_ff_by == "group")
+            connection_index = build_molecule_connection_index(self.topology, is_group=is_group)
             for label in labels:
                 if label not in self.forcefields:
                     logger.warning(
@@ -395,12 +405,14 @@ class TopologyParameterizer(GMSOBase):
                         self.config.speedup_by_moltag,
                         self.config.speedup_by_molgraph,
                     )
+
                     self._parameterize(
-                        self.topology,
-                        typemap,
+                        top=self.topology,
+                        typemap=typemap,
                         label_type=self.config.match_ff_by,
                         label=label,
                         speedup_by_moltag=self.config.speedup_by_moltag,  # This will be removed from the future iterations
+                        connection_index=connection_index,
                     )
         else:
             typemap = self._get_atomtypes(

--- a/gmso/parameterization/topology_parameterizer.py
+++ b/gmso/parameterization/topology_parameterizer.py
@@ -202,12 +202,15 @@ class TopologyParameterizer(GMSOBase):
         visited = dict()
         sig_cache = dict()
         for connection in connections:
-            sig = tuple(site.atom_type.name for site in connection.connection_members)
+            use_classes = all([site.atom_type.atomclass for site in connection.connection_members])
+            if use_classes:
+                sig = tuple(site.atom_type.atomclass for site in connection.connection_members)
+            else:
+                sig = tuple(site.atom_type.name for site in connection.connection_members)
             if getattr(connection, "bonds", None):
                 sig += tuple(b.bond_order for b in connection.bonds)
             elif hasattr(connection, "bond_order"):
                 sig += (connection.bond_order,)
-
             if sig in sig_cache:
                 match = sig_cache[sig]
             else:


### PR DESCRIPTION
### PR Summary:

I've been doing some digging into different ways to speed up GMSO, especially related to applying a force field.

This PR adds a signature cache to `_apply_connection_parameters` that lets us skip `get_connection_identifiers` for a connection that has already been found (if it has the same sig-cache). This is especially useful for molecules that have a bunch of repeated bonds, angles and dihedrals (like polymers).

**This script below with 500 alkane chains currently takes 160 seconds to apply the forcefield, but only  7 seconds with these changes!**

```
import mbuild as mb
import gmso
from gmso.parameterization.parameterize import apply
from gmso.core.forcefield import ForceField
import numpy as np

alkane = mb.load("CCCCCCCCCCCCCC", smiles=True)
alkane.name = "alkane"
comp = mb.fill_box(
    compound=[alkane], n_compounds=[500], density=0.2
)
top = comp.to_gmso()
oplsaa = ForceField("oplsaa")

start = time.time()
typed_top = apply(
    top=top,
    forcefields={"alkane": oplsaa},
    identify_connections=True,
    speedup_by_moltag=True,
)
finish = time.time()
total = finish - start
print(f"Finished in {np.round(total, 3)} seconds")

```

There are a couple other speed up additions:

1. Similar to some recent PRs where we build up a dict ahead of time for lookup rather than for loops, `molecule_utils.py` gets a method that does this for connections. This is used when iterate through multiple force fields passed to `apply()`, so the speed up only occurs in that scenario. This resulted in ~2x speed up for small systems. In larger systems, other areas dominated the time required.


2. `connections_identifier` now acts as a generator rather than building and returning a list.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
