### PR TITLE
Fix ordering and sorting to be dependent on presence of rigid bodies

### DIFF
--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -438,10 +438,6 @@ def _parse_particle_information(
     else:
         for site in itertools.chain(top.sites, top.virtual_sites):
             if isinstance(site, VirtualSite):
-                logger.warning(
-                    "This topology contains gmso.core.VirtualSite particles, but "
-                    "no rigid bodies were found. See Site.Molecule.isrigid to set rigid bodies."
-                )
                 xyz.append(site.position())
                 types.append(
                     site.name if site.virtual_type is None else site.virtual_type.name

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -405,8 +405,8 @@ def _parse_particle_information(
 
     if has_rigid:
         logger.warning(
-            "Rigid bodies are detected. Particles may be grouped " 
-            "and reindexed according to Molecule labels in the Topology. " 
+            "Rigid bodies are detected. Particles may be grouped "
+            "and reindexed according to Molecule labels in the Topology. "
             "Double check the particle ordering in the gsd snapshot."
         )
         for moleculeName in uniqueMoleculeODict:

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -405,7 +405,7 @@ def _parse_particle_information(
 
     if has_rigid:
         logger.warning(
-            "Rigid bodies are detected. Particles may be grouped 
+            "Rigid bodies are detected. Particles may be grouped
             and reindex according to site.molecule.name."
         )
         for moleculeName in uniqueMoleculeODict:
@@ -438,7 +438,7 @@ def _parse_particle_information(
         for site in itertools.chain(top.sites, top.virtual_sites):
             if isinstance(site, VirtualSite):
             logger.warning(
-                "This topology contains gmso.core.VirtualSite particles, but 
+                "This topology contains gmso.core.VirtualSite particles, but
                 no rigid bodies were found. See Atom.Molecule.isrigid to set rigid bodies."
             )
                 xyz.append(site.position())

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -404,6 +404,10 @@ def _parse_particle_information(
     has_rigid = any(site.molecule.isrigid for site in top.sites)
 
     if has_rigid:
+        logger.warning(
+            "Rigid bodies are detected. Particles may be grouped 
+            and reindex according to site.molecule.name."
+        )
         for moleculeName in uniqueMoleculeODict:
             for moleculeNumber, sitesList in enumerate(moleculeDict[moleculeName]):
                 for site in sitesList:
@@ -431,6 +435,10 @@ def _parse_particle_information(
     else:
         for site in itertools.chain(top.sites, top.virtual_sites):
             if isinstance(site, VirtualSite):
+            logger.warning(
+                "This topology contains gmso.core.VirtualSite particles, but 
+                no rigid bodies were found. See Atom.Molecule.isrigid to set rigid bodies."
+            )
                 xyz.append(site.position())
                 types.append(
                     site.name

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -401,34 +401,51 @@ def _parse_particle_information(
     charges = []
     rigid_ids = []
     n_prior_molecules = 0
-    has_rigid = False
+    has_rigid = any(site.molecule.isrigid for site in top.sites)
 
-    for moleculeName in uniqueMoleculeODict:
-        for moleculeNumber, sitesList in enumerate(moleculeDict[moleculeName]):
-            for site in sitesList:
-                if isinstance(site, VirtualSite):
-                    xyz.append(site.position())
-                    types.append(
-                        site.name
-                        if site.virtual_type is None
-                        else site.virtual_type.name
+    if has_rigid:
+        for moleculeName in uniqueMoleculeODict:
+            for moleculeNumber, sitesList in enumerate(moleculeDict[moleculeName]):
+                for site in sitesList:
+                    if isinstance(site, VirtualSite):
+                        xyz.append(site.position())
+                        types.append(
+                            site.name
+                            if site.virtual_type is None
+                            else site.virtual_type.name
+                        )
+                        masses.append(0 * u.amu)
+                    else:
+                        xyz.append(site.position)
+                        types.append(
+                            site.name if site.atom_type is None else site.atom_type.name
+                        )
+                        masses.append(site.mass)
+                    charges.append(site.charge if site.charge else 0 * u.elementary_charge)
+                    rigid_ids.append(
+                        site.molecule.number + n_prior_molecules
+                        if site.molecule.isrigid
+                        else -1
                     )
-                    masses.append(0 * u.amu)
-                else:
-                    xyz.append(site.position)
-                    types.append(
-                        site.name if site.atom_type is None else site.atom_type.name
-                    )
-                    masses.append(site.mass)
-                charges.append(site.charge if site.charge else 0 * u.elementary_charge)
-                rigid_ids.append(
-                    site.molecule.number + n_prior_molecules
-                    if site.molecule.isrigid
-                    else -1
+            n_prior_molecules += site.molecule.number + 1
+    else:
+        for site in itertools.chain(top.sites, top.virtual_sites):
+            if isinstance(site, VirtualSite):
+                xyz.append(site.position())
+                types.append(
+                    site.name
+                    if site.virtual_type is None
+                    else site.virtual_type.name
                 )
-                if not has_rigid and site.molecule.isrigid:
-                    has_rigid = True
-        n_prior_molecules += site.molecule.number + 1
+                masses.append(0 * u.amu)
+            else:
+                xyz.append(site.position)
+                types.append(
+                    site.name if site.atom_type is None else site.atom_type.name
+                )
+                masses.append(site.mass)
+            charges.append(site.charge if site.charge else 0 * u.elementary_charge)
+            rigid_ids.append(-1)
 
     # Convert to correct units, then strip to plain numpy for speed
     xyz = u.unyt_array(xyz).to_value(length_unit)
@@ -1949,8 +1966,6 @@ def _organize_generate_topology_molecule_info(top):
     moleculeDict = {}
     indexMap = {}
     uniqueMoleculeODict = OrderedDict()
-    n_sites_in_molecule = {}
-    molecule_indexOffset = 0
     last_molecule = None
 
     def _safe_number(molecule):
@@ -1960,30 +1975,29 @@ def _organize_generate_topology_molecule_info(top):
     for molecule in top.unique_site_labels("molecule", name_only=False):
         if molecule.name not in moleculeDict:
             if last_molecule is not None:
-                molecule_indexOffset += n_sites_in_molecule[last_molecule.name] * (
-                    _safe_number(last_molecule) + 1
-                )
                 uniqueMoleculeODict[molecule.name] = (
                     uniqueMoleculeODict[last_molecule.name]
                     + 1
                     + _safe_number(last_molecule)
                 )
             else:
-                molecule_indexOffset = 0
                 uniqueMoleculeODict[molecule.name] = 0
             moleculeDict[molecule.name] = []
-            n_sites_in_molecule[molecule.name] = len(
-                list(top.iter_sites_and_virtual_sites(key="molecule", value=molecule))
-            )
         moleculeDict[molecule.name].append([])
         for site in top.iter_sites_and_virtual_sites(key="molecule", value=molecule):
             moleculeDict[molecule.name][-1].append(site)
-            indexMap[site] = (
-                molecule_indexOffset
-                + _safe_number(molecule) * n_sites_in_molecule[molecule.name]
-                + len(moleculeDict[molecule.name][-1])
-                - 1
-            )
         last_molecule = molecule
+
+    has_rigid = any(site.molecule.isrigid for site in top.sites)
+    if has_rigid:
+        running_index = 0
+        for molecule_name in uniqueMoleculeODict:
+            for sites_list in moleculeDict[molecule_name]:
+                for site in sites_list:
+                    indexMap[site] = running_index
+                    running_index += 1
+    else:
+        for idx, site in enumerate(itertools.chain(top.sites, top.virtual_sites)):
+            indexMap[site] = idx
 
     return moleculeDict, indexMap, uniqueMoleculeODict

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -405,8 +405,9 @@ def _parse_particle_information(
 
     if has_rigid:
         logger.warning(
-            "Rigid bodies are detected. Particles may be grouped
-            and reindex according to site.molecule.name."
+            "Rigid bodies are detected. Particles may be grouped " 
+            "and reindexed according to Molecule labels in the Topology. " 
+            "Double check the particle ordering in the gsd snapshot."
         )
         for moleculeName in uniqueMoleculeODict:
             for moleculeNumber, sitesList in enumerate(moleculeDict[moleculeName]):
@@ -438,8 +439,8 @@ def _parse_particle_information(
         for site in itertools.chain(top.sites, top.virtual_sites):
             if isinstance(site, VirtualSite):
             logger.warning(
-                "This topology contains gmso.core.VirtualSite particles, but
-                no rigid bodies were found. See Atom.Molecule.isrigid to set rigid bodies."
+                "This topology contains gmso.core.VirtualSite particles, but "
+                "no rigid bodies were found. See Site.Molecule.isrigid to set rigid bodies."
             )
                 xyz.append(site.position())
                 types.append(

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -421,7 +421,9 @@ def _parse_particle_information(
                             site.name if site.atom_type is None else site.atom_type.name
                         )
                         masses.append(site.mass)
-                    charges.append(site.charge if site.charge else 0 * u.elementary_charge)
+                    charges.append(
+                        site.charge if site.charge else 0 * u.elementary_charge
+                    )
                     rigid_ids.append(
                         site.molecule.number + n_prior_molecules
                         if site.molecule.isrigid
@@ -433,9 +435,7 @@ def _parse_particle_information(
             if isinstance(site, VirtualSite):
                 xyz.append(site.position())
                 types.append(
-                    site.name
-                    if site.virtual_type is None
-                    else site.virtual_type.name
+                    site.name if site.virtual_type is None else site.virtual_type.name
                 )
                 masses.append(0 * u.amu)
             else:

--- a/gmso/external/convert_hoomd.py
+++ b/gmso/external/convert_hoomd.py
@@ -438,10 +438,10 @@ def _parse_particle_information(
     else:
         for site in itertools.chain(top.sites, top.virtual_sites):
             if isinstance(site, VirtualSite):
-            logger.warning(
-                "This topology contains gmso.core.VirtualSite particles, but "
-                "no rigid bodies were found. See Site.Molecule.isrigid to set rigid bodies."
-            )
+                logger.warning(
+                    "This topology contains gmso.core.VirtualSite particles, but "
+                    "no rigid bodies were found. See Site.Molecule.isrigid to set rigid bodies."
+                )
                 xyz.append(site.position())
                 types.append(
                     site.name if site.virtual_type is None else site.virtual_type.name

--- a/gmso/tests/test_hoomd.py
+++ b/gmso/tests/test_hoomd.py
@@ -156,6 +156,68 @@ class TestGsd(BaseTest):
             assert group[1] == 0
             assert group[0] < group[2]
 
+    def test_nonrigid_particle_order_matches_insertion_order(self):
+        """For non-rigid systems, snapshot particle positions must match top.sites
+        insertion order.
+        """
+        methane0 = mb.load("C", smiles=True)
+        methane0.name = "methane"
+        methane0.translate_to([0.5, 0.5, 0.5])
+
+        ethane0 = mb.load("CC", smiles=True)
+        ethane0.name = "ethane"
+        ethane0.translate_to([1.5, 1.5, 1.5])
+
+        methane1 = mb.load("C", smiles=True)
+        methane1.name = "methane"
+        methane1.translate_to([2.5, 2.5, 2.5])
+
+        ethane1 = mb.load("CC", smiles=True)
+        ethane1.name = "ethane"
+        ethane1.translate_to([3.5, 3.5, 3.5])
+
+        compound = mb.Compound()
+        for mol in [methane0, ethane0, methane1, ethane1]:
+            compound.add(mol)
+
+        top = from_mbuild(compound)
+        sites = list(top.sites)
+
+        snap, _ = to_gsd_snapshot(top, shift_coords=False)
+
+        assert snap.particles.N == len(sites)
+
+        # Snapshot particle i must correspond to sites[i] (insertion order)
+        for i, site in enumerate(sites):
+            expected = site.position.to_value("nm")
+            assert np.allclose(snap.particles.position[i], expected, atol=1e-5)
+
+    def test_same_name_different_size_bond_groups_per_molecule(self):
+        """Bond groups must reference only particles belonging to their own molecule
+        Layout: methane0 [0-4], methane1 [5-9], ethane0 [10-17], ethane1 [18-25]
+        """
+        methane = mb.load("C", smiles=True)
+        methane.name = "alkane"
+        ethane = mb.load("CC", smiles=True)
+        ethane.name = "alkane"
+        system = mb.fill_box(
+            compound=[methane, ethane], n_compounds=[2, 2], box=[5, 5, 5]
+        )
+        top = system.to_gmso()
+        top.identify_connections()
+
+        snap, _ = to_gsd_snapshot(top)
+
+        def bonds_in_range(lo, hi):
+            return [g for g in snap.bonds.group if lo <= min(g) and max(g) <= hi]
+
+        # 4 C-H bonds per methane
+        assert len(bonds_in_range(0, 4)) == 4
+        assert len(bonds_in_range(5, 9)) == 4
+        # 7 bonds per ethane (1 C-C + 6 C-H)
+        assert len(bonds_in_range(10, 17)) == 7
+        assert len(bonds_in_range(18, 25)) == 7
+
 
 class TestHoomd(BaseTest):
     def test_hoomd_simulation(self):


### PR DESCRIPTION
### PR Summary:

This uses different sorting methods in `convert_hoomd` depending on whether the topology contains rigid bodies. If rigid bodies are present, particle sorting changes, and is based on molecule (parent) grouping. This is required to correctly run rigid body simulations in hoomd. This also fixes an issue where we assumed that all molecules with the same label/name had the same number of sites per molecule.

### PR Checklist
------------
 - [ ] Includes appropriate unit test(s)
 - [ ] Appropriate docstring(s) are added/updated
 - [ ] Code is (approximately) PEP8 compliant
 - [ ] Issue(s) raised/addressed?
